### PR TITLE
Node formats revert grid use floats

### DIFF
--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -166,6 +166,7 @@ article {
 }
 
 footer.actions {
+  font-size: 1em;
   .action {
     color: $C_INTER;
     margin-right: 10px;

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -146,7 +146,6 @@ article {
 .not_read {
   a:before {
     content: '+ ';
-    font-size: 1.2em;
     font-weight: bold;
   }
 }
@@ -193,6 +192,7 @@ footer.actions {
       font-weight: bold;
       border-style: none;
       background-color: transparent;
+      height: auto;
     }
   }
 }

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -146,6 +146,7 @@ article {
 .not_read {
   a:before {
     content: '+ ';
+    font-size: 1.2em;
     font-weight: bold;
   }
 }
@@ -165,13 +166,6 @@ article {
 }
 
 footer.actions {
-  display: grid;
-  grid-template-columns: auto auto 1fr auto;
-  grid-gap: 0.8em;
-  font-size: 1em;
-  .formats {
-    grid-column: -1;
-  }
   .action {
     color: $C_INTER;
     margin-right: 10px;
@@ -198,7 +192,6 @@ footer.actions {
       font-weight: bold;
       border-style: none;
       background-color: transparent;
-      height: auto;
     }
   }
 }
@@ -207,7 +200,6 @@ footer.actions {
   color: $C_INTER;
   font-style: italic;
   font-size: x-small;
-  grid-column: 1 / -1;
 
   form,
   form div {

--- a/app/assets/stylesheets/parts/tags.scss
+++ b/app/assets/stylesheets/parts/tags.scss
@@ -1,4 +1,8 @@
 /* parti de la base de yggdras pour la partie sur les tags */
+.formats {
+  float: right;
+  clear: right;
+}
 .tag_in_place {
   display: inline-block;
   a:before {
@@ -7,7 +11,8 @@
     color: $C_BANDEAU;
   }
 }
-.tag_in_place {
+.tag_in_place,
+.formats {
   margin-bottom: 5px;
   color: $C_INTER;
   a {

--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -125,6 +125,12 @@
     }
   }
 
+  .node footer .formats
+  {
+    float: none;
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
   .node footer.actions .action .button_to {
     display: none;
   }

--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -125,13 +125,6 @@
     }
   }
 
-  .node footer {
-    grid-template-columns: auto;
-  }
-  .node footer .formats
-  {
-    grid-column: auto;
-  }
   .node footer.actions .action .button_to {
     display: none;
   }


### PR DESCRIPTION
To be compatible with IE and, normally, old browsers.

See comments: https://linuxfr.org/suivi/design-ajouter-une-icone-de-telechargement-a-cote-des-liens-markdown-et-epub#comment-1771335