### PR TITLE
readme: update mysql commands to create a database with real UTF-8 and give hint on user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Note: you can use libcurl4-gnutls-dev instead of libcurl4-openssl-dev.
 ```
 # mysql -p -u root
 <enter your root password for mysql>
-> CREATE DATABASE linuxfr_rails CHARACTER SET utf8;
+> CREATE DATABASE linuxfr_rails CHARACTER SET utf8mb4;
+> CREATE USER linuxfr_rails IDENTIFIED BY 'asecretpassword';
 > GRANT ALL PRIVILEGES ON linuxfr_rails.* TO "linuxfr_rails"@"localhost";
 > QUIT;
 (return to user)


### PR DESCRIPTION
Hello,

I'm creating again a development environment.

I've just seen that mysql commands currently advices to create the database with `utf8` instead of `utf8mb4` which is the real UTF-8 (for more details see [this blog post](https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434) which explain the first character set use a custom utf-8 on 3 bytes and the other uses the standard utf-8 on 4 bytes).

I took the opportunity too to add an example on how to create a user in mysql directly with SQL commands.

Thanks