### PR TITLE
Migrate tables from utf8 to utf8mb4 ("real" UTF-8)

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,6 +1,6 @@
 development:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: linuxfr_rails
   username: linuxfr_rails
   password:
@@ -11,14 +11,14 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: linuxfr_test
   username: linuxfr_test
   password:
 
 production:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: linuxfr_production
   username: linuxfr
   password: XXX

--- a/db/migrate/20161104094116_move_to_utf8mb4.rb
+++ b/db/migrate/20161104094116_move_to_utf8mb4.rb
@@ -1,0 +1,79 @@
+class MoveToUtf8mb4 < ActiveRecord::Migration
+  TABLES = [
+     'accounts',
+     'badges',
+     'banners',
+     'categories',
+     'comments',
+     'diaries',
+     'forums',
+     'friend_sites',
+     'friendly_id_slugs',
+     'links',
+     'logs',
+     'news',
+     'news_versions',
+     'nodes',
+     'pages',
+     'paragraphs',
+     'poll_answers',
+     'polls',
+     'posts',
+     'responses',
+     'sections',
+     'taggings',
+     'tags',
+     'trackers',
+     'users',
+     'wiki_pages',
+     'wiki_versions',
+  ]
+
+  def up
+    execute "ALTER DATABASE linuxfr_rails CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;"
+
+    execute "ALTER TABLE friendly_id_slugs DROP KEY index_friendly_id_slugs_on_slug_and_sluggable_type;"
+
+    execute "ALTER TABLE nodes DROP KEY index_nodes_on_content_id_and_content_type;"
+    execute "ALTER TABLE nodes DROP KEY index_nodes_on_content_type_and_public_and_interest;"
+
+    execute "ALTER TABLE pages DROP KEY index_pages_on_slug;"
+
+    TABLES.each do |tbl|
+      execute "ALTER TABLE #{tbl} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    end
+
+    execute "ALTER TABLE friendly_id_slugs ADD UNIQUE KEY `index_friendly_id_slugs_on_slug_and_sluggable_type` (`slug`(190),`sluggable_type`) USING BTREE;"
+
+    execute "ALTER TABLE nodes ADD UNIQUE KEY `index_nodes_on_content_id_and_content_type` (`content_id`,`content_type`(190)) USING BTREE;"
+    execute "ALTER TABLE nodes ADD KEY `index_nodes_on_content_type_and_public_and_interest` (`content_type`(190),`public`,`interest`) USING BTREE;"
+
+    execute "ALTER TABLE pages ADD KEY `index_pages_on_slug` (`slug`(190)) USING BTREE;"
+  end
+
+  def down
+    execute "ALTER DATABASE linuxfr_rails CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;"
+
+    execute "ALTER TABLE friendly_id_slugs DROP KEY index_friendly_id_slugs_on_slug_and_sluggable_type;"
+
+    execute "ALTER TABLE nodes DROP KEY index_nodes_on_content_id_and_content_type;"
+    execute "ALTER TABLE nodes DROP KEY index_nodes_on_content_type_and_public_and_interest;"
+
+    execute "ALTER TABLE oauth_applications DROP KEY index_oauth_applications_on_owner_id_and_owner_type;"
+
+    execute "ALTER TABLE pages DROP KEY index_pages_on_slug;"
+
+    TABLES.each do |tbl|
+      execute "ALTER TABLE #{tbl} CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+    end
+
+    execute "ALTER TABLE friendly_id_slugs ADD UNIQUE KEY `index_friendly_id_slugs_on_slug_and_sluggable_type` (`slug`,`sluggable_type`) USING BTREE;"
+
+    execute "ALTER TABLE nodes ADD UNIQUE KEY `index_nodes_on_content_id_and_content_type` (`content_id`,`content_type`) USING BTREE;"
+    execute "ALTER TABLE nodes ADD KEY `index_nodes_on_content_type_and_public_and_interest` (`content_type`,`public`,`interest`) USING BTREE;"
+
+    execute "ALTER TABLE oauth_applications ADD KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`) USING BTREE;"
+
+    execute "ALTER TABLE pages ADD KEY `index_pages_on_slug` (`slug`) USING BTREE;"
+  end
+end


### PR DESCRIPTION
The current schema uses "utf8" instead of "utf8mb4" for all text.

The "utf8" MySQL charset is a flawed implementation of UTF-8 which only supports 3-byte characters, thus preventing from using emoji 🐧 or other Unicode stuff. The real UTF-8 charset for MySQL is "utf8mb4", the only problem with converting to utf8mb4 is that text indices are limited to 767 bytes (255 × 3 bytes) which is too small to handle a utf8mb4 VARCHAR(255).

Since I don't know if the actual production content includes indexed strings that are longer than 190 characters, I only changed the index lengths to index the 190 first characters, without altering the actual content of the tables. The oauth_ tables actually use text identifiers, but as far as I know, only for non-utf8 text, so I'm not migrating them to utf8mb4.

Generating schema.rb on my machine changes a lot of field lengths and stuff, so I'll let you do it yourself if the migration goes well.

There are other changes to the codebase needed for proper handling of 4-byte characters in the site's content, but this is the first step to making Linuxfr UTF-8-compatible.