### PR TITLE
moderation-box: on mobile, first message in tribune is miss-aligned due to the float display of input

### DIFF
--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -55,6 +55,7 @@
     }
     #moderation_box {
       .inbox {
+        clear: both;
         p {
           display: block;
         }


### PR DESCRIPTION
So apply `clear: both` on inbox to align back first medoration tribune chat on mobile screen.