### PR TITLE
markup fix: form_tag havent html option like form_for

### DIFF
--- a/app/views/polls/_answers_current.html.haml
+++ b/app/views/polls/_answers_current.html.haml
@@ -1,4 +1,4 @@
-= form_tag "/sondages/#{poll.new_record? ? 0 : poll.to_param}/vote", :html => { :id => "#{dom_id poll}#{id_suffix}" } do
+= form_tag "/sondages/#{poll.new_record? ? 0 : poll.to_param}/vote", :id => "#{dom_id poll}#{id_suffix}" do
   %ul.poll.current
     = list_of poll.answers do |answer|
       = radio_button_tag :position, answer.position, false, :id => "position_#{answer.position}#{id_suffix}"


### PR DESCRIPTION
this generate an invalid html attr like « html="{:id=&gt;&quot;poll_223_sidebar&quot;}" »
