### PR TITLE
Nightgrey fixes

### DIFF
--- a/app/assets/stylesheets/contrib/nightgrey.css.scss
+++ b/app/assets/stylesheets/contrib/nightgrey.css.scss
@@ -973,6 +973,12 @@ li.comment .content .signature:before {
 .comment .content {
   border-left: 1px dotted #6A6A6A;
   padding: 0 50px 0 5px;
+  list-style-type: disc;
+  
+  li {
+      margin-left: 40px;
+      list-style-type: disc;
+  }
 }
 .comment .avatar {
   float: right;


### PR DESCRIPTION
Hi, here some fixes on contrib/nightgrey:
- Visited links color too close to background
- Distorted avatars
- Ugly padding/margin around "pertinent"/"inutile"
- Display blockquote like RonRonnement
