### PR TITLE
Display links to wikipedia without prefix

### DIFF
--- a/lib/lfmarkdown.rb
+++ b/lib/lfmarkdown.rb
@@ -55,7 +55,17 @@ protected
     @text.gsub!(WP_LINK_REGEXP) do
       word = $1
       escaped = word.gsub(/\(|\)|'/) {|x| "\\#{x}" }
-      "[#{word}](http://fr.wikipedia.org/wiki/#{escaped} \"Définition Wikipédia\")"
+      tokens = word.split(":")
+      if (tokens.length == 2)
+        case tokens[0]
+          when "en", "es", "eo", "de", "wikt" 
+            "[#{tokens[1]}](http://fr.wikipedia.org/wiki/#{escaped} \"Définition Wikipédia\")"
+          else
+            "[#{word}](http://fr.wikipedia.org/wiki/#{escaped} \"Définition Wikipédia\")"    
+        end
+      else
+        "[#{word}](http://fr.wikipedia.org/wiki/#{escaped} \"Définition Wikipédia\")"
+      end
     end
   end
 


### PR DESCRIPTION
This is a first try, I did not test it.
Do not hesitate to comment if it could be enhanced.  

When a user wants to reference a wikipedia page, in another language
than french, or reference the wiktionary, he could use a prefix like 'en' or 'wikt'.
This works well, but the prefix is displayed in the result page.

This commit try to parse the given input, to check if there is prefix,
and in this case do not display the prefix.

This fixes
http://linuxfr.org/suivi/option-de-langue-pour-les-liens-wikipedia
