### PR TITLE
Redesign tribune to look likes common Instant Messaging UI

### DIFF
--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -112,9 +112,9 @@ class Chat
     date = /\d{4}-\d{2}-\d{2}/.exec(norlogeDatetime)
     time = /\d{2}:\d{2}:\d{2}/.exec(norlogeDatetime)
     index = @board.find(".board-left time[data-clock-date=\"" + date + "\"][data-clock-time=\"" + time + "\"]").length + 1
-    $(x).attr("data-clockDate", date)
-    $(x).attr("data-clockTime", time)
-    $(x).attr("data-clockIndex", index)
+    $(x).attr("data-clock-date", date)
+    $(x).attr("data-clock-time", time)
+    $(x).attr("data-clock-index", index)
 
   left_highlitizer: (event) =>
     time = $(event.target).data("clockTime")

--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -6,6 +6,9 @@ class Chat
   constructor: (@board) ->
     @input = @board.find("input[type=text]")
     @inbox = @board.find(".inbox")
+    @isInboxLarge = @inbox.hasClass("large")
+    @inboxContainer = @board.find(".inbox-container")
+    @inboxContainer.animate({scrollTop: @inbox.height()})
     @chan = @board.data("chan")
     @board.find(".board-left .norloge").click @norloge
     @board.find("form").submit @postMessage
@@ -26,7 +29,11 @@ class Chat
   onChat: (msg) =>
     existing = $("#board_" + msg.id)
     return  if existing.length > 0
-    @inbox.prepend(msg.message).find(".board-left:first .norloge").click @norloge
+    if @isInboxLarge
+      @inbox.append(msg.message).find(".board-left:first .norloge").click @norloge
+      @inboxContainer.animate({scrollTop: @inbox.height()})
+    else
+      @inbox.prepend(msg.message).find(".board-left:first .norloge").click @norloge
     @norlogize      right for right in @inbox.find(".board-right:first")
     @norlogize_left left  for left  in @inbox.find(".board-left time:first")
 

--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -30,12 +30,14 @@ class Chat
     existing = $("#board_" + msg.id)
     return  if existing.length > 0
     if @isInboxLarge
-      @inbox.append(msg.large).find(".board-left:first .norloge").click @norloge
+      @inbox.append(msg.large).find(".board-left:last .norloge").click @norloge
       @inboxContainer.scrollTop(@inbox.height())
+      @norlogize      right for right in @inbox.find(".board-right:last")
+      @norlogize_left left  for left  in @inbox.find(".board-left time:last")
     else
       @inbox.prepend(msg.message).find(".board-left:first .norloge").click @norloge
-    @norlogize      right for right in @inbox.find(".board-right:first")
-    @norlogize_left left  for left  in @inbox.find(".board-left time:first")
+      @norlogize      right for right in @inbox.find(".board-right:first")
+      @norlogize_left left  for left  in @inbox.find(".board-left time:first")
 
   postMessage: (event) =>
     form = $(event.target)

--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -8,7 +8,7 @@ class Chat
     @inbox = @board.find(".inbox")
     @isInboxLarge = @inbox.hasClass("large")
     @inboxContainer = @board.find(".inbox-container")
-    @inboxContainer.animate({scrollTop: @inbox.height()})
+    @inboxContainer.scrollTop(@inbox.height())
     @chan = @board.data("chan")
     @board.find(".board-left .norloge").click @norloge
     @board.find("form").submit @postMessage
@@ -30,8 +30,8 @@ class Chat
     existing = $("#board_" + msg.id)
     return  if existing.length > 0
     if @isInboxLarge
-      @inbox.append(msg.message).find(".board-left:first .norloge").click @norloge
-      @inboxContainer.animate({scrollTop: @inbox.height()})
+      @inbox.append(msg.large).find(".board-left:first .norloge").click @norloge
+      @inboxContainer.scrollTop(@inbox.height())
     else
       @inbox.prepend(msg.message).find(".board-left:first .norloge").click @norloge
     @norlogize      right for right in @inbox.find(".board-right:first")

