### PR TITLE
Fix the overflow for the ol elements

### DIFF
--- a/app/assets/stylesheets/RonRonnement.css.scss
+++ b/app/assets/stylesheets/RonRonnement.css.scss
@@ -826,7 +826,7 @@ footer.actions {
       border-image:         url('/favicon.png') 0 0 0 32;
     }
   }
-  ul {
+  ul,ol {
     overflow: hidden;
     padding-bottom: 1px;
   }


### PR DESCRIPTION
Correction de l'overflow pour les liste ordonnées en plus des listes non ordonnées. On peut voir le problème sur https://linuxfr.org/moderation/news/sortie-de-tinycc-0-9-26
