### PR TITLE
Gemfile: update therubyracer to release 0.12.3 to support Ruby 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "state_machine",           "~>1.2"
 gem "jquery-rails",          "~>4.0"
 gem "sass-rails",            "~>5.0"
 gem "coffee-rails",          "~>4.1"
-gem "therubyracer",          "~>0.12", require: 'v8'
+gem "therubyracer",          "~>0.12.3", require: 'v8'
 gem "uglifier"
 
 # Rspec-rails must be in development for rake stats and in test for normal stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.3.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.19)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -257,7 +257,7 @@ GEM
       redis-store (~> 1.1.0)
     redis-store (1.1.7)
       redis (>= 2.2)
-    ref (1.0.5)
+    ref (2.0.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rinku (1.7.3)
@@ -307,8 +307,8 @@ GEM
     state_machine (1.2.0)
     subexec (0.2.3)
     sushi (0.0.4)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
@@ -389,11 +389,11 @@ DEPENDENCIES
   spring
   state_machine (~> 1.2)
   sushi
-  therubyracer (~> 0.12)
+  therubyracer (~> 0.12.3)
   thin
   uglifier
   unicorn (~> 5.1)
   web-console (~> 2.1)
 
 BUNDLED WITH
-   1.13.7
+   1.15.4


### PR DESCRIPTION
Gemfile.lock has been automatically updated on bundle install.

Note that it only solves the raised exception:

```
adrien@bureau-ado:~/code/linuxfr.org$ bin/rake db:setup
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:21: warning: constant ::Fixnum is deprecated
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:85:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'coffee-rails'.
Gem Load Error is: wrong argument type Class (expected Module)
Backtrace for gem load error is:
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:23:in `include'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:23:in `block (2 levels) in <top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:22:in `class_eval'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:22:in `block in <top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:21:in `each'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8/conversion.rb:21:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `block in require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/therubyracer-0.12.2/lib/v8.rb:22:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `block in require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs/ruby_racer_runtime.rb:108:in `available?'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs/runtimes.rb:53:in `each'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs/runtimes.rb:53:in `find'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs/runtimes.rb:53:in `best_available'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs/runtimes.rb:47:in `autodetect'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs.rb:5:in `<module:ExecJS>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/execjs-2.5.0/lib/execjs.rb:4:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `block in require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/coffee-script-2.4.1/lib/coffee_script.rb:1:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `block in require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/coffee-script-2.4.1/lib/coffee-script.rb:1:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `block in require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:274:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/coffee-rails-4.1.0/lib/coffee-rails.rb:1:in `<top (required)>'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:82:in `require'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:82:in `block (2 levels) in require'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `each'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `block in require'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `each'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `require'
/home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler.rb:108:in `require'
/home/adrien/code/linuxfr.org/config/application.rb:6:in `<top (required)>'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:82:in `require'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:82:in `preload'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:143:in `serve'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:131:in `block in run'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:125:in `loop'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:125:in `run'
/home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application/boot.rb:18:in `<top (required)>'
/home/adrien/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/adrien/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
-e:1:in `<main>'
Bundler Error Backtrace:
 (Bundler::GemRequireError)
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `each'
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `block in require'
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `each'
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `require'
	from /home/adrien/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler.rb:108:in `require'
	from /home/adrien/code/linuxfr.org/config/application.rb:6:in `<top (required)>'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:82:in `require'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:82:in `preload'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:143:in `serve'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:131:in `block in run'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:125:in `loop'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application.rb:125:in `run'
	from /home/adrien/code/linuxfr.org/vendor/ruby/2.4.0/gems/spring-1.3.4/lib/spring/application/boot.rb:18:in `<top (required)>'
	from /home/adrien/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/adrien/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```

After having applied this patch and run again `bin/rake db:setup`, the command hangs up and nothing is done in the mysql database.