### PR TITLE
Use full links to the content in comments.

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,6 @@
 %h2
-  = link_to "[^]", "#comment-#{comment.parent_id}", :title => "Aller au commentaire parent", :class => "parent" unless comment.root?
-  %a(href="#comment-#{comment.id}" class="anchor") #
+  = link_to "[^]", "#{path_for_content comment.content}#comment-#{comment.parent_id}", :title => "Aller au commentaire parent", :class => "parent" unless comment.root?
+  = link_to "#", "#{path_for_content comment.content}#comment-#{comment.id}", :title => "Lien direct vers ce commentaire", :class => "anchor"
   = ' '
   = link_to comment.title, "/nodes/#{comment.node_id}/comments/#{comment.id}", :class => "title"
 %p.meta


### PR DESCRIPTION
Before this patch, the links in the comment boxes were not relevant when
the comment was not presented directly on the related content. For
instance on the comment's own page, the [^] link led to a non-existent
local anchor and the '#' link led to the comment on the page itself.

This fixes https://linuxfr.org/suivi/liens-non-fonctionnels-sur-la-page-du-commentaire-et-la-liste-des-commentaires-dun-utilisateur
