### PR TITLE
Content font size rendering has been a bit reduced with the new font

### DIFF
--- a/app/assets/stylesheets/parts/comment.scss
+++ b/app/assets/stylesheets/parts/comment.scss
@@ -41,7 +41,7 @@ li.comment {
     margin: 0 5px 5px 10px;
   }
   .content {
-    font-size: 1.1em;
+    font-size: 1.2em;
     line-height: 1.5em;
     border-left: 1px solid $C_INTER;
     padding-left: 5px;

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -40,7 +40,7 @@ article {
     padding-top: 5px;
     padding-bottom: 5px;
     min-height: 70px;
-    font-size: 1.1em;
+    font-size: 1.2em;
     line-height: 1.5em;
 
     &.hidden {


### PR DESCRIPTION
Si j'ai bien compris ce que Zenitram voulait dire, le texte semble être rendu un petit peu plus petit qu'avec les polices systèmes.

Ce PR augmente leur taille de `0.1em` pour faciliter la lecture.