### PR TITLE
Corrections pour RonRonnement

### DIFF
--- a/app/assets/stylesheets/RonRonnement.css.scss
+++ b/app/assets/stylesheets/RonRonnement.css.scss
@@ -973,7 +973,8 @@ ul.threads {
   padding: 0;
   list-style: none;
   /* premier d'un thread */
-  > li.comment {
+  > li.comment,
+  li#comment_new {
     /* voir ^article$ */
     padding-top: 0;
     padding-left: 1.25em;


### PR DESCRIPTION
Il y a 2 commits pour corriger RonRonnement. Le premier est pour corriger l'affichage lors de la prévisualisation de la modification d'un commentaire qui n'était pas correcte (pas de _border_, _bullet_ du `li` affichée…). Le deuxième corrige une erreur de padding lors de la prévisualisation d'un nouveau commentaire (ou de la modification d'un commentaire) qui ne respectait pas ce qui était affiché ensuite.
