### PR TITLE
Appel de la méthode gravatar_hash de account à la place de user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,7 @@ class User < ActiveRecord::Base
   end
 
   def gravatar_url
-    "http://www.gravatar.com/avatar/#{gravatar_hash}.jpg?s=100&d=#{CGI::escape DEFAULT_AVATAR_URL}"
+    "http://www.gravatar.com/avatar/#{account.gravatar_hash}.jpg?s=100&d=#{CGI::escape DEFAULT_AVATAR_URL}"
   end
 
   def avatar_url(style, https)


### PR DESCRIPTION
La méthode gravatar_hash est dans l'account, pas l'user.

Sans ce patch, j'ai un problème lors de la prévisualisation d'un commentaire
