### PR TITLE
create_sections migration failed

### DIFF
--- a/db/migrate/20090113223625_create_sections.rb
+++ b/db/migrate/20090113223625_create_sections.rb
@@ -14,7 +14,7 @@ class CreateSections < ActiveRecord::Migration
       t.timestamps
     end
     add_index :sections, :cached_slug
-    add_index :sections, [:published, :title]
+    add_index :sections, [:state, :title]
   end
 
   def self.down


### PR DESCRIPTION
create_sections migration failed on 
    add_index :sections, [:published, :title]
published is not a column, i just replace 
    published 
by 
    state
