### PR TITLE
redaction layout: force middle column to not grow bigger than 55% of the page

### DIFF
--- a/app/assets/stylesheets/parts/redaction.scss
+++ b/app/assets/stylesheets/parts/redaction.scss
@@ -211,8 +211,9 @@ body#redaction-index {
     margin-left: 15px;
     padding-left: 3px;
     padding-right: 3px;
-    flex-basis: 1vw;
+    flex-basis: 40%;
     flex-grow: 1;
+    max-width: 55%;
     p {
       margin: 0 0 5px;
       padding: 5px;

--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -171,6 +171,7 @@
     }
     #edition {
       flex-basis: 100%;
+      max-width: 100%;
       margin: auto;
       margin-top: 10px;
       order: 0;


### PR DESCRIPTION
Il manquait encore ces modifications pour régler comme il faut le layout de l'espace de rédaction.

Cette correction permet au layout de ne plus dépendre ni du contenu (qui pouvait forcer une taille très grande à la partie centrale), ni du zoom du navigateur.