### PR TITLE
Allow posting to the board through OAuth

### DIFF
--- a/app/models/access_grant.rb
+++ b/app/models/access_grant.rb
@@ -29,7 +29,7 @@ class AccessGrant < ActiveRecord::Base
     {
       access_token: access_token,
       refresh_token: refresh_token,
-      expires_in: Devise.timeout_in.to_i
+      expires_at: access_token_expires_at.to_i
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
     post "oauth/authorized"   => "oauth#authorized"
     post "oauth/access_token" => "oauth#access_token"
     get  "oauth/user"         => "oauth#user"
+    post "oauth/board/post"   => "oauth#board_post"
   end
 
   # Redaction

--- a/db/pages/developer.html
+++ b/db/pages/developer.html
@@ -156,6 +156,35 @@ GET https://linuxfr.org/auth/oauth/user
 {"created_at":"2004-07-21T20:23:47+02:00","email":"nono@linuxfr.org","login":"NoNo"}
 </pre>
 
+<p>
+	Il est aussi possible de poster sur la tribune :
+</p>
+
+<pre>
+POST https://linuxfr.org/auth/oauth/board/post
+</pre>
+
+<h4>Paramètres</h4>
+<dl>
+	<dt><var>bearer_token</var</dt>
+	<dd>Chaîne de caractères obligatoire - Le jeton d'autorisation.</dd>
+	<dt><var>message</var</dt>
+	<dd>Chaîne de caractères obligatoire - Message à poster sur la tribune</dd>
+</dl>
+
+<h4>Réponse</h4>
+<dl>
+	<dt><var>id</var</dt>
+	<dd>
+		Entier - Id du post qui vient d'être créé, le cas échéant.
+	</dd>
+</dl>
+
+<h4>Exemple de réponse</h4>
+<pre>
+{"id": 42}
+</pre>
+
 <h4>Bibliothèques</h4>
 
 <p>


### PR DESCRIPTION
Pour préciser, ça permettrait de poster des commentaires directement à partir de http://sauf.ca mais aussi de pouvoir utiliser OLCC sans avoir à copier-coller le cookie à la main (surtout maintenant qu'il n'est plus accessible à partir de l'interface de gestion du compte, et qu'il est devenu très long et avec des caractères bizarres difficiles à copier).

Cette pull request remplace la précédente https://github.com/linuxfrorg/linuxfr.org/issues/199
