### PR TITLE
Add irony mark in the markdown cheatsheet.

### DIFF
--- a/app/views/shared/_wiki_help.html.haml
+++ b/app/views/shared/_wiki_help.html.haml
@@ -5,7 +5,7 @@
     %tbody
       %tr
         %td Caractères spéciaux à copier-coller
-        %td ½ «  » ’ … ‰ € – — ‐<br/>¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁰<br/>æ Æ à À â Â ä Ä<br/>ç Ç<br/>€ é É è È ê Ê ë Ë<br/>î Î ï Ï<br/>œ Œ ô Ô ö Ö<br/>ù Ù û Û ü Ü<br/>Espaces fine (&thinsp;) normal (&#32;) demi-cadratin (&ensp;) <a href="http://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)<br/>Insécables fine (&#8239;) normal (&nbsp;)
+        %td ½ «  » ’ … ‰ € – — ‐ ⸮<br/>¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁰<br/>æ Æ à À â Â ä Ä<br/>ç Ç<br/>€ é É è È ê Ê ë Ë<br/>î Î ï Ï<br/>œ Œ ô Ô ö Ö<br/>ù Ù û Û ü Ü<br/>Espaces fine (&thinsp;) normal (&#32;) demi-cadratin (&ensp;) <a href="http://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)<br/>Insécables fine (&#8239;) normal (&nbsp;)
       %tr
         %td _italique_
         %td <em>italique</em>


### PR DESCRIPTION
This is a punctuation mark used to indicate that a sentence should be
understood at a second level.
Two unicode characters can be used :
- U+061F, ARABIC QUESTION MARK
- U+2E2E, REVERSED QUESTION MARK

I chose the second because of the meaning closest to the concept of
irony and not the first which would be rather a diverted use.
