### PR TITLE
Correction d'une faute de frappe

### DIFF
--- a/app/views/dashboard/_news.html.haml
+++ b/app/views/dashboard/_news.html.haml
@@ -1,7 +1,7 @@
 %h2
   Vos dépêches en attente de modération
 - if @news.empty?
-  Voud n'avez aucune dépêche en cours de modération
+  Vous n'avez aucune dépêche en cours de modération
 - else
   %table#my_trackers
     %tr


### PR DESCRIPTION
Le commit corrige la page du tableau de bord où il est écrit _Vou**d**_

Bon, c'était surtout pour faire un test pour faire plaisir à baud123< (cf. la tribune des modérateurs)
