### PR TITLE
Add support for user-provided bookmarks.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 class ApplicationController < ActionController::Base
   include Canable::Enforcers
 
@@ -77,6 +77,7 @@ protected
     opts = { routing_type: (only_path ? :path : :url) }
     case content
     when Diary then content.new_record? ? "/journaux" : polymorphic_url([content.owner, content], opts)
+    when Bookmark then content.new_record? ? "/liens" : polymorphic_url([content.owner, content], opts)
     when News  then content.new_record? ? "/news" : url_for_news(content, opts)
     when Post  then polymorphic_url([content.forum, content], opts)
                else polymorphic_url(content, opts)

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -75,7 +75,7 @@ class BookmarksController < ApplicationController
 protected
 
   def bookmark_params
-    params.require(:bookmark).permit(:title, :link, :cc_licensed)
+    params.require(:bookmark).permit(:title, :link, :lang, :cc_licensed)
   end
 
   def find_bookmark

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,97 @@
+# encoding: utf-8
+require 'uri'
+
+class BookmarksController < ApplicationController
+  before_action :authenticate_account!, except: [:index, :show]
+  before_action :find_bookmark, except: [:index, :new, :create]
+  after_action  :marked_as_read, only: [:show], if: :account_signed_in?
+  after_action  :expire_cache, only: [:create, :update, :destroy, :move]
+  caches_page   :index, if: Proc.new { |c| c.request.format.atom? && c.request.ssl? }
+  respond_to :html, :atom, :md
+
+### Global ###
+
+  def index
+    @order = params[:order]
+    @order = "created_at" unless VALID_ORDERS.include?(@order)
+    @nodes = Node.public_listing(Bookmark, @order).page(params[:page])
+    respond_with(@nodes)
+  end
+
+  def new
+    @bookmark = current_user.bookmarks.build
+    @bookmark.cc_licensed = false
+    return not_enough_karma('liens') unless @bookmark.creatable_by?(current_account)
+    enforce_create_permission(@bookmark)
+  end
+
+  def create
+    @bookmark = current_user.bookmarks.build
+    return not_enough_karma('liens') unless @bookmark.creatable_by?(current_account)
+    enforce_create_permission(@bookmark)
+    @bookmark.attributes = bookmark_params
+    if !preview_mode && @bookmark.save
+      current_account.tag(@bookmark.node, params[:tags])
+      redirect_to [@bookmark.owner, @bookmark], notice: "Votre lien a bien été partagé"
+    else
+      @bookmark.node = Node.new(user_id: current_user.id, cc_licensed: false)
+      @bookmark.valid?
+      flash.now[:alert] = "Votre lien semble invalide. Êtes-vous sûr ?" unless @bookmark.link =~ /\A#{URI::regexp(['http', 'https'])}\z/
+      render :new
+    end
+  end
+
+### By user ###
+
+  def show
+    enforce_view_permission(@bookmark)
+    path = user_bookmark_path(@user, @bookmark, format: params[:format])
+    redirect_to path, status: 301 if request.path != path
+    headers['Link'] = %(<#{user_bookmark_url @user, @bookmark}>; rel="canonical")
+    flash.now[:alert] = "Attention, ce lien a été supprimé et n'est visible que par les admins" unless @bookmark.visible?
+  end
+
+  def edit
+    enforce_update_permission(@bookmark)
+  end
+
+  def update
+    enforce_update_permission(@bookmark)
+    @bookmark.attributes = bookmark_params
+    if !preview_mode && @bookmark.save
+      redirect_to [@user, @bookmark], notice: "Le lien a bien été modifié"
+    else
+      flash.now[:alert] = "Impossible d'enregistrer ce lien" if @bookmark.invalid?
+      render :edit
+    end
+  end
+
+  def destroy
+    enforce_destroy_permission(@bookmark)
+    @bookmark.mark_as_deleted
+    redirect_to bookmarks_url, notice: "Le lien a bien été supprimé"
+  end
+
+protected
+
+  def bookmark_params
+    params.require(:bookmark).permit(:title, :link, :cc_licensed)
+  end
+
+  def find_bookmark
+    @user  = User.find(params[:user_id])
+    @bookmark = @user.bookmarks.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    bookmark = Bookmark.find(params[:id])
+    redirect_to [bookmark.owner, bookmark]
+  end
+
+  def marked_as_read
+    current_account.read(@bookmark.node) unless params[:format] == "md"
+  end
+
+  def expire_cache
+    return if @bookmark.new_record?
+    expire_page action: :index, format: :atom
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   def show
     path = user_path(id: @user, format: params[:format])
     redirect_to path, status: 301 and return if request.path != path
-    find_nodes([News, Diary])
+    find_nodes([News, Diary, Bookmark])
     respond_to do |wants|
       wants.html
       wants.atom

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,16 @@ class UsersController < ApplicationController
     end
   end
 
+  def liens
+    path = liens_user_path(id: @user, format: params[:format])
+    redirect_to path, status: 301 and return if request.path != path
+    find_nodes(Bookmark)
+    respond_to do |wants|
+      wants.html
+      wants.atom { render 'bookmarks/index' }
+    end
+  end
+
   def posts
     path = posts_user_path(id: @user, format: params[:format])
     redirect_to path, status: 301 and return if request.path != path

--- a/app/helpers/node_helper.rb
+++ b/app/helpers/node_helper.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 module NodeHelper
 
   ContentPresenter = Struct.new(:record, :title, :meta, :tags, :notice, :image, :body, :actions, :css_class, :hidden) do
@@ -115,7 +115,7 @@ module NodeHelper
   def read_it(content)
     node = content.node
     path = path_for_content(content)
-    link = link_to_unless_current("Lire la suite", path, itemprop: "url") { "" }
+    link = link_to_unless_current(content.label_for_expand, path, itemprop: "url") { "" }
     ret  = tag(:meta, itemprop: "interactionCount", content: "UserComments:#{node.try(:comments_count)}")
     nb_comments = content_tag(:span, pluralize(node.try(:comments_count), "commentaire"), class: "nb_comments")
     if current_account

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -8,6 +8,7 @@
 #  cached_slug       :string(165)
 #  owner_id          :integer
 #  link              :string(1024)
+#  lang              :string(2)        not null
 #  created_at        :datetime
 #  updated_at        :datetime
 #

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,65 @@
+# encoding: utf-8
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id                :integer          not null, primary key
+#  title             :string(160)      not null
+#  cached_slug       :string(165)
+#  owner_id          :integer
+#  link              :string(1024)
+#  created_at        :datetime
+#  updated_at        :datetime
+#
+
+# The users can post on theirs bookmarks.
+# They can be used for sharing interesting,
+# stuff found on other websites.
+#
+class Bookmark < Content
+  self.table_name = "bookmarks"
+  self.type = "Lien"
+
+  belongs_to :owner, class_name: 'User'
+
+  validates :title,     presence: { message: "Le titre est obligatoire" },
+                        length: { maximum: 100, message: "Le titre est trop long" }
+  validates :link, presence: { message: "Vous ne pouvez pas poster un lien vide" }
+
+  def create_node(attrs={})
+    attrs[:cc_licensed] = false
+    super
+  end
+  
+  def label_for_expand
+    "Discuter"
+  end
+  
+  def alternative_formats
+    false
+  end
+  
+### SEO ###
+
+  extend FriendlyId
+  friendly_id
+
+  def should_generate_new_friendly_id?
+    title_changed?
+  end
+
+### ACL ###
+
+  def creatable_by?(account)
+    account.karma > 0
+  end
+
+  def updatable_by?(account)
+    account.moderator? || account.admin?
+  end
+
+  def destroyable_by?(account)
+    account.moderator? || account.admin?
+  end
+
+end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -16,6 +16,14 @@ class Content < ActiveRecord::Base
 
   class << self; attr_accessor :type; end
 
+  def label_for_expand
+    "Lire la suite"
+  end
+
+  def alternative_formats
+    true
+  end
+  
 ### License ###
 
   attr_accessor :cc_licensed, :tmp_owner_id
@@ -99,5 +107,4 @@ class Content < ActiveRecord::Base
       'yearly'
     end
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ActiveRecord::Base
   has_one  :account, dependent: :destroy, inverse_of: :user
   has_many :nodes, inverse_of: :user
   has_many :diaries, dependent: :destroy, inverse_of: :owner, foreign_key: "owner_id"
+  has_many :bookmarks, dependent: :destroy, inverse_of: :owner, foreign_key: "owner_id"
   has_many :news_versions, dependent: :nullify
   has_many :wiki_versions, dependent: :nullify
   has_many :comments, inverse_of: :user

--- a/app/views/bookmarks/_bookmark.atom.builder
+++ b/app/views/bookmarks/_bookmark.atom.builder
@@ -1,0 +1,12 @@
+url = polymorphic_url([bookmark.owner, bookmark])
+feed.entry(bookmark, :url => url) do |entry|
+  entry.title(bookmark.title)
+  entry.content("#{link_to bookmark.link}".html_safe + atom_comments_link(url), :type => 'html')
+  entry.author do |author|
+    author.name(bookmark.owner.name)
+  end
+  bookmark.node.popular_tags.each do |tag|
+    entry.category(:term => tag.name)
+  end
+  entry.wfw :commentRss, "https://#{MY_DOMAIN}/nodes/#{bookmark.node.id}/comments.atom"
+end

--- a/app/views/bookmarks/_bookmark.html.haml
+++ b/app/views/bookmarks/_bookmark.html.haml
@@ -1,0 +1,6 @@
+= article_for bookmark do |c|
+  - c.title = "#{link_to "Lien", "/liens", class: "topic"} #{link_to bookmark.title, [bookmark.owner, bookmark]}".html_safe
+  - c.image = avatar_img(bookmark.owner)
+  - c.body = "#{link_to bookmark.link}".html_safe
+  - if current_account && current_account.can_update?(bookmark)
+    - c.actions = link_to("Modifier", edit_user_bookmark_path(user_id: bookmark.owner, id: bookmark), class: 'action')

--- a/app/views/bookmarks/_bookmark.html.haml
+++ b/app/views/bookmarks/_bookmark.html.haml
@@ -1,6 +1,8 @@
 = article_for bookmark do |c|
   - c.title = "#{link_to "Lien", "/liens", class: "topic"} #{link_to bookmark.title, [bookmark.owner, bookmark]}".html_safe
   - c.image = avatar_img(bookmark.owner)
-  - c.body = "#{link_to bookmark.link}".html_safe
+  - c.body = capture do
+    %ul
+      %li{lang: bookmark.lang}= "#{link_to bookmark.link, bookmark.link, hreflang: bookmark.lang}".html_safe
   - if current_account && current_account.can_update?(bookmark)
     - c.actions = link_to("Modifier", edit_user_bookmark_path(user_id: bookmark.owner, id: bookmark), class: 'action')

--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -1,0 +1,16 @@
+= messages_on_error @bookmark
+
+%p
+  = form.label :link, "Lien à partager"
+  = form.text_field :link, autocomplete: 'off', required: 'required', spellcheck: 'false', maxlength: 1024
+%p
+  = form.label :title, "Sujet du lien"
+  = form.text_field :title, autocomplete: 'off', required: 'required', spellcheck: 'true', maxlength: 100
+%p
+- if form.object.new_record?
+  %p
+    = label_tag :tags
+    = text_field_tag :tags, nil, class: 'autocomplete', 'data-url' => autocomplete_tags_path, value: params[:tags], size: 100
+%p
+  = form.submit "Prévisualiser", id: "bookmark_preview"
+  = form.submit "Poster le lien", 'data-disable-with' => "Enregistrement en cours" if @preview_mode

--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -4,6 +4,9 @@
   = form.label :link, "Lien à partager"
   = form.text_field :link, autocomplete: 'off', required: 'required', spellcheck: 'false', maxlength: 1024
 %p
+  = form.label :lang, "Langue"
+  = form.select :lang, Lang.all
+%p
   = form.label :title, "Sujet du lien"
   = form.text_field :title, autocomplete: 'off', required: 'required', spellcheck: 'true', maxlength: 100
 %p

--- a/app/views/bookmarks/_preview.html.haml
+++ b/app/views/bookmarks/_preview.html.haml
@@ -1,4 +1,6 @@
 = article_for preview do |c|
   - c.title = "#{link_to "Lien", "/liens", class: "topic"} #{link_to spellcheck(preview.title), "#"}".html_safe
   - c.image = avatar_img(preview.node.user)
-  - c.body = "#{link_to preview.link}".html_safe
+  - c.body = capture do
+    %ul
+      %li{lang: preview.lang}= "#{link_to preview.link, preview.link, hreflang: preview.lang}".html_safe

--- a/app/views/bookmarks/_preview.html.haml
+++ b/app/views/bookmarks/_preview.html.haml
@@ -1,0 +1,4 @@
+= article_for preview do |c|
+  - c.title = "#{link_to "Lien", "/liens", class: "topic"} #{link_to spellcheck(preview.title), "#"}".html_safe
+  - c.image = avatar_img(preview.node.user)
+  - c.body = "#{link_to preview.link}".html_safe

--- a/app/views/bookmarks/edit.html.haml
+++ b/app/views/bookmarks/edit.html.haml
@@ -1,0 +1,11 @@
+%main#contents(role="main")
+  =h1 "Éditer un lien"
+
+  = render "preview", preview: @bookmark if @preview_mode
+
+  %h2 Édition
+  = form_for [@bookmark.owner, @bookmark] do |form|
+    = render form
+
+  %h2 Modération
+  = button_to "Supprimer", [@bookmark.owner, @bookmark], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce lien ?" }, class: "delete_button"

--- a/app/views/bookmarks/index.atom.builder
+++ b/app/views/bookmarks/index.atom.builder
@@ -1,0 +1,11 @@
+atom_feed(:root_url => bookmarks_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
+  if @user
+    feed.title("LinuxFr.org : les liens de #{@user.name}")
+  else
+    feed.title("LinuxFr.org : les liens")
+  end
+  feed.updated(@nodes.first.try :created_at)
+  feed.icon("/favicon.png")
+
+  render :partial => @nodes.map(&:content), :locals => { :feed => feed }
+end

--- a/app/views/bookmarks/index.html.haml
+++ b/app/views/bookmarks/index.html.haml
@@ -1,0 +1,4 @@
+=h1 "Les liens"
+- feed "Flux Atom des liens"
+- new_content_link = link_to("Partager un lien", "/liens/nouveau") if current_account
+= paginated_nodes @nodes, new_content_link

--- a/app/views/bookmarks/new.html.haml
+++ b/app/views/bookmarks/new.html.haml
@@ -1,0 +1,10 @@
+%main#contents(role="main")
+  =h1 "Partager un lien"
+
+  %p
+    Des <a href="/regles_de_moderation">règles de modération</a> sont applicables aux liens (et au reste du site).
+
+  = render "preview", preview: @bookmark if @preview_mode
+
+  = form_for @bookmark do |form|
+    = render form

--- a/app/views/bookmarks/new.html.haml
+++ b/app/views/bookmarks/new.html.haml
@@ -2,7 +2,10 @@
   =h1 "Partager un lien"
 
   %p
-    Des <a href="/regles_de_moderation">règles de modération</a> sont applicables aux liens (et au reste du site).
+    La rubrique « liens » est destinée à recevoir les, euh…, liens vers des contenus en rapport avec la ligne éditoriale de LinuxFr.org. En particulier et de manière non exhaustive les articles concernant Linux, les logiciels libres, le matériel libre, les arts libres, sont les bienvenus. Vous pouvez aussi partager ici des liens vers vos propre contenus hébergés ailleurs.
+
+  %p
+    Les <a href="/regles_de_moderation">règles de modération</a> sont applicables aux liens comme au reste du site.
 
   = render "preview", preview: @bookmark if @preview_mode
 

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -1,0 +1,5 @@
+%main#contents(role="main")
+  - title @bookmark.title
+  - meta_for @bookmark
+  = render @bookmark
+  = render @bookmark.node

--- a/app/views/layouts/_site.html.haml
+++ b/app/views/layouts/_site.html.haml
@@ -7,6 +7,7 @@
       %li= link_to "Accueil", '/', title: "Page d'accueil du site"
     %li{class: ("active" if controller_name == "news" || controller_name == "sections")}= link_to "Dépêches", '/news', title: "Actualités, événements et autres nouveautés"
     %li{class: ("active" if controller_name == "diaries" || (controller_name == "users" && action_name == "show"))}= link_to "Journaux", '/journaux', title: "Journaux personnels de nos visiteurs"
+    %li{class: ("active" if controller_name == "bookmarks" || (controller_name == "users" && action_name == "show"))}= link_to "Liens", '/liens', title: "Liens remarquables"
     %li{class: ("active" if controller_name == "forums" || controller_name == "posts")}= link_to "Forums", '/forums', title: "Questions/réponses, petites annonces"
     %li{class: ("active" if controller_name == "wiki_pages" || controller_name == "wiki_versions")}= link_to "Wiki", '/wiki', title: "Pages wiki"
     %li{class: ("active" if current_page?("/redaction"))}= link_to "Rédaction", '/redaction', title: "Participez à la rédaction des dépêches"

--- a/app/views/nodes/_actions.html.haml
+++ b/app/views/nodes/_actions.html.haml
@@ -1,6 +1,7 @@
-.formats
-  = link_to "Markdown", "#{path_for_content node.content}.md", title: "Télécharger ce contenu au format markdown", class: "action"
-  = link_to "Epub", "#{path_for_content node.content}.epub", title: "Télécharger ce contenu au format epub", class: "action"
+- if node.content.alternative_formats
+  .formats
+    = link_to "Markdown", "#{path_for_content node.content}.md", title: "Télécharger ce contenu au format markdown", class: "action"
+    = link_to "Epub", "#{path_for_content node.content}.epub", title: "Télécharger ce contenu au format epub", class: "action"
 - if current_account && current_account.can_vote?(node.content)
   .vote
     Ce contenu est-il #{button_to "pertinent", "/nodes/#{node.id}/vote/for", remote: true, class: "relevant"}

--- a/app/views/users/_recent.html.haml
+++ b/app/views/users/_recent.html.haml
@@ -51,6 +51,7 @@
   %ul
     %li= link_to "journaux", journaux_user_path(@user)
     %li= link_to "dépêches", news_user_path(@user)
+    %li= link_to "liens", liens_user_path(@user)
     %li= link_to "messages sur les forums", posts_user_path(@user)
     %li= link_to "entrées du suivi", suivi_user_path(@user)
     %li= link_to "ajouts au wiki", wiki_user_path(@user)

--- a/app/views/users/liens.html.haml
+++ b/app/views/users/liens.html.haml
@@ -1,0 +1,7 @@
+- content_for :column do
+  = render 'recent'
+  = render 'nodes'
+
+=h1 "#{@user.name} a partagé #{pluralize @nodes.total_count, "lien"}"
+- feed "Flux Atom des liens de #{@user.name}"
+= paginated_nodes @nodes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,11 @@ Rails.application.routes.draw do
         post :move
       end
     end
+    resources :liens, controller: "bookmarks", as: "bookmarks", except: [:index, :new, :create]
     member do
       get :news
       get :journaux
+      get :liens
       get :posts
       get :suivi
       get :comments
@@ -28,6 +30,7 @@ Rails.application.routes.draw do
     end
   end
   resources :journaux, controller: "diaries", as: "diaries", only: [:index, :new, :create]
+  resources :liens, controller: "bookmarks", as: "bookmarks", only: [:index, :new, :create]
 
   # Forums
   resources :forums, only: [:index, :show] do

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -47,6 +47,14 @@ SitemapGenerator::Sitemap.add_links do |sitemap|
     sitemap.add user_diary_path(user_id: diary.owner, id: diary), priority: 0.8, changefreq: diary.changefreq, lastmod: diary.lastmod
   end
 
+  # Bookmarks
+  sitemap.add bookmarks_path, priority: 0.6, changefreq: 'hourly'
+  Node.sitemap(Bookmark).find_each do |node|
+    bookmark = node.content
+    next if bookmark.owner.nil?
+    sitemap.add user_bookmark_path(user_id: bookmark.owner, id: bookmark), priority: 0.8, changefreq: bookmark.changefreq, lastmod: bookmark.lastmod
+  end
+
   # Forums
   sitemap.add forums_path, priority: 0.3, changefreq: 'hourly'
   Forum.find_each do |forum|

--- a/db/migrate/20180318212400_create_bookmarks.rb
+++ b/db/migrate/20180318212400_create_bookmarks.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+class CreateBookmarks < ActiveRecord::Migration
+  def self.up
+    create_table :bookmarks do |t|
+      t.string :title,       limit: 160, null: false
+      t.string :cached_slug, limit: 165
+      t.integer :owner_id
+      t.string :link, null: false
+      t.string :lang, null: false, limit: 2
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+    add_index :bookmarks, :owner_id
+    add_index :bookmarks, :cached_slug
+  end
+
+  def self.down
+    drop_table :bookmarks
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031210801) do
+ActiveRecord::Schema.define(version: 20180318212400) do
 
   create_table "accounts", force: :cascade do |t|
     t.integer  "user_id",                limit: 4
@@ -65,6 +65,19 @@ ActiveRecord::Schema.define(version: 20171031210801) do
     t.boolean "active",                     default: true
   end
 
+  create_table "bookmarks", force: :cascade do |t|
+    t.string   "title",       limit: 160, null: false
+    t.string   "cached_slug", limit: 165
+    t.integer  "owner_id",    limit: 4
+    t.string   "link",        limit: 255, null: false
+    t.string   "lang",        limit: 2,   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "bookmarks", ["cached_slug"], name: "index_bookmarks_on_cached_slug", using: :btree
+  add_index "bookmarks", ["owner_id"], name: "index_bookmarks_on_owner_id", using: :btree
+
   create_table "categories", force: :cascade do |t|
     t.string   "title",      limit: 32, null: false
     t.datetime "created_at"
@@ -105,19 +118,6 @@ ActiveRecord::Schema.define(version: 20171031210801) do
 
   add_index "diaries", ["cached_slug"], name: "index_diaries_on_cached_slug", using: :btree
   add_index "diaries", ["owner_id"], name: "index_diaries_on_owner_id", using: :btree
-
-  create_table "bookmarks", force: :cascade do |t|
-    t.string   "title",             limit: 160
-    t.string   "cached_slug",       limit: 165
-    t.integer  "owner_id",          limit: 4
-    t.string   "link",              limit: 1024,        null: false
-    t.string   "lang",              limit: 2, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "bookmarks", ["cached_slug"], name: "index_bookmarks_on_cached_slug", using: :btree
-  add_index "bookmarks", ["owner_id"], name: "index_bookmarks_on_owner_id", using: :btree
 
   create_table "forums", force: :cascade do |t|
     t.string   "state",       limit: 10, default: "active", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,6 +106,18 @@ ActiveRecord::Schema.define(version: 20171031210801) do
   add_index "diaries", ["cached_slug"], name: "index_diaries_on_cached_slug", using: :btree
   add_index "diaries", ["owner_id"], name: "index_diaries_on_owner_id", using: :btree
 
+  create_table "bookmarks", force: :cascade do |t|
+    t.string   "title",             limit: 160
+    t.string   "cached_slug",       limit: 165
+    t.integer  "owner_id",          limit: 4
+    t.string   "link",              limit: 1024,        null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "bookmarks", ["cached_slug"], name: "index_bookmarks_on_cached_slug", using: :btree
+  add_index "bookmarks", ["owner_id"], name: "index_bookmarks_on_owner_id", using: :btree
+
   create_table "forums", force: :cascade do |t|
     t.string   "state",       limit: 10, default: "active", null: false
     t.string   "title",       limit: 32,                    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 20171031210801) do
     t.string   "cached_slug",       limit: 165
     t.integer  "owner_id",          limit: 4
     t.string   "link",              limit: 1024,        null: false
+    t.string   "lang",              limit: 2, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Please review this PR which adds support for a new content type in the form of bookmarks provided by the users. A bookmark is a link to a website along with a short description. Like other contents on the site this one can be commented, rated, tagged.

This commit provides the basics of the features. Registered users can submit and comment the bookmarks, anyone can read them.

Missing features include at least an atom feed and the forms for moderation.