### PR TITLE
Bugs css

### DIFF
--- a/public/stylesheets/RonRonnement.css
+++ b/public/stylesheets/RonRonnement.css
@@ -358,7 +358,8 @@ input[type='submit'] {
       float: left;
       text-indent: -9998em;
       overflow: hidden;
-      text-align: left; }
+      text-align: left;
+      width: 0px; }
     #site form input#search_submit {
       width: 0px;
       position: absolute;


### PR DESCRIPTION
Salut

j'ai regardé le bug des images qui dépassent, j'ai un peu changé la gestion de cette image, du score et de la date.
j'ai rajouté une min-height sur le contenu aussi, du coup ça ne déborde plus mais parfois il y a du blanc en trop. Je ne sais pas comment faire mieux. sachant que les images de dépêches ont des tailles différentes (la plus haute est public/images/sections/67.png, section éducation http://alpha.linuxfr.org/sections/education )

j'ai aussi regardé le bug de la boîte de recherche sur webkit.

par contre je n'ai pas beaucoup testé

Nicolas

PS : je n'ai appliqué que sur la css par défaut jusque là