--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -112,9 +112,9 @@ class Chat
     date = /\d{4}-\d{2}-\d{2}/.exec(norlogeDatetime)
     time = /\d{2}:\d{2}:\d{2}/.exec(norlogeDatetime)
     index = @board.find(".board-left time[data-clock-date=\"" + date + "\"][data-clock-time=\"" + time + "\"]").length + 1
-    x.dataset.clockDate = date
-    x.dataset.clockTime = time
-    x.dataset.clockIndex = index
+    $(x).attr("data-clockDate", date)
+    $(x).attr("data-clockTime", time)
+    $(x).attr("data-clockIndex", index)
 
   left_highlitizer: (event) =>
     time = $(event.target).data("clockTime")

--- a/app/assets/stylesheets/parts/buttons.scss
+++ b/app/assets/stylesheets/parts/buttons.scss
@@ -102,7 +102,8 @@ input[type="submit"] {
   &.submit_board {
     background-image: inline("feather-icons/dist/icons/message-square.svg");
   }
-  &.submit_news {
+  &.submit_news,
+  &.submit {
     background-image: inline("feather-icons/dist/icons/send.svg");
   }
   &.urgent_news {

--- a/app/assets/stylesheets/parts/tribune.scss
+++ b/app/assets/stylesheets/parts/tribune.scss
@@ -73,6 +73,7 @@ body#boards-show {
     display: flex;
     flex-direction: column;
     justify-content: end;
+    min-height: 99%;
   }
   form.chat {
     > div {

--- a/app/assets/stylesheets/parts/tribune.scss
+++ b/app/assets/stylesheets/parts/tribune.scss
@@ -11,21 +11,16 @@ body#boards-show {
     text-align: justify;
   }
 }
+
 #redaction_board {
-  #board_message {
-    border: 1px solid #999;
-    padding: 4px;
-  }
   div.chat {
-    border: 1px solid #999;
-    background-color: white;
+    display: flex;
     padding: 0.2em;
   }
   .avatar {
-    float: left;
     height: 36px;
     width: 36px;
-    margin: 0.2em;
+    margin: 0 1em 0.2em 0.2em;
   }
   .norloge,
   .user_link a {
@@ -43,7 +38,7 @@ body#boards-show {
     }
   }
   .message {
-    margin: 0.4em;
+    margin: 1em 0;
   }
   details {
     margin: 1em 0;
@@ -68,6 +63,26 @@ body#boards-show {
       input {
         margin: 0;
       }
+    }
+  }
+  form.chat {
+    > div {
+      display: -ms-flexbox;
+      display: flex;
+      margin: 0.5em;
+    }
+    #board_message {
+      border: 1px solid #999;
+      border-right: 0;
+      padding: 4px;
+      height: 28px;
+      flex-grow: 1;
+    }
+    button {
+      background-color: white;
+      border: 1px solid #999;
+      border-left: none;
+      margin: 0;
     }
   }
 }

--- a/app/assets/stylesheets/parts/tribune.scss
+++ b/app/assets/stylesheets/parts/tribune.scss
@@ -14,8 +14,12 @@ body#boards-show {
 
 #redaction_board {
   div.chat {
+    display: -ms-flexbox;
     display: flex;
     padding: 0.2em;
+    > div {
+      -ms-flex: 1;
+    }
   }
   .avatar {
     height: 36px;
@@ -70,6 +74,8 @@ body#boards-show {
     overflow: auto;
   }
   .inbox.large {
+    display: -ms-flexbox;
+    -ms-flex-direction: column;
     display: flex;
     flex-direction: column;
     justify-content: end;
@@ -86,6 +92,7 @@ body#boards-show {
       border-right: 0;
       padding: 4px;
       height: 28px;
+      -ms-flex: 1;
       flex-grow: 1;
     }
     button {

--- a/app/assets/stylesheets/parts/tribune.scss
+++ b/app/assets/stylesheets/parts/tribune.scss
@@ -78,7 +78,7 @@ body#boards-show {
     -ms-flex-direction: column;
     display: flex;
     flex-direction: column;
-    justify-content: end;
+    justify-content: flex-end;
     min-height: 99%;
   }
   form.chat {

--- a/app/assets/stylesheets/parts/tribune.scss
+++ b/app/assets/stylesheets/parts/tribune.scss
@@ -65,6 +65,15 @@ body#boards-show {
       }
     }
   }
