### PR TITLE
Changement CSS : avoir un curseur "lien" sur les <input> "pertinent" et "inutile"

### DIFF
--- a/public/stylesheets/RonRonnement.css
+++ b/public/stylesheets/RonRonnement.css
@@ -655,7 +655,8 @@ footer.actions .action {
     font-size: x-small;
     color: #a99c90;
     border-style: none;
-    background-color: transparent; }
+    background-color: transparent;
+    cursor: pointer; }
   .vote .button_to div:hover {
     text-decoration: underline; }
 


### PR DESCRIPTION
Actuellement, les liens (qui sont en fait des <input>) "pertinent" et "inutile" ne modifient pas le curseur quand il est au dessus.
Cette modification permet d'avoir un curseur "pointer", qui est celui qui s'affiche quand on survole un "vrai" lien ou un bouton d'un formulaire.
