### PR TITLE
#1926 - news: "Aller plus loin" message no longer displayed if no links

### DIFF
--- a/app/views/news/_news.html.haml
+++ b/app/views/news/_news.html.haml
@@ -8,6 +8,7 @@
     = news.body
     - if defined?(with_second_part) && with_second_part
       = news.second_part
-      %h2 Aller plus loin
-      %ul.links
-        = render news.links.select([:id, :lang, :title, :url])
+      - if news.links && news.links.any?
+        %h2 Aller plus loin
+        %ul.links
+          = render news.links.select([:id, :lang, :title, :url])


### PR DESCRIPTION
Cf. https://linuxfr.org/suivi/ne-pas-afficher-le-aller-plus-loin-s-il-n-y-a-pas-de-liens-dans-une-depeche

Attention, 1er développement de ma part sur un projet Ruby on Rails

Je n'ai pas réussi à lancer de tests automatisés sur le projet (RAILS_ENV=test bin/rails test -> 0 runs), je n'en ai donc pas écrit pour cette modification.
Tests réalisés en local : affichage de dépêches avec et sans lien, que la création de ces dépêches ait eu lieu avant ou après la modification (mais en mode dégradé : board non actif, langue forcée à la création des liens)

Le test sur news.links est peut-être superflu, mais je n'étais pas sûr que cette collection soit valorisée pour toutes les dépêches existantes.