### PR TITLE
Removing the left padding in the Markdown editor.

### DIFF
--- a/app/assets/stylesheets/RonRonnement.css.scss
+++ b/app/assets/stylesheets/RonRonnement.css.scss
@@ -1437,6 +1437,7 @@ img {
 }
 
 .markItUpEditor {
+  padding: 5px;
   background:none;
   border: 1px solid $C_INTER;
 }


### PR DESCRIPTION
Since the background image is not used anymore, the left padding move the text
to the right for no reason.
