### PR TITLE
Fixe max height for image on computer screen

### DIFF
--- a/app/assets/stylesheets/RonRonnement.css.scss
+++ b/app/assets/stylesheets/RonRonnement.css.scss
@@ -1832,3 +1832,10 @@ img {
     article { border-width: 1px 0; }
   }
 }
+
+	/*	fixe for computer screen	*/
+@media screen and (max-height: 1100px) {
+	.content img, .content svg {
+		max-height: 700px;
+	}
+}


### PR DESCRIPTION
it's fixe a max lenght for image and svg in contents (coments and articles) for screen with minus than 1100px height.
Checked on 1600x900 (and reverse), 1920x1080 (and reverse).