### PR TITLE
Allow displaying the main board in the sidebar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,6 +55,7 @@ protected
       :polls_on_home, :wiki_pages_on_home, :trackers_on_home, :bookmarks_on_home,
       :sort_by_date_on_home, :hide_signature, :show_negative_nodes,
       :totoz_style, :totoz_source,
+      :board_in_sidebar,
       user_attributes: [:id, :name, :homesite, :jabber_id, :signature, :avatar, :custom_avatar_url]
     ])
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -310,6 +310,7 @@ class Account < ActiveRecord::Base
                          256 => :hide_signature,
                          512 => :show_negative_nodes,
                         1024 => :bookmarks_on_home,
+                        2048 => :board_in_sidebar,
                          scopes: false
 
   def types_on_home

--- a/app/views/boards/_boards.html.haml
+++ b/app/views/boards/_boards.html.haml
@@ -1,6 +1,6 @@
 - board = boards.build
 .board{'data-chan' => Push.private_key(board.meta)}
   - if current_account && current_account.can_post_on_board?
-    = render 'boards/form', form: board
+    = render 'boards/form', form: board, box: box
   .inbox
     = render partial: 'boards/board', collection: boards, locals: { box: box }

--- a/app/views/boards/_box.html.haml
+++ b/app/views/boards/_box.html.haml
@@ -1,0 +1,5 @@
+#redaction_box.box
+  %h1
+    = link_to "Tribune", '/board'
+  = render 'boards/boards', boards: Board.limit(15, Board.free), box: true
+

--- a/app/views/boards/_form.html.haml
+++ b/app/views/boards/_form.html.haml
@@ -1,5 +1,5 @@
 = form_tag "/board", class: 'chat' do
   = hidden_field :board, :object_type, value: form.object_type
   = hidden_field :board, :object_id, value: form.object_id
-  = text_field :board, :message, value: '', size: 80, autocomplete: 'off', required: 'required', spellcheck: 'true', autofocus: (form.object_type == Board.free)
+  = text_field :board, :message, value: '', size: box ? 20 : 80, autocomplete: 'off', required: 'required', spellcheck: 'true', autofocus: (form.object_type == Board.free)
   = submit_tag 'Envoyer', class: "submit_board"

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -78,3 +78,12 @@
   %p
     %label.factice Sûr de vos modifications ?
     = f.submit "Enregistrer"
+
+%h2 Choisir les contenus affichés sur la barre latérale
+= form_for @account, url: registration_path(:account), method: :put do |f|
+  %p
+    = f.check_box :board_in_sidebar
+    = f.label :board_in_sidebar, "Tribune"
+  %p
+    %label.factice Sûr de vos modifications ?
+    = f.submit "Enregistrer"

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -25,6 +25,8 @@
         %li= link_to "Pas de compte&nbsp;? S'inscrire&nbsp;!".html_safe, '/compte/inscription'
   - if current_account
     = render 'redaction/box'
+    - if current_account.try(:board_in_sidebar)
+      = render 'boards/box'
     - if current_account.amr?
       = render 'moderation/box'
     - if current_account.admin?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -176,4 +176,6 @@ Devise.setup do |config|
   # end
 
   config.expire_all_remember_me_on_sign_out = false
+
+  config.reconfirmable = false
 end


### PR DESCRIPTION
This pull request is for the following tracker entry: https://linuxfr.org/suivi/tribune-dans-la-sidebar

It allows users to choose to show the main discussion board in the site's sidebar, displaying the 15 last messages.