### PR TITLE
Add a border for missing title on images

### DIFF
--- a/app/assets/stylesheets/common/generics.css.scss
+++ b/app/assets/stylesheets/common/generics.css.scss
@@ -37,3 +37,6 @@
 #edition img[alt="Titre de l'image"] {
   border: 3px dotted red;
 }
+#edition img[alt=""] {
+  border: 3px dotted red;
+}


### PR DESCRIPTION
Use case
user manually create image tag without title like `![](url)`