### PR TITLE
fonts: use Lato Regular for contents and comments, keep Light variant for other texts

### DIFF
--- a/app/assets/stylesheets/parts/a_tag.scss
+++ b/app/assets/stylesheets/parts/a_tag.scss
@@ -3,7 +3,7 @@ html {
   background-image: url("/images/contrib/RonRonnement/background_html.png");
   background-repeat: repeat-x;
   background-position: top;
-  font-family: "Lato Light";
+  font-family: "Lato Light", sans-serif;
   padding: 0 $PX_MARGE_DROITE 0 $PX_MARGE_GAUCHE;
   scroll-behavior: smooth;
   box-sizing: border-box;

--- a/app/assets/stylesheets/parts/comment.scss
+++ b/app/assets/stylesheets/parts/comment.scss
@@ -41,6 +41,7 @@ li.comment {
     margin: 0 5px 5px 10px;
   }
   .content {
+    font-family: "Lato";
     font-size: 1.1em;
     line-height: 1.5em;
     border-left: 1px solid $C_INTER;

--- a/app/assets/stylesheets/parts/comment.scss
+++ b/app/assets/stylesheets/parts/comment.scss
@@ -41,7 +41,7 @@ li.comment {
     margin: 0 5px 5px 10px;
   }
   .content {
-    font-family: "Lato";
+    font-family: "Lato", sans-serif;
     font-size: 1.1em;
     line-height: 1.5em;
     border-left: 1px solid $C_INTER;

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -40,7 +40,7 @@ article {
     padding-top: 5px;
     padding-bottom: 5px;
     min-height: 70px;
-    font-family: "Lato";
+    font-family: "Lato", sans-serif;
     font-size: 1.1em;
     line-height: 1.5em;
 
@@ -137,7 +137,7 @@ article {
   h4,
   h5,
   h6 {
-    font-family: Merriweather;
+    font-family: Merriweather, serif;
     font-weight: normal;
     a {
       font-weight: normal;

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -40,6 +40,7 @@ article {
     padding-top: 5px;
     padding-bottom: 5px;
     min-height: 70px;
+    font-family: "Lato";
     font-size: 1.1em;
     line-height: 1.5em;
 


### PR DESCRIPTION
Ce PR propose d'utiliser "Lato Regular" pour les textes des contenus tout en gardant "Lato Light" pour le reste du site (boutons, menus...).

A voir avec les utilisateurs / designers, si ça peut mieux convenir pour la gestion des polices.

[![Rendu avec contenus sous "Lato Regular"](https://cloud.adorsaz.ch/index.php/s/DxEHsEda3MQ8rRi/download)](https://cloud.adorsaz.ch/index.php/s/DxEHsEda3MQ8rRi/download)