### PR TITLE
Make the .links list in bookmarks less gridy

### DIFF
--- a/app/assets/stylesheets/parts/bookmark.scss
+++ b/app/assets/stylesheets/parts/bookmark.scss
@@ -36,4 +36,7 @@
       color: #888;
     }
   }
+  .links {
+    display: block; /* cancel display:grid for bookmark entries */
+  }
 }


### PR DESCRIPTION
This list only ever contains one link in bookmark. Let's make it not a grid to save vertical space and avoid useless restriction on the link's width.

See how the poor link in https://linuxfr.org/users/antistress/liens/usb-4-0-usb4-specification-published-phoronix seems so cramped for instance. Let us allow it to express itself at its full capacity!