### PR TITLE
Tag moderation (public->not public, not the removal part)

### DIFF
--- a/app/controllers/moderation/tags_controller.rb
+++ b/app/controllers/moderation/tags_controller.rb
@@ -1,0 +1,7 @@
+# encoding: UTF-8
+class Moderation::TagsController < ModerationController
+
+  def index
+    @tags = Tag.public_tags
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -46,6 +46,16 @@ class Tag < ActiveRecord::Base
     EOS
   end
 
+  def self.public_tags(offset=0, count=10000)
+    Tag.find_by_sql <<-EOS
+        SELECT t.name, t.taggings_count
+        FROM tags t
+        WHERE t.public = 1
+        ORDER BY t.taggings_count ASC
+        LIMIT #{offset},#{count}
+    EOS
+  end
+
 ### Visibility ###
 
   def updatable_by?(account)

--- a/app/views/moderation/news/index.html.haml
+++ b/app/views/moderation/news/index.html.haml
@@ -26,6 +26,9 @@
   = link_to "Images externes", moderation_images_path
 
 %h2
+  = link_to "Tags publics", moderation_tags_path
+
+%h2
   = link_to "Sondages", moderation_polls_path
 - if @polls.empty?
   %p Aucune proposition

--- a/app/views/moderation/tags/index.html.haml
+++ b/app/views/moderation/tags/index.html.haml
@@ -1,0 +1,5 @@
+%h2 Tags publics par nombre croissant d'occurences
+
+- @tags.each do |tag|
+  .tag
+    = link_to("#{tag.name} (#{tag.taggings_count})", public_tag_path(tag.name))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
     resources :plonk, only: [:create]
     resources :block, only: [:create]
     resources :images, only: [:index, :destroy]
+    resources :tags, only: [:index]
   end
 
   # Admin


### PR DESCRIPTION
Not declared into https://linuxfr.org/suivi (the invalid https://linuxfr.org/suivi/moderer-les-tags is not the same subject)

Only a way to move a tag from public to not public. No way to fully remove, or merge, or rename.