### PR TITLE
Toolbar: stop current animation before animate

### DIFF
--- a/app/assets/javascripts/toolbar.coffee
+++ b/app/assets/javascripts/toolbar.coffee
@@ -45,7 +45,7 @@ class Toolbar
     return  if @nb_items == 0
     item = @items[@current - 1]
     pos = $(item).offset().top
-    $("html,body").animate scrollTop: pos, 500
+    $("html,body").stop().animate scrollTop: pos, 500
     $("#toolbar_current_item").text @current  if @visible
     false
 
@@ -82,7 +82,7 @@ class Toolbar
     return  if @nb_alt_items == 0
     item = @alt_items[@alt_current - 1]
     pos = $(item).offset().top
-    $("html,body").animate scrollTop: pos, 500
+    $("html,body").stop().animate scrollTop: pos, 500
     $("#toolbar_current_alt_item").text @alt_current  if @visible
     false
 


### PR DESCRIPTION
Stop any currently running scroll animation before starting a new one.
Allows to navigate much faster between items.
See: http://api.jquery.com/stop/
