### PR TITLE
h1 to h2, in order to display name of tag

### DIFF
--- a/app/views/tags/public.html.haml
+++ b/app/views/tags/public.html.haml
@@ -2,7 +2,7 @@
   = render "tags/near", :on_public => true
 = render "hide"
 
-=h1 "Tous les contenus taggés avec #{@tag.name}"
+=h2 "Tous les contenus taggés avec #{@tag.name}"
 - link = link_to("Afficher uniquement les contenus que j'ai taggés avec #{@tag.name}", tag_path(@tag.name)) if current_account
 = paginated_section @nodes, link do
   #contents


### PR DESCRIPTION
suite à http://linuxfr.org/suivi/ajouter-nom-du-tag-sur-la-ligne-de-son-statut peut-être tout simplement changer le h1 (caché par la css) en h2
