### PR TITLE
Allow posting to boards with no authenticity token

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 class BoardsController < ApplicationController
+  skip_before_action :verify_authenticity_token
   before_action :authenticate_account!, only: :create
   after_action :expire_cache, only: [:create]
   caches_page :show, if: Proc.new { |c| c.request.format.xml? }


### PR DESCRIPTION
I'm not sure why commits d12a858861f8616f6610a15b2380530f2d9d7284 and f57814656adf8bb291a882a01a4243e947a16e6f removed the special function (that checks for the referrer and then the authenticity token if there is no referrer) but it means the tribune is now broken for more than half its users.

This pull request makes the controller bypass the authenticity token check, which is the minimum necessary to allow third-party clients to post.