### PR TITLE
'+' in wikipedia links

### DIFF
--- a/lib/lfmarkdown.rb
+++ b/lib/lfmarkdown.rb
@@ -45,7 +45,7 @@ class LFMarkdown < Redcarpet
 protected
 
   LF_LINK_REGEXP = RUBY_VERSION.starts_with?('1.8') ? /\[\[\[([ '\.:\-\w]+)\]\]\]/ : /\[\[\[([ '\.:\-\p{Word}]+)\]\]\]/
-  WP_LINK_REGEXP = RUBY_VERSION.starts_with?('1.8') ? /\[\[([ '\.:!\-\(\)\w]+)\]\]/ : /\[\[([ '\.:!\-\(\)\p{Word}]+)\]\]/
+  WP_LINK_REGEXP = RUBY_VERSION.starts_with?('1.8') ? /\[\[([ '\.\+:!\-\(\)\w]+)\]\]/ : /\[\[([ '\.\+:!\-\(\)\p{Word}]+)\]\]/
 
   def process_internal_wiki_links
     @text.gsub!(LF_LINK_REGEXP, '[\1](/wiki/\1 "Lien du wiki interne LinuxFr.org")')


### PR DESCRIPTION
When a user want to reference a wikipedia page which contains a '+'
char, he could not use the wikipedia dedicated syntax.

This commit modifies the regular expression to allow one such a use.

This fixes
http://linuxfr.org/suivi/les-liens-wikip%C3%A9dia-ne-g%C3%A8rent-pas-les
