### PR TITLE
Remove screen max-height media query

### DIFF
--- a/app/assets/stylesheets/responsive/xs.scss
+++ b/app/assets/stylesheets/responsive/xs.scss
@@ -1,4 +1,4 @@
-@media screen and (max-width: 25em), screen and (max-height: 25em), handheld {
+@media screen and (max-width: 25em), handheld {
   #sidebar #branding {
     width: $PX_BRANDING_LARG / 2;
     margin-right: 10px;


### PR DESCRIPTION
This property makes the page jump and therefore difficult to read for specific screen configurations when the navigation bar is shown / hidden while scrolling up and down (for instance on Firefox Mobile with a 1080p screen and a minimum screen width of 617 dp / display size of 280).