### PR TITLE
Provide a TSV-format board backend

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -5,7 +5,7 @@ class BoardsController < ApplicationController
   before_action :authenticate_account!, only: :create
   after_action :expire_cache, only: [:create]
   caches_page :show, if: Proc.new { |c| c.request.format.xml? }
-  respond_to :html, :xml
+  respond_to :html, :xml, :tsv
 
   def show
     @boards = Board.all(Board.free)
@@ -23,6 +23,7 @@ class BoardsController < ApplicationController
       wants.html { redirect_to :back rescue redirect_to root_url }
       wants.js   { render nothing: true }
       wants.xml  { render nothing: true }
+      wants.tsv  { render nothing: true }
     end
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -88,10 +88,18 @@ class Board
   ALLOWED_TAGS = %w(b i u s strong em code)
 
   def clean
-    @message    = sanitize_message @message
-    @user_agent = h @user_agent.to_s.encode(Encoding::UTF_8)
+    @message    = sanitize_message remove_control_chars @message
+    @user_agent = h remove_control_chars @user_agent.to_s.encode(Encoding::UTF_8)
     @user_name  = h @user_name
     @user_url   = h @user_url
+  end
+
+  def remove_control_chars(msg)
+    sanitized = ""
+    msg.each_char do |char|
+      sanitized << char unless char.ascii_only? and (char.ord < 32 or char.ord == 127)
+    end
+    return sanitized
   end
 
   def sanitize_message(msg)

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -1,6 +1,7 @@
 #main_board
   =h1 "Tribune"
   = link_to "Version XML", "/board/index.xml"
+  = link_to "Version TSV", "/board/index.tsv"
   %p
     %strong Conditions d'utilisation :
     cette tribune est un espace de discussion soumis aux lois en vigueur

--- a/app/views/boards/show.tsv.erb
+++ b/app/views/boards/show.tsv.erb
@@ -1,0 +1,3 @@
+<% @boards.reverse_each do |board| %>
+<%= board.id %>	<%= board.created_at.to_s(:timestamp) %>	<%= board.remove_control_chars board.user_agent %>	<%= board.user_name %>	<%= board.remove_control_chars board.message %>
+<% end %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,1 +1,2 @@
 Mime::Type.register "text/x-markdown", :md
+Mime::Type.register "text/tab-separated-values", :tsv


### PR DESCRIPTION
Most modern clients now use TSV-formatted backends instead of the needlessly fickle and complicated legacy XML format.

In addition to adding a `board.tsv` URL, this patch adds stripping of control characters from user-provided strings (which is needed for TSV, and which doesn't disturb other formats since they don't display them anyway).