### PR TITLE
Update footer nodes to be more responsive

### DIFF
--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -146,7 +146,6 @@ article {
 .not_read {
   a:before {
     content: '+ ';
-    font-size: 1.2em;
     font-weight: bold;
   }
 }
@@ -166,6 +165,13 @@ article {
 }
 
 footer.actions {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  grid-gap: 0.8em;
+  font-size: 1em;
+  .formats {
+    grid-column: -1;
+  }
   .action {
     color: $C_INTER;
     margin-right: 10px;
@@ -192,6 +198,7 @@ footer.actions {
       font-weight: bold;
       border-style: none;
       background-color: transparent;
+      height: auto;
     }
   }
 }
@@ -200,6 +207,7 @@ footer.actions {
   color: $C_INTER;
   font-style: italic;
   font-size: x-small;
+  grid-column: 1 / -1;
 
   form,
   form div {

--- a/app/assets/stylesheets/parts/tags.scss
+++ b/app/assets/stylesheets/parts/tags.scss
@@ -1,8 +1,4 @@
 /* parti de la base de yggdras pour la partie sur les tags */
-.formats {
-  float: right;
-  clear: right;
-}
 .tag_in_place {
   display: inline-block;
   a:before {
@@ -11,8 +7,7 @@
     color: $C_BANDEAU;
   }
 }
-.tag_in_place,
-.formats {
+.tag_in_place {
   margin-bottom: 5px;
   color: $C_INTER;
   a {

--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -125,6 +125,13 @@
     }
   }
 
+  .node footer {
+    grid-template-columns: auto;
+  }
+  .node footer .formats
+  {
+    grid-column: auto;
+  }
   .node footer.actions .action .button_to {
     display: none;
   }


### PR DESCRIPTION
To correctly display download link on mobile screens, this solution
had to remove the float:right CSS option and use more modern CSS grids.

So, on big screen, we display footer on two lines (one with
almost everything except vote div, the other with the vote div).

On small screen, we in one column and so we have one line by
functionnality.

The downside is the display with Internet Explorer is broken (download
links hidde the read it button).

PS: see result in the tracker: https://linuxfr.org/suivi/design-ajouter-une-icone-de-telechargement-a-cote-des-liens-markdown-et-epub#comment-1767266