### PR TITLE
Fix column colours not going to the bottom of the page.

### DIFF
--- a/app/assets/stylesheets/RonRonnement.css.scss
+++ b/app/assets/stylesheets/RonRonnement.css.scss
@@ -68,7 +68,7 @@ body {
   padding-top: $PX_TOP;
   border: solid #999;
   border-width: 0 1px;
-  background: #fff;
+  background: linear-gradient(90deg, $C_CLAIR, $C_CLAIR $PX_BRANDING_LARG, $C_CONTAINER $PX_BRANDING_LARG, $C_CONTAINER) #fff;
 }
 
 a {


### PR DESCRIPTION
Depending on whether the content column is smaller or bigger than the
sidebar, we ended up with columns changing colours at the middle of the
page.

This commit emulates full height columns by using a custom gradient on
the column container (the body tag). This fixes the graphical glitch
on recent enough browsers while not altering anything on older ones.

See http://caniuse.com/#feat=background-img-opts for supported browsers.
