### PR TITLE
Allow users to choose the source for their tribune smileys in preferences

### DIFF
--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -10,7 +10,7 @@ class Chat
     @board.find(".board-left .norloge").click @norloge
     @board.find("form").submit @postMessage
     @totoz_type = $.cookie("totoz-type")
-    @totoz_url  = $.cookie("totoz-url") or "https://sfw.totoz.eu/gif/"
+    @totoz_url  = $.cookie("totoz-url") or "https://totoz.moul.es/"
     @norlogize      right for right in @board.find(".board-right")
     @norlogize_left left  for left  in @board.find(".board-left time").get().reverse()
     @board.on("mouseenter", ".board-left time", @left_highlitizer)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,7 @@ protected
       :hide_avatar, :news_on_home, :diaries_on_home, :posts_on_home,
       :polls_on_home, :wiki_pages_on_home, :trackers_on_home, :bookmarks_on_home,
       :sort_by_date_on_home, :hide_signature, :show_negative_nodes,
+      :totoz_style, :totoz_source,
       user_attributes: [:id, :name, :homesite, :jabber_id, :signature, :avatar, :custom_avatar_url]
     ])
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+class RegistrationsController < Devise::RegistrationsController
+  def edit
+    self.resource.totoz_style = cookies.permanent["totoz-type"]
+    self.resource.totoz_source = cookies.permanent["totoz-url"]
+
+    super
+  end
+
+  def update
+    super
+
+    cookies.permanent["totoz-type"] = self.resource.totoz_style
+    cookies.permanent["totoz-url"] = self.resource.totoz_source
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -57,6 +57,9 @@ class Account < ActiveRecord::Base
   attr_accessor :amr_id
   delegate :name, to: :user
 
+  attr_accessor :totoz_style
+  attr_accessor :totoz_source
+
   scope :unconfirmed, -> { where(confirmed_at: nil) }
 
 ### Validation ###

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -12,9 +12,9 @@
     sous la responsabilité de leurs auteurs respectifs.
   %p
     Vous pouvez choisir le type d'affichage pour les photos&nbsp;:
-    %a{onclick: "$.cookie('totoz-type', 'popup', {path: '/board', expires: new Date('01/01/2042')});" } en surimpression,
-    %a{onclick: "$.cookie('totoz-type', 'inline', {path: '/board', expires: new Date('01/01/2042')});" } insérées avec le texte
+    %a{onclick: "$.cookie('totoz-type', 'popup', {path: '/', expires: new Date('01/01/2042')});" } en surimpression,
+    %a{onclick: "$.cookie('totoz-type', 'inline', {path: '/', expires: new Date('01/01/2042')});" } insérées avec le texte
     ou
-    %a{onclick: "$.cookie('totoz-type', null, {path: '/board'});" } sans
+    %a{onclick: "$.cookie('totoz-type', 'none', {path: '/'});" } sans
   %main#contents(role="main")
     = render 'boards', boards: @boards, box: false

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -59,3 +59,22 @@
   %p
     %label.factice Sûr de vos modifications ?
     = f.submit "Enregistrer"
+
+%h2 Choisir vos préférences pour la tribune
+= form_for @account, url: registration_path(:account), method: :put do |f|
+  %h3 Affichage des totoz
+  %p
+    = f.radio_button :totoz_style, "inline"
+    = f.label :totoz_style_inline, "En ligne"
+  %p
+    = f.radio_button :totoz_style, "popup"
+    = f.label :totoz_style_popup, "En popup"
+  %p
+    = f.radio_button :totoz_style, "none"
+    = f.label :totoz_style_none, "Ne pas afficher"
+  %h3 Source des totoz
+  %p
+    = f.select :totoz_source, {"totoz.moul.es" => "https://totoz.moules.es/", "totoz.moul.es (NSFW)" => "https://nsfw.totoz.moul.es/", "claudex.be/sfwttz" => "https://claudex.be/sfwttz/", "claudex.be/ttz (NSFW)" => "https://claudex.be/ttz/"}
+  %p
+    %label.factice Sûr de vos modifications ?
+    = f.submit "Enregistrer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,8 @@ Rails.application.routes.draw do
 
   # Accounts
   devise_for :account, path: "compte", controllers: {
-    sessions: "sessions"
+    sessions: "sessions",
+    registrations: "registrations",
   }, path_names: {
     sign_in: "connexion",
     sign_out: "deconnexion",


### PR DESCRIPTION
This commit does the following things:

* Add a "tribune preferences" section in user preferences that allows to choose how smileys are displayed (inline, popup, not at all) and where they are pulled from.
* Change the default server from sfw.totoz.eu (the domain has not be renewed) to totoz.moul.es (same website, different domain)

The new preferences are stored in cookies so as to be compatible with the already existing tribune code (which already checks for these cookies) with very little changes.

[Here](https://linuxfr.org/suivi/changer-la-source-par-defaut-des-totoz-pour-la-tribune) is the related bug report on linuxfr.org.