### PR TITLE
Un patch pour le ticket de suivi

### DIFF
--- a/lib/lfmarkdown.rb
+++ b/lib/lfmarkdown.rb
@@ -27,6 +27,7 @@ class LFMarkdown < Markdown
 
   def to_html
     process_wikipedia_links
+    process_newlines
     extract_code
     ret = fix_heading_levels(super)
     ret = process_code(ret)
@@ -40,6 +41,14 @@ protected
 
   def process_wikipedia_links
     @text.gsub!(WP_LINK_REGEXP, '[\1](http://fr.wikipedia.org/wiki/\1 "Définition Wikipédia")')
+  end
+
+  # Code taken from http://github.github.com/github-flavored-markdown/
+  def process_newlines
+    # in very clear cases, let newlines become <br /> tags
+    @text.gsub!(/^[\w\<][^\n]*\n+/) do |x|
+      x =~ /\n{2}/ ? x : (x.strip!; x << "  \n")
+    end
   end
 
   def fix_heading_levels(str)

--- a/spec/lib/lfmarkdown_spec.rb
+++ b/spec/lib/lfmarkdown_spec.rb
@@ -27,6 +27,11 @@ describe LFMarkdown do
     html.should == "<p>foo_bar_baz</p>\n"
   end
 
+  it "handles single line breaks" do
+    html = LFMarkdown.new("foo\nbar\n\nbaz").to_html
+    html.should == "<p>foo<br/>\nbar</p>\n\n<p>baz</p>\n"
+  end
+
   it "accepts heading levels from <h2> to <h5>" do
     md = LFMarkdown.new <<EOS
 Title 1


### PR DESCRIPTION
Ce patch corrige le problème mentionné dans le ticket "Retour à la ligne ne fonctionne plus".
https://linuxfr.org/suivi/retour-%C3%A0-la-ligne-ne-fonctionne-plus
