### PR TITLE
Wikipage add truncated body to show summary on home page

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -3,12 +3,13 @@
 #
 # Table name: wiki_pages
 #
-#  id          :integer          not null, primary key
-#  title       :string(100)      not null
-#  cached_slug :string(105)
-#  body        :text(4294967295)
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id             :integer          not null, primary key
+#  title          :string(100)      not null
+#  cached_slug    :string(105)
+#  body           :text(4294967295)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  truncated_body :text(65535)
 #
 
 #

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -40,6 +40,7 @@ class WikiPage < Content
   attr_accessor :wiki_body, :message, :user_id
 
   wikify_attr :body
+  truncate_attr :body
 
   after_save :create_new_version
   def create_new_version

--- a/app/views/wiki_pages/_wiki_page.html.haml
+++ b/app/views/wiki_pages/_wiki_page.html.haml
@@ -1,6 +1,5 @@
 = article_for wiki_page do |c|
   - c.meta  = ""
   - c.title = "#{link_to "Wiki", "/wiki", class: "topic"} #{link_to wiki_page.title, wiki_page}".html_safe
-  - c.body  = wiki_page.body
   - if current_account && current_account.can_update?(wiki_page)
     - c.actions = link_to("Modifier", "/wiki/#{wiki_page.to_param}/modifier", class: 'action')

--- a/db/migrate/20171031210801_add_truncated_body_to_wiki_page.rb
+++ b/db/migrate/20171031210801_add_truncated_body_to_wiki_page.rb
@@ -1,0 +1,8 @@
+class AddTruncatedBodyToWikiPage < ActiveRecord::Migration
+  def change
+    add_column :wiki_pages, :truncated_body, :text
+    WikiPage.all.each do |wiki_page|
+        wiki_page.update_attribute :truncated_body, LFTruncator.truncate(wiki_page.body, nb_words=80)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302181642) do
+ActiveRecord::Schema.define(version: 20171031210801) do
 
   create_table "accounts", force: :cascade do |t|
     t.integer  "user_id",                limit: 4
@@ -384,11 +384,12 @@ ActiveRecord::Schema.define(version: 20170302181642) do
   add_index "users", ["cached_slug"], name: "index_users_on_cached_slug", using: :btree
 
   create_table "wiki_pages", force: :cascade do |t|
-    t.string   "title",       limit: 100,        null: false
-    t.string   "cached_slug", limit: 105
-    t.text     "body",        limit: 4294967295
+    t.string   "title",          limit: 100,        null: false
+    t.string   "cached_slug",    limit: 105
+    t.text     "body",           limit: 4294967295
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "truncated_body", limit: 65535
   end
 
   add_index "wiki_pages", ["cached_slug"], name: "index_wiki_pages_on_cached_slug", using: :btree

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -3,12 +3,13 @@
 #
 # Table name: wiki_pages
 #
-#  id          :integer          not null, primary key
-#  title       :string(100)      not null
-#  cached_slug :string(105)
-#  body        :text(4294967295)
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id             :integer          not null, primary key
+#  title          :string(100)      not null
+#  cached_slug    :string(105)
+#  body           :text(4294967295)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  truncated_body :text(65535)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
This series of patch allows home page to show only truncated body for WikiPage nodes.

Currently, when a user ask to see wikipage on the home page, he sees full Wiki page each time a new page is published.

These patches fixes that by updating the current wiki_pages table schema to add a new column named truncated_body. As for diaries, this column will contains HTML code with 80 words inside it.

Then, same code from helpers is used to display the content of wiki_page nodes (if exits, truncated_body content, otherwise body content). That's why I've removed the override of content.body in the app/views/wiki_pages/_wiki_page.html.haml file.

Note, a database migration have to be applied. The migration script add the truncated_body column to the database schema and insert content using directly the LFTruncator as when the wiki page will be saved (it uses the same helper methods than diaries to automatically compute them on body change).

Original report can be found here:
https://linuxfr.org/suivi/afficher-de-maniere-reduite-les-pages-wiki-sur-le-systeme-d-accueil

PS: Screenshot of the result:

![Dev env with a wiki page on the home page](https://cloud.adorsaz.ch/index.php/s/XVY1Mm8GBlik1iP/download)