### PR TITLE
Fix size of comment textarea when JS not available

### DIFF
--- a/app/assets/stylesheets/common/markitup.scss
+++ b/app/assets/stylesheets/common/markitup.scss
@@ -163,3 +163,8 @@
     }
   }
 }
+
+textarea.markItUp:not(.markItUpEditor) {
+  width: 100%;
+  height: 10em;
+}


### PR DESCRIPTION
When JS is not available, the textarea for writing comments is too tiny.
This addition sets its size. It only applies when JS is disabled.
When the JS is enabled, the textarea has both classes .markItUp and .markItUpEditor,
which is not the case with JS disabled.