### PR TITLE
change size limit on board messages from 500 to 65536

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -89,7 +89,7 @@ class Board
     doc = Nokogiri::HTML::Document.new
     doc.encoding = "utf-8"
     node = Nokogiri::HTML::DocumentFragment.new(doc)
-    inner_sanitize(node, msg[0, 500])
+    inner_sanitize(node, msg[0, 65536])
     msg = Rinku.auto_link(node.to_s, :urls) { "[url]" }
     sanitize(msg, tags: ALLOWED_TAGS + ['a'])
   end


### PR DESCRIPTION
See <http://linuxfr.org/suivi/lever-la-limitation-en-taille-des-messages-de-la-tribune>.

The sanitization code would cut board messages at 500 characters. This
is much too little: it naturally happens that people write messages of
over 500 characters to explain their point of view -- eg. when
collaborating on the writing of a news item.

I left a limit in place, namely 65536, to avoid flooding attacks on
the server. This means that the upper limit on space usage on the
server is around 256Kio, which is less than uploaded images.