### PR TITLE
Redaction layout adjust columns flex

### DIFF
--- a/app/assets/stylesheets/parts/redaction.scss
+++ b/app/assets/stylesheets/parts/redaction.scss
@@ -207,11 +207,11 @@ body#redaction-index {
     overflow: visible;
   }
   #edition {
-    margin-right: 3vw;
-    margin-left: 3vw;
+    margin-right: 15px;
+    margin-left: 15px;
     padding-left: 3px;
     padding-right: 3px;
-    flex-basis: 400px;
+    flex-basis: 1vw;
     flex-grow: 1;
     p {
       margin: 0 0 5px;
@@ -255,17 +255,14 @@ body#redaction-index {
   input#link_title {
     width: 100%; // this rule force the input to not enlarge the #edition flex box
   }
-  #metadata {
-    width: 280px;
-  }
   #toolpanel {
-    width: 280px;
     .inbox p {
       margin: 2px 0;
     }
   }
   #metadata,
   #toolpanel {
+    width: 20%;
     padding-left: 3px;
     padding-right: 3px;
     background: transparent;

--- a/app/assets/stylesheets/parts/tab.scss
+++ b/app/assets/stylesheets/parts/tab.scss
@@ -1,15 +1,18 @@
 .tab-header-container {
   display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
+  -ms-flwx-wrap: wrap;
+  flex-wrap: wrap;
   .tab {
     font-size: 1.5em;
     line-height: 1.3em;
+    cursor: pointer;
     // Use background to display a little border below tabs
     background: no-repeat 0px 1.65rem / 2rem transparent;
     background-image: url("/images/icones/underline.png");
     background-image: url("/images/icones/underline.svg"), none;
     padding-bottom: 5px;
+    margin-right: 10px;
     // For tabs not active, show an alternative background
     &:not([data-show-content]) {
       background-image: url("/images/icones/not-active-underline.png");


### PR DESCRIPTION
Ce PR ajuste un peu la définition des 3 colonnes pour l'espace de rédaction.

Ça permet de prendre un peu plus d'écrans en charge pour l'instant.

En plus, j'ai activé le wrap pour les onglets (justement pour les petits écrans) et j'ai appliquer le changement de curseur au survol des onglets.