### PR TITLE
add name of tag to status

### DIFF
--- a/app/views/tags/_hide.html.haml
+++ b/app/views/tags/_hide.html.haml
@@ -1,7 +1,7 @@
 - if current_account && current_account.can_update?(@tag)
   - if @tag.public?
-    %p Ce tag est actuellement visible.
+    %p Le tag #{@tag.name} est actuellement visible.
     = button_to "Cacher ce tag", hide_tag_path(@tag)
   - else
-    %p Ce tag est actuellement caché.
+    %p Le tag #{@tag.name} est actuellement caché.
     = button_to "Rendre à nouveau visible ce tag", hide_tag_path(@tag)


### PR DESCRIPTION
Sur la page http://linuxfr.org/tags/cin%C3%A9ma/public le nom du tag n'apparaît que dans le titre de la page, autant le rajouter dans le statut du tag (bon ce serait pas mal d'ajouter le nombre de contenus ayant ce tag et le nombre de fois où le tag a été ajouté aussi :D)