+  .inbox-container {
+    height: 40vh;
+    overflow: auto;
+  }
+  .inbox.large {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+  }
   form.chat {
     > div {
       display: -ms-flexbox;

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -69,7 +69,8 @@ class Board
 
   def push
     rendered = BoardsController.new.render_to_body(partial: "board", locals: { board: self, box: false })
-    Push.create(meta, kind: :chat, message: rendered)
+    largeRendered = BoardsController.new.render_to_body(partial: "board", locals: { board: self, box: false, is_large: true })
+    Push.create(meta, kind: :chat, message: rendered, large: largeRendered)
   end
 
   def self.chan_key(object_type, object_id)

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -140,6 +140,10 @@ class News < Content
     news.author_email = account.email
     news.editor = account
     news.save
+    message = "Merci d'avoir initié cette rédaction collaborative !
+      Durant toute la phase de rédaction, vous pourrez utiliser la présente
+      messagerie instantanée pour discuter avec les participants."
+    Board.new(object_type: Board.news, object_id: news.id, message: message, user_name: "Le bot LinuxFr").save
     news
   end
 

--- a/app/views/boards/_board.html.haml
+++ b/app/views/boards/_board.html.haml
@@ -1,6 +1,20 @@
-%p.chat{id: "board-#{board.id}"}
-  %span{class: "board-left", title: board.user_agent}
-    - norloge = norloge(board, box)
-    %time.norloge{datetime: board.created_at.iso8601, norloge: norloge}= norloge
-    %b= board.user_link
-  %span{class: "board-right"}= board.message
+- if not(defined?(is_large)) or not(is_large)
+  %p.chat{id: "board-#{board.id}"}
+    %span{class: "board-left", title: board.user_agent}
+      - norloge = norloge(board, box)
+      %time.norloge{datetime: board.created_at.iso8601, norloge: norloge}= norloge
+      %b= board.user_link
+    %span{class: "board-right"}= board.message
+- else
+  .chat{id: "board-#{board.id}"}
+    = image_tag(board.avatar_url, class: "avatar", alt: "")
+    %div
+      %div{class: "board-left"}
+        %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
+          - if board.created_at.today?
+            Aujourd'hui,
+          - else
+            = "Il y a #{time_ago_in_words board.created_at},"
+          = board.created_at.strftime('%Hh%M')
+      .user_link= board.user_link
+      .message{class: "board-right"}= board.message

--- a/app/views/boards/_large.html.haml
+++ b/app/views/boards/_large.html.haml
@@ -3,18 +3,7 @@
   .inbox-container
     .inbox.large
       - boards.reverse.each do |board|
-        .chat{id: "board-#{board.id}"}
-          = image_tag(board.avatar_url, class: "avatar", alt: "")
-          %div
-            %div{class: "board-left"}
-              %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
-                - if board.created_at.today?
-                  Aujourd'hui,
-                - else
-                  = "Il y a #{time_ago_in_words board.created_at},"
-                = board.created_at.strftime('%Hh%M')
-            .user_link= board.user_link
-            .message{class: "board-right"}= board.message
+        = render board, board: board, box: box, is_large: true
   - if current_account && current_account.can_post_on_board?
     = form_tag "/board", class: 'chat' do
       = hidden_field :board, :object_type, value: board.object_type

--- a/app/views/boards/_large.html.haml
+++ b/app/views/boards/_large.html.haml
@@ -1,23 +1,24 @@
 - board = boards.build
 .board{'data-chan' => Push.private_key(board.meta)}
+  .inbox-container
+    .inbox.large
+      - boards.reverse.each do |board|
+        .chat{id: "board-#{board.id}"}
+          = image_tag(board.avatar_url, class: "avatar", alt: "")
+          %div
+            %div{class: "board-left"}
+              %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
+                - if board.created_at.today?
+                  Aujourd'hui,
+                - else
+                  = "Il y a #{time_ago_in_words board.created_at},"
+                = board.created_at.strftime('%Hh%M')
+            .user_link= board.user_link
+            .message{class: "board-right"}= board.message
   - if current_account && current_account.can_post_on_board?
     = form_tag "/board", class: 'chat' do
       = hidden_field :board, :object_type, value: board.object_type
       = hidden_field :board, :object_id, value: board.object_id
       %div
-        = text_field :board, :message, value: '', autocomplete: 'off', required: 'required', spellcheck: 'true'
+        = text_field :board, :message, value: '', placeholder: 'Écrire un message…', autocomplete: 'off', required: 'required', spellcheck: 'true'
         %button.submit
-  .inbox
-    - boards.each do |board|
-      .chat{id: "board-#{board.id}"}
-        = image_tag(board.avatar_url, class: "avatar", alt: "")
-        %div
-          %div{class: "board-left"}
-            %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
-              - if board.created_at.today?
-                Aujourd'hui,
-              - else
-                = "Il y a #{time_ago_in_words board.created_at},"
-              = board.created_at.strftime('%Hh%M')
-          .user_link= board.user_link
-          .message{class: "board-right"}= board.message

--- a/app/views/boards/_large.html.haml
+++ b/app/views/boards/_large.html.haml
@@ -4,17 +4,20 @@
     = form_tag "/board", class: 'chat' do
       = hidden_field :board, :object_type, value: board.object_type
       = hidden_field :board, :object_id, value: board.object_id
-      = text_field :board, :message, value: '', size: 30, autocomplete: 'off', required: 'required', spellcheck: 'true'
+      %div
+        = text_field :board, :message, value: '', autocomplete: 'off', required: 'required', spellcheck: 'true'
+        %button.submit
   .inbox
     - boards.each do |board|
       .chat{id: "board-#{board.id}"}
         = image_tag(board.avatar_url, class: "avatar", alt: "")
-        %div{class: "board-left"}
-          %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
-            - if board.created_at.today?
-              Aujourd'hui,
-            - else
-              = "Il y a #{time_ago_in_words board.created_at},"
-            = board.created_at.strftime('%Hh%M')
-        .user_link= board.user_link
-        .message{class: "board-right"}= board.message
+        %div
+          %div{class: "board-left"}
+            %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
+              - if board.created_at.today?
+                Aujourd'hui,
+              - else
+                = "Il y a #{time_ago_in_words board.created_at},"
+              = board.created_at.strftime('%Hh%M')
+          .user_link= board.user_link
+          .message{class: "board-right"}= board.message

--- a/app/views/moderation/news/show.html.haml
+++ b/app/views/moderation/news/show.html.haml
@@ -5,7 +5,7 @@
     = render 'vote'
     = render 'attendees', attendees: @news.attendees
     = render 'editions', news: @news
-    = render 'board'
+    = render 'boards/large', boards: @boards, box: false
 
 - if @news.paragraphs.any?
   = article_for @news do |c|

--- a/app/views/redaction/news/show.html.haml
+++ b/app/views/redaction/news/show.html.haml
@@ -8,7 +8,7 @@
       %h1.urgent Dépêche urgente !
     = render 'attendees', attendees: @news.attendees
     = render 'editions', news: @news
-    = render 'board', boards: @boards, box: false
+    = render 'boards/large', boards: @boards, box: false
 
 = article_for @news do |c|
   - c.title = capture do


### PR DESCRIPTION
Comme proposé par le nouveau design:

- la tribune "large" est utilisé pour l'espace de rédaction (accueil et édition) et les news en modération
- la tribune "large" affiche les messages de haut en bas.
- un bouton "Envoyer" avec l'icône d'avion a été ajouté au formulaire.
- le texte "Envoyer un message..." a été ajouté dans le placeholder
- un petit message de remerciement est directement écrit dans la tribune lors de la création d'une dépêche

Les nouveaux messages qui viennent d'être envoyés sont affichés avec le rendu "large" pour les tribunes large et normal pour les autres (ça nécessite de faire toujours les 2 rendus avant de pousser dans Redis).

[![Nouvelle tribune large](https://cloud.adorsaz.ch/index.php/s/NzS9CkoG6GHH7H4/download)](https://cloud.adorsaz.ch/index.php/s/NzS9CkoG6GHH7H4)