### PR TITLE
Orthotypographic fixes and rewording

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -36,23 +36,23 @@ langs =
   fr: "Français"
   en: "Anglais"
   de: "Allemand"
-  it: "Italien"
+  eu: "Basque"
+  ct: "Catalan"
+  cn: "Chinois"
+  ko: "Coréen"
+  da: "Danois"
   es: "Espagnol"
   fi: "Finnois"
-  eu: "Basque"
-  ja: "Japonais"
-  ru: "Russe"
-  pt: "Portugais"
-  nl: "Néerlandais"
-  da: "Danois"
   el: "Grec"
-  sv: "Suédois"
-  cn: "Chinois"
-  pl: "Polonais"
-  xx: "!? hmmm ?!"
-  ct: "Catalan"
+  it: "Italien"
+  ja: "Japonais"
+  nl: "Néerlandais"
   no: "Norvégien"
-  ko: "Coréen"
+  pl: "Polonais"
+  pt: "Portugais"
+  ru: "Russe"
+  sv: "Suédois"
+  xx: "!? hmmm ?!"
 
 $("#form_links").nested_fields "news", "link", "lien", "fieldset", title: "text", url: "url", lang: langs
 $("#form_answers").nested_fields "poll", "answer", "choix", "p", answer: "text"
@@ -63,7 +63,7 @@ $("article.news .edited_by").each ->
   nb = field.find("a").length
   if nb > 3
     was = field.html()
-    field.html "<a>#{nb} contributeurs</a>"
+    field.html "<a>#{nb} contributeurs</a>"
     field.one "click", -> field.html was
 
 # Toolbar preferences
@@ -105,7 +105,7 @@ $("input#tags").autocompleter()
 $(".tag_in_place").on("in_place:form", ->
   $("input.autocomplete").autocompleter().focus()
 ).on("in_place:success", ->
-  $.noticeAdd text: "Tags ajoutés"
+  $.noticeAdd text: "Étiquettes ajoutées"
 ).editionInPlace()
 $(".add_tag, .remove_tag").click( ->
   $(@).blur().parents("form").data hidden: "true"
@@ -122,10 +122,10 @@ $(document).bind("keypress", "g", ->
 ).bind "keypress", "shift+?", ->
   $.noticeAdd
     text: """
-      Raccourcis clavier : <ul>
-      <li>? pour l'aide</li>
-      <li>&lt; pour le commentaire/contenu non-lu précédent</li>
-      <li>&gt; pour le commentaire/contenu non-lu suivant</li>
+      Raccourcis clavier : <ul>
+      <li>? pour l’aide</li>
+      <li>&lt; pour le commentaire/contenu non lu précédent</li>
+      <li>&gt; pour le commentaire/contenu non lu suivant</li>
       <li>[ pour le contenu avec commentaire précédent</li>
       <li>] pour le contenu avec commentaire suivant</li>
       <li>g pour aller au début de la page</li>

--- a/app/assets/javascripts/redaction.coffee
+++ b/app/assets/javascripts/redaction.coffee
@@ -20,7 +20,7 @@ class Redaction
     $.noticeAdd text: "La dépêche a été refusée par #{msg.username}", stay: true
 
   onRewrite: (msg) ->
-    $.noticeAdd text: "La dépêche a été renvoyée dans l'espace de rédaction par #{msg.username}", stay: true
+    $.noticeAdd text: "La dépêche a été renvoyée dans l’espace de rédaction par #{msg.username}", stay: true
 
   onVote: (msg) ->
     $.noticeAdd text: "#{msg.username} a voté #{msg.word}"
@@ -36,7 +36,7 @@ class Redaction
     slug  = parts[parts.length - 1]
     """
     <li><a href="/redaction/news/#{slug}/revisions/#{msg.version}">
-      #{msg.username}&nbsp;: #{msg.message} - #{msg.creationdate}
+      #{msg.username} : #{msg.message} - #{msg.creationdate}
     </a></li>
     """
 

--- a/app/assets/stylesheets/common/generics.scss
+++ b/app/assets/stylesheets/common/generics.scss
@@ -36,7 +36,7 @@
   }
 }
 
-#edition img[alt="Titre de l'image"],
+#edition img[alt="Titre de l’image"],
 #edition img[alt=""] {
   border: 3px dotted red;
 }

--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -4,12 +4,12 @@ class Admin::AdminsController < AdminController
 
   def create
     @account.give_admin_rights!
-    redirect_to @account.user, notice: "Nouveau rôle : admin"
+    redirect_to @account.user, notice: "Nouveau rôle : admin"
   end
 
   def destroy
     @account.remove_all_rights!
-    redirect_to @account.user, notice: "Rôle retiré : admin"
+    redirect_to @account.user, notice: "Rôle retiré : admin"
   end
 
 protected

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -15,7 +15,7 @@ class Admin::CategoriesController < AdminController
     if @category.save
       redirect_to admin_categories_url, notice: 'Nouvelle catégorie créée.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette catégorie"
+      flash.now[:alert] = "Impossible d’enregistrer cette catégorie"
       render :new
     end
   end
@@ -28,7 +28,7 @@ class Admin::CategoriesController < AdminController
     if @category.save
       redirect_to admin_categories_url, notice: 'Catégorie mise à jour.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette catégorie"
+      flash.now[:alert] = "Impossible d’enregistrer cette catégorie"
       render :edit
     end
   end

--- a/app/controllers/admin/editors_controller.rb
+++ b/app/controllers/admin/editors_controller.rb
@@ -4,12 +4,12 @@ class Admin::EditorsController < AdminController
 
   def create
     @account.give_editor_rights!
-    redirect_to @account.user, notice: "Nouveau rôle : animateur"
+    redirect_to @account.user, notice: "Nouveau rôle : animateur"
   end
 
   def destroy
     @account.remove_all_rights!
-    redirect_to @account.user, notice: "Rôle retiré : animateur"
+    redirect_to @account.user, notice: "Rôle retiré : animateur"
   end
 
 protected

--- a/app/controllers/admin/forums_controller.rb
+++ b/app/controllers/admin/forums_controller.rb
@@ -17,7 +17,7 @@ class Admin::ForumsController < AdminController
       @forum.move_to_bottom
       redirect_to admin_forums_url, notice: "Forum créé"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce forum"
+      flash.now[:alert] = "Impossible d’enregistrer ce forum"
       render :new
     end
   end
@@ -30,7 +30,7 @@ class Admin::ForumsController < AdminController
     if @forum.save
       redirect_to admin_forums_url, notice: "Forum modifié"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce forum"
+      flash.now[:alert] = "Impossible d’enregistrer ce forum"
       render :edit
     end
   end
@@ -42,7 +42,7 @@ class Admin::ForumsController < AdminController
 
   def reopen
     @forum.reopen
-    redirect_to admin_forums_url, notice: "Forum ré-ouvert"
+    redirect_to admin_forums_url, notice: "Forum réouvert"
   end
 
   def destroy

--- a/app/controllers/admin/friend_sites_controller.rb
+++ b/app/controllers/admin/friend_sites_controller.rb
@@ -17,7 +17,7 @@ class Admin::FriendSitesController < AdminController
       @friend_site.move_to_bottom
       redirect_to admin_friend_sites_url, notice: "Site ami créé"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce site"
+      flash.now[:alert] = "Impossible d’enregistrer ce site"
       render :new
     end
   end
@@ -30,7 +30,7 @@ class Admin::FriendSitesController < AdminController
     if @friend_site.save
       redirect_to admin_friend_sites_url, notice: "Site ami modifié"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce site"
+      flash.now[:alert] = "Impossible d’enregistrer ce site"
       render :edit
     end
   end

--- a/app/controllers/admin/moderators_controller.rb
+++ b/app/controllers/admin/moderators_controller.rb
@@ -4,12 +4,12 @@ class Admin::ModeratorsController < AdminController
 
   def create
     @account.give_moderator_rights!
-    redirect_to @account.user, notice: "Nouveau rôle : modérateur"
+    redirect_to @account.user, notice: "Nouveau rôle : modérateur"
   end
 
   def destroy
     @account.remove_all_rights!
-    redirect_to @account.user, notice: "Rôle retiré : modérateur"
+    redirect_to @account.user, notice: "Rôle retiré : modérateur"
   end
 
 protected

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -15,7 +15,7 @@ class Admin::PagesController < AdminController
     if @page.save
       redirect_to admin_pages_url, notice: 'Nouvelle page créée.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette page"
+      flash.now[:alert] = "Impossible d’enregistrer cette page"
       render :new
     end
   end
@@ -28,7 +28,7 @@ class Admin::PagesController < AdminController
     if @page.save
       redirect_to admin_pages_url, notice: 'Page mise à jour.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette page"
+      flash.now[:alert] = "Impossible d’enregistrer cette page"
       render :edit
     end
   end

--- a/app/controllers/admin/responses_controller.rb
+++ b/app/controllers/admin/responses_controller.rb
@@ -15,7 +15,7 @@ class Admin::ResponsesController < AdminController
     if @response.save
       redirect_to admin_responses_url, notice: 'Nouvelle réponse créée.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette réponse"
+      flash.now[:alert] = "Impossible d’enregistrer cette réponse"
       render :new
     end
   end
@@ -28,7 +28,7 @@ class Admin::ResponsesController < AdminController
     if @response.save
       redirect_to admin_responses_url, notice: 'Réponse mise à jour.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette réponse"
+      flash.now[:alert] = "Impossible d’enregistrer cette réponse"
       render :edit
     end
   end

--- a/app/controllers/admin/sections_controller.rb
+++ b/app/controllers/admin/sections_controller.rb
@@ -15,7 +15,7 @@ class Admin::SectionsController < AdminController
     if @section.save
       redirect_to admin_sections_url, notice: 'Nouvelle section créée.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette section"
+      flash.now[:alert] = "Impossible d’enregistrer cette section"
       render :new
     end
   end
@@ -28,7 +28,7 @@ class Admin::SectionsController < AdminController
     if @section.save
       redirect_to admin_sections_url, notice: 'Section mise à jour.'
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette section"
+      flash.now[:alert] = "Impossible d’enregistrer cette section"
       render :edit
     end
   end

--- a/app/controllers/api/authorized_applications_controller.rb
+++ b/app/controllers/api/authorized_applications_controller.rb
@@ -3,6 +3,6 @@ class Api::AuthorizedApplicationsController < ApplicationController
 
   def destroy
     Doorkeeper::AccessToken.revoke_all_for params[:id], current_account
-    redirect_to edit_account_registration_path, notice: "L'autorisation a bien été révoquée"
+    redirect_to edit_account_registration_path, notice: "L’autorisation a bien été révoquée"
   end
 end

--- a/app/controllers/api/v1/diary_controller.rb
+++ b/app/controllers/api/v1/diary_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::DiaryController < Api::V1::ApiController
       diary.save
       render json: diary
     else
-      render json: { error: "You don't have enough karma to post a diary" }
+      render json: { error: "You don’t have enough karma to post a diary" }
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ protected
     @title         = %w(LinuxFr.org)
     @author        = nil
     @keywords      = %w(Linux Logiciel Libre GNU Free Software Actualité Forum Communauté)
-    @description   = "L'actualité du Logiciel Libre et de Linux, sur un site francophone contributif géré par une équipe bénévole par et pour des libristes enthousiastes"
+    @description   = "L’actualité du logiciel libre et des sujets voisins (DIY, Open Hardware, Open Data, les Communs, etc.), sur un site francophone contributif géré par une équipe bénévole par et pour des libristes enthousiastes"
     @feeds         = {}
     @last_comments = Comment.footer
     @popular_tags  = Tag.footer

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -37,7 +37,7 @@ class BookmarksController < ApplicationController
       @bookmark.node = Node.new(user_id: current_user.id, cc_licensed: false)
       @bookmark.node.preview_tags = params[:tags]
       @bookmark.valid?
-      flash.now[:alert] = "Votre lien semble invalide. Êtes-vous sûr ?" unless @bookmark.link =~ /\A#{URI::regexp(['http', 'https'])}\z/
+      flash.now[:alert] = "Votre lien semble invalide. Le confimez‑vous ?" unless @bookmark.link =~ /\A#{URI::regexp(['http', 'https'])}\z/
       render :new
     end
   end
@@ -49,7 +49,7 @@ class BookmarksController < ApplicationController
     path = user_bookmark_path(@user, @bookmark, format: params[:format])
     redirect_to path, status: 301 if request.path != path
     headers['Link'] = %(<#{user_bookmark_url @user, @bookmark}>; rel="canonical")
-    flash.now[:alert] = "Attention, ce lien a été supprimé et n'est visible que par les admins" unless @bookmark.visible?
+    flash.now[:alert] = "Attention, ce lien a été supprimé et n’est visible que par les administrateurs" unless @bookmark.visible?
   end
 
   def edit
@@ -62,7 +62,7 @@ class BookmarksController < ApplicationController
     if !preview_mode && @bookmark.save
       redirect_to [@user, @bookmark], notice: "Le lien a bien été modifié"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce lien" if @bookmark.invalid?
+      flash.now[:alert] = "Impossible d’enregistrer ce lien" if @bookmark.invalid?
       render :edit
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,9 +21,9 @@ class CommentsController < ApplicationController
     enforce_create_permission(@comment)
   rescue Canable::Transgression
     if current_account.blocked?
-      flash[:alert] = "L'équipe de modération a temporairement bloqué vos commentaires sur le site"
+      flash[:alert] = "L’équipe de modération a temporairement bloqué vos commentaires sur le site"
     else
-      flash[:alert] = "Impossible de commenter un contenu vieux de plus de 3 mois"
+      flash[:alert] = "Impossible de commenter un contenu datant de plus de trois mois"
     end
     redirect_to_content @node.content
   end
@@ -61,7 +61,7 @@ class CommentsController < ApplicationController
       flash[:notice] = "Votre commentaire a bien été modifié"
       redirect_to url_for_content(@node.content) + "#comment-#{@comment.id}"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce commentaire" if @comment.invalid?
+      flash.now[:alert] = "Impossible d’enregistrer ce commentaire" if @comment.invalid?
       render :edit
     end
   end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -35,7 +35,7 @@ class DiariesController < ApplicationController
       @diary.node = Node.new(user_id: current_user.id, cc_licensed: @diary.cc_licensed)
       @diary.node.preview_tags = params[:tags]
       @diary.valid?
-      flash.now[:alert] = "Votre journal ne contient pas de liens. Êtes-vous sûr ?" unless @diary.body =~ /<a /
+      flash.now[:alert] = "Votre journal ne contient pas de liens. Confirmez‑vous que cela est normal ?" unless @diary.body =~ /<a /
       render :new
     end
   end
@@ -47,7 +47,7 @@ class DiariesController < ApplicationController
     path = user_diary_path(@user, @diary, format: params[:format])
     redirect_to path, status: 301 if request.path != path
     headers['Link'] = %(<#{user_diary_url @user, @diary}>; rel="canonical")
-    flash.now[:alert] = "Attention, ce journal a été supprimé et n'est visible que par les admins" unless @diary.visible?
+    flash.now[:alert] = "Attention, ce journal a été supprimé et n’est visible que par les administrateurs" unless @diary.visible?
   end
 
   def edit
@@ -79,7 +79,7 @@ class DiariesController < ApplicationController
       space = :redaction if @news.draft?
       redirect_to [space, @news]
     else
-      redirect_to "/", notice: "Merci d'avoir proposé ce journal en dépêche"
+      redirect_to "/", notice: "Merci d’avoir proposé ce journal en dépêche"
     end
   rescue
     flash.now[:alert] = "Impossible de proposer ce journal en dépêche"
@@ -91,7 +91,7 @@ class DiariesController < ApplicationController
     @diary.move_to_forum params.require(:post).permit(:forum_id)
     redirect_to diaries_url, notice: "Le journal a bien été déplacé vers les forums"
   rescue
-    flash.now[:alert] = "Impossible de déplacer ce journal. Avez-vous bien choisi un forum ?"
+    flash.now[:alert] = "Impossible de déplacer ce journal. Avez‑vous bien choisi un forum ?"
     render :edit
   end
 

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -16,7 +16,7 @@ class ForumsController < ApplicationController
   def show
     @forum = Forum.find(params[:id])
     @posts = @forum.posts.with_node_ordered_by(@order).page(params[:page])
-    flash.now[:alert] = "Attention, ce forum a été archivé et n'accueille plus de nouvelles discussions." unless @forum.active?
+    flash.now[:alert] = "Attention, ce forum a été archivé et n’accueille plus de nouvelles discussions." unless @forum.active?
     respond_to do |wants|
       wants.html
       wants.atom

--- a/app/controllers/moderation/block_controller.rb
+++ b/app/controllers/moderation/block_controller.rb
@@ -6,6 +6,6 @@ class Moderation::BlockController < ModerationController
     nb_days  = (params[:nb_days] || 2).to_i
     @account = Account.find(params[:account_id])
     @account.block(nb_days, current_user.id)
-    render json: { notice: "Les commentaires de #{@account.login} sont bloqués pour #{pluralize nb_days, "jour"}" }
+    render json: { notice: "Les commentaires de #{@account.login} sont bloqués pendant #{pluralize nb_days, "jour"}" }
   end
 end

--- a/app/controllers/moderation/news_controller.rb
+++ b/app/controllers/moderation/news_controller.rb
@@ -19,8 +19,8 @@ class Moderation::NewsController < ModerationController
     redirect_to path, status: 301 and return if request.path != path
     @boards = Board.all(Board.news, @news.id)
     headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
-    flash.now[:alert] = "Attention, cette dépêche a été supprimée et n'est visible que par les modérateurs" if @news.deleted?
-    flash.now[:alert] = "Attention, cette dépêche a été refusée et n'est visible que par les modérateurs" if @news.refused?
+    flash.now[:alert] = "Attention, cette dépêche a été supprimée et n’est visible que par les modérateurs" if @news.deleted?
+    flash.now[:alert] = "Attention, cette dépêche a été refusée et n’est visible que par les modérateurs" if @news.refused?
     respond_to do |wants|
       wants.html { render :show, layout: 'chat_n_edit' }
       wants.js { render partial: 'short' }
@@ -48,7 +48,7 @@ class Moderation::NewsController < ModerationController
   def accept
     enforce_accept_permission(@news)
     if @news.has_default_paragraph?
-      redirect_to [:moderation, @news], alert: "Impossible de publier une dépêche avec le texte par défaut d'un paragraphe"
+      redirect_to [:moderation, @news], alert: "Impossible de publier une dépêche avec le texte par défaut d’un paragraphe"
     elsif @news.unlocked?
       @news.moderator_id = current_user.id
       @news.accept!
@@ -56,7 +56,7 @@ class Moderation::NewsController < ModerationController
       NewsNotifications.accept(@news).deliver_now
       redirect_to @news, alert: "Dépêche acceptée"
     else
-      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu'un est en train de la modifier"
+      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu’un est en train de la modifier"
     end
   end
 
@@ -73,7 +73,7 @@ class Moderation::NewsController < ModerationController
     elsif @news.unlocked?
       @boards = Board.all(Board.news, @news.id)
     else
-      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu'un est train de la modifier"
+      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu’un est train de la modifier"
     end
   end
 
@@ -85,7 +85,7 @@ class Moderation::NewsController < ModerationController
       NewsNotifications.rewrite(@news).deliver_now
       redirect_to @news, alert: "Dépêche renvoyée en rédaction"
     else
-      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu'un est en train de la modifier"
+      redirect_to [:moderation, @news], alert: "Impossible de modérer la dépêche tant que quelqu’un est en train de la modifier"
     end
   end
 

--- a/app/controllers/moderation/plonk_controller.rb
+++ b/app/controllers/moderation/plonk_controller.rb
@@ -6,6 +6,6 @@ class Moderation::PlonkController < ModerationController
     nb_days  = (params[:nb_days] || 2).to_i
     @account = Account.find(params[:account_id])
     @account.plonk(nb_days, current_user.id)
-    render json: { notice: "#{@account.login} a été plonké pour #{pluralize nb_days, "jour"}" }
+    render json: { notice: "#{@account.login} a été plonké pendant #{pluralize nb_days, "jour"}" }
   end
 end

--- a/app/controllers/moderation/polls_controller.rb
+++ b/app/controllers/moderation/polls_controller.rb
@@ -9,8 +9,8 @@ class Moderation::PollsController < ModerationController
 
   def show
     enforce_view_permission(@poll)
-    flash.now[:alert] = "Attention, ce sondage a été supprimé et n'est visible que par les modérateurs" if @poll.deleted?
-    flash.now[:alert] = "Attention, ce sondage a été refusé et n'est visible que par les modérateurs" if @poll.refused?
+    flash.now[:alert] = "Attention, ce sondage a été supprimé et n’est visible que par les modérateurs" if @poll.deleted?
+    flash.now[:alert] = "Attention, ce sondage a été refusé et n’est visible que par les modérateurs" if @poll.refused?
   end
 
   def accept
@@ -35,7 +35,7 @@ class Moderation::PollsController < ModerationController
     if @poll.save
       redirect_to [:moderation, @poll], notice: "Modification enregistrée"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce sondage"
+      flash.now[:alert] = "Impossible d’enregistrer ce sondage"
       render :edit
     end
   end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -28,7 +28,7 @@ class NewsController < ApplicationController
   end
 
   def new
-    redirect_to root_url, alert: "Désolé, il n'est pas possible de proposer une dépêche en l'absence de sections" unless Section.exists?
+    redirect_to root_url, alert: "Désolé, il n’est pas possible de proposer une dépêche en l’absence de sections" unless Section.exists?
     @news = News.new
     @news.cc_licensed = true
   end
@@ -43,7 +43,7 @@ class NewsController < ApplicationController
       @news.urgent! if params[:news][:urgent] == "1"
       @news.submitted_at = DateTime.now
       @news.submit!
-      redirect_to news_index_url, notice: "Votre proposition de dépêche a bien été soumise, et sera modérée dans les heures ou jours à venir"
+      redirect_to news_index_url, notice: "Votre proposition de dépêche a bien été soumise, et sera modérée dans les heures ou les jours à venir"
     else
       @news.node = Node.new(cc_licensed: @news.cc_licensed)
       @news.node.preview_tags = params[:tags]

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -35,7 +35,7 @@ class PollsController < ApplicationController
     @poll.attributes = poll_params
     @poll.tmp_owner_id = current_account.user_id
     if !preview_mode && @poll.save
-      redirect_to polls_url, notice: "L'équipe de modération de LinuxFr.org vous remercie pour votre proposition de sondage"
+      redirect_to polls_url, notice: "L’équipe de modération de LinuxFr.org vous remercie pour votre proposition de sondage"
     else
       @poll.node = Node.new
       @poll.valid?
@@ -48,7 +48,7 @@ class PollsController < ApplicationController
     @answer = @poll.answers.where(position: params[:position]).first
     if @answer
       @answer.vote(request.remote_ip)
-      redirect_to @poll, notice: "Merci d'avoir voté pour ce sondage"
+      redirect_to @poll, notice: "Merci d’avoir voté pour ce sondage"
     else
       redirect_to @poll, alert: "Veuillez choisir une proposition avant de voter"
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
     path = forum_post_path(@forum, @post, format: params[:format])
     redirect_to path, status: 301 and return if request.path != path
     headers['Link'] = %(<#{forum_post_url @forum, @post}>; rel="canonical")
-    flash.now[:alert] = "Attention, ce message a été supprimé et n'est visible que par les admins" unless @post.visible?
+    flash.now[:alert] = "Attention, ce message a été supprimé et n’est visible que par les administrateurs" unless @post.visible?
   end
 
   def edit
@@ -55,7 +55,7 @@ class PostsController < ApplicationController
     if !preview_mode && @post.save
       redirect_to forum_posts_url, notice: "Votre message a bien été modifié"
     else
-      flash.now[:alert] = "Impossible d'enregistrer ce message" if @post.invalid?
+      flash.now[:alert] = "Impossible d’enregistrer ce message" if @post.invalid?
       render :edit
     end
   end

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -13,7 +13,7 @@ class ReadingsController < ApplicationController
   def destroy
     @node.unread_by(current_account.id)
     respond_to do |wants|
-     wants.json { render json: { notice: "Ce contenu n'est plus marqué comme lu" } }
+     wants.json { render json: { notice: "Ce contenu n’est plus marqué comme lu" } }
      wants.html { redirect_to_content @node.content }
     end
   end

--- a/app/controllers/redaction/links_controller.rb
+++ b/app/controllers/redaction/links_controller.rb
@@ -20,7 +20,7 @@ class Redaction::LinksController < RedactionController
     if @link.lock_by(current_user)
       render partial: 'form'
     else
-      render status: :forbidden, text: "Désolé, #{@link.locker} est déjà en train de modifier ce lien !"
+      render status: :forbidden, text: "Désolé, #{@link.locker} est déjà en train de modifier ce lien !"
     end
   end
 

--- a/app/controllers/redaction/news_controller.rb
+++ b/app/controllers/redaction/news_controller.rb
@@ -51,7 +51,7 @@ class Redaction::NewsController < RedactionController
     enforce_reassign_permission(@news)
     @news.reassign_to params[:user_id], current_user.name
     namespace = @news.draft? ? :redaction : :moderation
-    redirect_to [namespace, @news], notice: "L'auteur initial de la dépêche a été changé"
+    redirect_to [namespace, @news], notice: "L’auteur initial de la dépêche a été changé"
   end
 
   def reorganize
@@ -59,7 +59,7 @@ class Redaction::NewsController < RedactionController
       @news.put_paragraphs_together
       render :reorganize, layout: "chat_n_edit"
     else
-      render status: :forbidden, text: "Désolé, un verrou a déjà été posé sur cette dépêche !"
+      render status: :forbidden, text: "Désolé, un verrou a déjà été posé sur cette dépêche !"
     end
   end
 
@@ -80,7 +80,7 @@ class Redaction::NewsController < RedactionController
       @news.submit_and_notify(current_user)
       redirect_to '/redaction', notice: "Dépêche soumise à la modération"
     else
-      redirect_to [:redaction, @news], alert: "Impossible de soumettre la dépêche car quelqu'un est encore en train de la modifier"
+      redirect_to [:redaction, @news], alert: "Impossible de soumettre la dépêche car quelqu’un est encore en train de la modifier"
     end
   end
 

--- a/app/controllers/redaction/paragraphs_controller.rb
+++ b/app/controllers/redaction/paragraphs_controller.rb
@@ -25,7 +25,7 @@ class Redaction::ParagraphsController < RedactionController
     if @paragraph.lock_by(current_user)
       render partial: 'form'
     else
-      render status: :forbidden, text: "Désolé, #{@paragraph.locker} est déjà en train de modifier ce paragraphe !"
+      render status: :forbidden, text: "Désolé, #{@paragraph.locker} est déjà en train de modifier ce paragraphe !"
     end
   end
 

--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -9,7 +9,7 @@ class StylesheetsController < ApplicationController
       Rails.logger.info @account.uploaded_stylesheet
       msg = { notice: "Feuille de style enregistrée" }
     else
-      msg = { alert: "Erreur lors de l'enregistrement de la feuille de style" }
+      msg = { alert: "Erreur lors de l’enregistrement de la feuille de style" }
     end
     redirect_to edit_stylesheet_url, msg
   end
@@ -30,7 +30,7 @@ class StylesheetsController < ApplicationController
         @account.remove_uploaded_stylesheet!
         msg = { notice: "Feuille de style enregistrée" }
       else
-        msg = { alert: "Cette feuille de style n'est pas valide" }
+        msg = { alert: "Cette feuille de style n’est pas valide" }
       end
     end
     redirect_to edit_stylesheet_url, msg

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -25,7 +25,7 @@ class TagsController < ApplicationController
   def update
     @node.taggings.create(tag_id: @tag.id, user_id: current_account.user_id)
     respond_to do |wants|
-     wants.json { render json: { notice: "Tag ajouté" } }
+     wants.json { render json: { notice: "Étiquette ajoutée" } }
      wants.html { redirect_to_content @node.content }
     end
   end
@@ -34,7 +34,7 @@ class TagsController < ApplicationController
     @tag = Tag.where(name: params[:id]).first
     @node.taggings.where(tag_id: @tag.id, user_id: current_account.user_id).delete_all if @tag
     respond_to do |wants|
-     wants.json { render json: { notice: "Tag enlevé" } }
+     wants.json { render json: { notice: "Étiquette enlevée" } }
      wants.html { redirect_to_content @node.content }
     end
   end
@@ -78,7 +78,7 @@ class TagsController < ApplicationController
   def hide
     enforce_update_permission(@tag)
     @tag.toggle!("public")
-    redirect_back fallback_location: root_url, notice: "La visibilité du tag a bien été modifiée"
+    redirect_back fallback_location: root_url, notice: "La visibilité de l’étiquette a bien été modifiée"
   rescue
     redirect_to root_url
   end

--- a/app/controllers/trackers_controller.rb
+++ b/app/controllers/trackers_controller.rb
@@ -73,7 +73,7 @@ class TrackersController < ApplicationController
     if !preview_mode && @tracker.save
       redirect_to @tracker, notice: "Entrée du suivi modifiée"
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette entrée de suivi" unless @tracker.valid?
+      flash.now[:alert] = "Impossible d’enregistrer cette entrée de suivi" unless @tracker.valid?
       render :edit
     end
   end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -21,7 +21,7 @@ class WikiPagesController < ApplicationController
     path = wiki_page_path(@wiki_page, format: params[:format])
     redirect_to path, status: 301 and return if request.path != path
     headers['Link'] = %(<#{wiki_page_url @wiki_page}>; rel="canonical")
-    flash.now[:alert] = "Attention, cette page a été supprimée et n'est visible que par les admins" unless @wiki_page.visible?
+    flash.now[:alert] = "Attention, cette page a été supprimée et n’est visible que par les administrateurs" unless @wiki_page.visible?
     respond_with @wiki_page
   rescue ActiveRecord::RecordNotFound
     if current_account
@@ -67,7 +67,7 @@ class WikiPagesController < ApplicationController
     if !preview_mode && @wiki_page.save
       redirect_to @wiki_page, notice: "Modification enregistrée"
     else
-      flash.now[:alert] = "Impossible d'enregistrer cette page de wiki" if @wiki_page.invalid?
+      flash.now[:alert] = "Impossible d’enregistrer cette page de wiki" if @wiki_page.invalid?
       render :edit
     end
   end

--- a/app/helpers/atom_helper.rb
+++ b/app/helpers/atom_helper.rb
@@ -4,8 +4,8 @@ module AtomHelper
   def atom_comments_link(content, url)
     str = <<-EOS
     <p>
-      <strong>Commentaires :</strong>
-      <a href=\"//#{MY_DOMAIN}/nodes/#{content.node.id}/comments.atom\">voir le flux atom</a>
+      <strong>Commentaires :</strong>
+      <a href=\"//#{MY_DOMAIN}/nodes/#{content.node.id}/comments.atom\">voir le flux Atom</a>
       <a href=\"#{url}#comments\">ouvrir dans le navigateur</a>
     </p>
     EOS

--- a/app/helpers/node_helper.rb
+++ b/app/helpers/node_helper.rb
@@ -35,7 +35,7 @@ module NodeHelper
     cp.meta ||= posted_by(record)
     cp.tags ||= tags_for(record.node)
     cp.body ||= (ContentPresenter.collection? ?
-                 record.truncated_body.sub("[...](suite)", " " + link_to("(...)", path_for_content(record))).html_safe :
+                 record.truncated_body.sub("[...](suite)", " " + link_to("(…)", path_for_content(record))).html_safe :
                  record.body)
     render 'nodes/content', cp.to_hash
   end
@@ -106,7 +106,7 @@ module NodeHelper
     date_time    = content.is_a?(Comment) ? content.created_at : content.node.try(:created_at)
     date_time  ||= Time.now
     date         = content_tag(:span, "le #{date_time.to_s(:date)}", class: "date")
-    time         = content_tag(:span,  "à #{date_time.to_s(:time)}", class: "time")
+    time         = content_tag(:span, "à #{date_time.to_s(:time)}", class: "time")
     published_at = content_tag(:time, date + " " + time, datetime: date_time.iso8601, class: "updated")
     caption      = content_tag(:span, "", class: "floating_spacer") +
                    content_tag(:span, "Posté par #{ user_link } #{ published_at }.".html_safe, class: "posted_by_spanblock")
@@ -123,7 +123,7 @@ module NodeHelper
       status = node.read_status(current_account)
       visit  = case status
                when :not_read then ", non visité"
-               when Integer   then ", #{pluralize status, "nouveau", "nouveaux"} !"
+               when Integer   then ", #{pluralize status, "nouveau", "nouveaux"} !"
                else                ", déjà visité"
                end
       visit  = content_tag(:span, visit, class: "visit")

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -31,13 +31,13 @@ module UsersHelper
     return unless karma > 0
     attrs = {}
     attrs[:rel] = "nofollow" unless user.account.try(:karma).to_i > Account.default_karma
-    link_to("page perso", user.homesite, attrs)
+    link_to("site Web personnel", user.homesite, attrs)
   end
 
   def jabber_link(user)
     return unless current_account
     return if user.jabber_id.blank?
-    link_to("jabber id", "xmpp:" + user.jabber_id)
+    link_to("adresse XMPP", "xmpp:" + user.jabber_id)
   end
 
 end

--- a/app/mailers/news_notifications.rb
+++ b/app/mailers/news_notifications.rb
@@ -3,8 +3,8 @@
 # This mailer is used to notify news writers when their news are accepted or refused.
 #
 class NewsNotifications < ActionMailer::Base
-  MODERATORS = "Equipe de modération LinuxFr.org <moderateurs@linuxfr.org>"
-  EDITORS    = "Equipe de rédaction LinuxFr.org <redacteurs@linuxfr.org>"
+  MODERATORS = "Équipe de modération de LinuxFr.org <moderateurs@linuxfr.org>"
+  EDITORS    = "Équipe de rédaction de LinuxFr.org <redacteurs@linuxfr.org>"
 
   def accept(news)
     send_moderation_email "Dépêche acceptée :", news
@@ -30,7 +30,7 @@ class NewsNotifications < ActionMailer::Base
 
   def refuse_template(news, message, template)
     @news    = news
-    @message = message.present? ? "Le modérateur a tenu à ajouter : #{message}\n\n" : ""
+    @message = message.present? ? "Le modérateur a tenu à ajouter : #{message}\n\n" : ""
     @response= Response.find(template)
     send_moderation_email "Dépêche refusée :", news
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -67,19 +67,19 @@ class Account < ActiveRecord::Base
   LOGIN_REGEXP = /\A[\p{Word}.+\-]+\z/
   validates :login, presence: { message: "Veuillez choisir un pseudo"},
                     uniqueness: { message: "Ce pseudo est déjà pris" },
-                    format: { message: "Le pseudo n'est pas valide", with: LOGIN_REGEXP, allow_blank: true, on: :create },
-                    length: { maximum: 40, message: "Le login est trop long" }
+                    format: { message: "Le pseudo n’est pas valide", with: LOGIN_REGEXP, allow_blank: true, on: :create },
+                    length: { maximum: 40, message: "Le nom d’utilisateur est trop long" }
 
   EMAIL_REGEXP = /\A[\p{Word}.%+\-]+@[\p{Word}.\-]+\.[\w]{2,}\z/i
-  validates :email, presence: { message: "Veuillez remplir l'adresse de courriel" },
+  validates :email, presence: { message: "Veuillez remplir l’adresse de courriel" },
                     uniqueness: { message: "Cette adresse de courriel est déjà utilisée", case_sensitive: false, allow_blank: true },
-                    format: { message: "L'adresse de courriel n'est pas valide", with: EMAIL_REGEXP, allow_blank: true },
-                    length: { maximum: 128, message: "L'adresse de courriel est trop longue" }
+                    format: { message: "L’adresse de courriel n’est pas valide", with: EMAIL_REGEXP, allow_blank: true },
+                    length: { maximum: 128, message: "L’adresse de courriel est trop longue" }
 
   validates :password, presence: { message: "Le mot de passe est absent", on: :create },
                        confirmation: { message: "La confirmation du mot de passe ne correspond pas au mot de passe" }
 
-  validates :stylesheet, length: { maximum: 255, message: "L'URL de la feuille de style est trop longue" }
+  validates :stylesheet, length: { maximum: 255, message: "L’URL de la feuille de style est trop longue" }
 
 ### Authentication ###
 
@@ -155,7 +155,7 @@ class Account < ActiveRecord::Base
   def log_role
     roles = previous_changes["role"]
     return if roles.nil?
-    logs.create(description: "Changement de rôle : #{roles.join ' → '}", user_id: amr_id)
+    logs.create(description: "Changement de rôle : #{roles.join ' → '}", user_id: amr_id)
   end
 
   # An AMR is someone who is either an admin or a moderator
@@ -278,7 +278,7 @@ class Account < ActiveRecord::Base
   def block(nb_days, user_id)
     $redis.set("block/#{self.id}", 1)
     $redis.expire("block/#{self.id}", nb_days * 86400)
-    logs.create(description: "Interdiction de poster des commentaires pour #{pluralize nb_days, "jour"}", user_id: user_id)
+    logs.create(description: "Interdiction de poster des commentaires pendant #{pluralize nb_days, "jour"}", user_id: user_id)
   end
 
   def can_block?
@@ -294,7 +294,7 @@ class Account < ActiveRecord::Base
   def plonk(nb_days, user_id)
     $redis.set("plonk/#{self.id}", 1)
     $redis.expire("plonk/#{self.id}", nb_days * 86400)
-    logs.create(description: "Interdiction de tribune pour #{pluralize nb_days, "jour"}", user_id: user_id)
+    logs.create(description: "Interdiction de tribune pendant #{pluralize nb_days, "jour"}", user_id: user_id)
   end
 
   def can_plonk?

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -69,7 +69,7 @@ class Diary < Content
       @news.save!
       $redis.set "convert/#{@news.id}", self.id
       @news.node.update_column(:cc_licensed, true) if node.cc_licensed?
-      @news.links.create title: "Journal à l'origine de la dépêche", url: "https://#{MY_DOMAIN}/users/#{owner.to_param}/journaux/#{to_param}", lang: "fr"
+      @news.links.create title: "Journal à l’origine de la dépêche", url: "https://#{MY_DOMAIN}/users/#{owner.to_param}/journaux/#{to_param}", lang: "fr"
       @news.submit! unless node.cc_licensed?
       @news
     end

--- a/app/models/friend_site.rb
+++ b/app/models/friend_site.rb
@@ -16,6 +16,6 @@ class FriendSite < ActiveRecord::Base
 
   validates :title, presence: { message: "Le titre est obligatoire" },
                     length: { maximum: 255, message: "Le titre est trop long" }
-  validates :url,   presence: { message: "L'URL est obligatoire" },
-                    length: { maximum: 255, message: "L'URL est trop longue" }
+  validates :url,   presence: { message: "L’URL est obligatoire" },
+                    length: { maximum: 255, message: "L’URL est trop longue" }
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -27,7 +27,7 @@ class Link < ActiveRecord::Base
   validates :title, presence: { message: "Un lien doit obligatoirement avoir un titre" },
                     length: { maximum: 100, message: "Le titre est trop long" }
   validates :url, presence: { message: "Un lien doit obligatoirement avoir une URL" },
-                  length: { maximum: 255, message: "L'URL est trop longue" }
+                  length: { maximum: 255, message: "L’URL est trop longue" }
   validate  :authorized_protocol
 
   def url=(raw)
@@ -43,12 +43,12 @@ class Link < ActiveRecord::Base
 
   def authorized_protocol
     if url.blank?
-      errors.add(:url, "L'URL est obligatoire")
+      errors.add(:url, "L’URL est obligatoire")
     else
       uri = URI.parse(url)
       return true if PROTOCOLS.include?(uri.scheme)
       return true if uri.scheme.nil? && uri.host == MY_DOMAIN
-      errors.add(:url, "L'URL d'un lien n'est pas valide")
+      errors.add(:url, "L’URL d’un lien n’est pas valide")
     end
   end
 
@@ -90,7 +90,7 @@ class Link < ActiveRecord::Base
 ### Presentation ###
 
   def to_s
-    "[#{lang}] #{title} : #{url}"
+    "[#{lang}] #{title} : #{url}"
   end
 
 ### Push ###

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -24,10 +24,10 @@
 # that will be reviewed and moderated by the LinuxFr.org team.
 #
 class News < Content
-  DEFAULT_FIRST_PART = "Un court chapeau introduisant l'article, ou le " +
-    "synthétisant, aidera les visiteurs du site à savoir s'ils doivent procéder " +
+  DEFAULT_FIRST_PART = "Un court chapeau introduisant l’article, ou le " +
+    "synthétisant, aidera les visiteurs du site à savoir s’ils doivent procéder " +
     "à une lecture approfondie de votre article.".freeze
-  DEFAULT_PARAGRAPH = "Vous pouvez éditer ce paragraphe en cliquant sur le crayon !".freeze
+  DEFAULT_PARAGRAPH = "Vous pouvez éditer ce paragraphe en cliquant sur le crayon !".freeze
 
   self.table_name = "news"
   self.type = "Dépêche"
@@ -52,12 +52,12 @@ class News < Content
 
   validates :title,        presence: { message: "Le titre est obligatoire" },
                            length: { maximum: 100, message: "Le titre est trop long" }
-  validates :body,         presence: { message: "Nous n'acceptons pas les dépêches vides" }
+  validates :body,         presence: { message: "Nous n’acceptons pas les dépêches vides" }
   validates :section,      presence: { message: "Veuillez choisir une section pour cette dépêche" }
   validates :author_name,  presence: { message: "Veuillez entrer votre nom" },
-                           length: { maximum: 32, message: "Le nom de l'auteur est trop long" }
+                           length: { maximum: 32, message: "Le nom de l’auteur est trop long" }
   validates :author_email, presence: { message: "Veuillez entrer votre adresse de courriel" },
-                           length: { maximum: 64, message: "L'adresse email de l'auteur est trop longue" }
+                           length: { maximum: 64, message: "L’adresse de courriel de l’auteur est trop longue" }
 
 ### SEO ###
 
@@ -131,7 +131,7 @@ class News < Content
 
   def self.create_for_redaction(account)
     news = News.new
-    news.title = "Nouvelle dépêche #{News.maximum(:id).to_i + 1}"
+    news.title = "Nouvelle dépêche nᵒ #{News.maximum(:id).to_i + 1}"
     news.section = Section.default
     news.wiki_body = DEFAULT_FIRST_PART
     news.wiki_second_part = DEFAULT_PARAGRAPH
@@ -140,7 +140,7 @@ class News < Content
     news.author_email = account.email
     news.editor = account
     news.save
-    message = "Merci d'avoir initié cette rédaction collaborative !
+    message = "Merci d’avoir initié cette rédaction coopérative !
       Durant toute la phase de rédaction, vous pourrez utiliser la présente
       messagerie instantanée pour discuter avec les participants."
     Board.new(object_type: Board.news, object_id: news.id, message: message, user_name: "Le bot LinuxFr").save
@@ -149,7 +149,7 @@ class News < Content
 
   def followup(message, user)
     NewsNotifications.followup(self, message).deliver_now
-    msg = "<b>Relance :</b> #{message}"
+    msg = "<b>Relance :</b> #{message}"
     Board.new(object_type: Board.news, object_id: self.id, message: msg, user_name: user.name).save
   end
 
@@ -187,8 +187,8 @@ class News < Content
   before_validation :wikify_fields
   def wikify_fields
     return if wiki_body.blank?
-    self.body        = wikify(wiki_body).gsub(/^<p>NdM/, '<p><abbr title="Note des modérateurs">NdM</abbr>')
-    self.second_part = wikify(wiki_second_part).gsub(/^<p>NdM/, '<p><abbr title="Note des modérateurs">NdM</abbr>')
+    self.body        = wikify(wiki_body).gsub(/^<p>N\.?\p{Z}?[Dd]\.?\p{Z}?M\.?\p{Z}?:/, '<p><abbr title="Note des modérateurs">N. D. M. :</abbr>')
+    self.second_part = wikify(wiki_second_part).gsub(/^<p>N\.?\p{Z}?[Dd]\.?\p{Z}?M\.?\p{Z}?:/, '<p><abbr title="Note des modérateurs">N. D. M. :</abbr>')
   end
 
   mark_as_safe_attr :body

--- a/app/models/news_version.rb
+++ b/app/models/news_version.rb
@@ -25,13 +25,13 @@ class NewsVersion < ActiveRecord::Base
 
   before_update :raise_on_update
   def raise_on_update
-    raise ActiveRecordError.new "On ne modifie pas les anciennes versions !"
+    raise ActiveRecordError.new "On ne modifie pas les anciennes versions !"
   end
 
 ### Presentation ###
 
   def message
-    "Révision n°#{self.version}"
+    "Révision nᵒ #{self.version}"
   end
 
   def author_name

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,7 +33,7 @@ class Page < ActiveRecord::Base
   def truncated_body
     LFTruncator.
       truncate(body, 80).
-      sub("[...](suite)", " <a href=\"/#{slug}\">(...)</a>").
+      sub("[...](suite)", " <a href=\"/#{slug}\">(…)</a>").
       html_safe
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,7 +28,7 @@ class Post < Content
   validates :forum,     presence: { message: "Vous devez choisir un forum" }
   validates :title,     presence: { message: "Le titre est obligatoire" },
                         length: { maximum: 100, message: "Le titre est trop long" }
-  validates :wiki_body, presence: { message: "Vous ne pouvez pas poster un journal vide" }
+  validates :wiki_body, presence: { message: "Vous ne pouvez pas poster une entrée de forum vide" }
 
   wikify_attr   :body
   truncate_attr :body

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,7 @@ class Tag < ActiveRecord::Base
   has_many :taggings, dependent: :destroy, inverse_of: :tag
   has_many :nodes, -> { distinct }, through: :taggings
 
-  validates :name, presence: true, length: { maximum: 64, message: "Le tag est trop long" }
+  validates :name, presence: true, length: { maximum: 64, message: "Le nom d’étiquette est trop long" }
 
   attr_accessor :tagged_by_current
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,12 +29,12 @@ class User < ActiveRecord::Base
   has_many :taggings, -> { includes(:tag) }, dependent: :destroy
   has_many :tags, -> { distinct }, through: :taggings
 
-  validates_format_of :homesite, message: "L'URL du site web personnel n'est pas valide", with: URI::regexp(%w(http https)), allow_blank: true
-  validates :homesite, length: { maximum: 100, message: "L'URL est trop longue" }
+  validates_format_of :homesite, message: "L’adresse du site Web personnel n’est pas valide", with: URI::regexp(%w(http https)), allow_blank: true
+  validates :homesite, length: { maximum: 100, message: "L’adresse du site Web personnel est trop longue" }
   validates :name, length: { maximum: 40, message: "Le nom affiché est trop long" }
-  validates :jabber_id, length: { maximum: 32, message: "L'URL JabberID est trop longue" }
+  validates :jabber_id, length: { maximum: 32, message: "L’adresse XMPP est trop longue" }
   validates :signature, length: { maximum: 255, message: "La signature est trop longue" }
-  validates :custom_avatar_url, length: { maximum: 255, message: "L'URL de l'avatar est trop longue" }
+  validates :custom_avatar_url, length: { maximum: 255, message: "L’adresse de l’avatar est trop longue" }
 
   def self.collective
     find_by(name: "Collectif")
@@ -77,7 +77,7 @@ class User < ActiveRecord::Base
   def validate_url
     return if custom_avatar_url.blank?
     return if custom_avatar_url.starts_with?("//")
-    errors.add(:url, "Adresse de téléchargement d'avatar non valide")
+    errors.add(:url, "Adresse de téléchargement d’avatar non valide")
   end
 
   def avatar_url

--- a/app/models/wiki_version.rb
+++ b/app/models/wiki_version.rb
@@ -26,14 +26,14 @@ class WikiVersion < ActiveRecord::Base
 
   before_update :raise_on_update
   def raise_on_update
-    raise ActiveRecordError.new "On ne modifie pas les anciennes versions !"
+    raise ActiveRecordError.new "On ne modifie pas les anciennes versions !"
   end
 
 ### Presentation ###
 
   def message
     msg = read_attribute(:message)
-    msg.blank? ? "Révision n°#{self.id}" : msg
+    msg.blank? ? "Révision nᵒ #{self.id}" : msg
   end
 
   def author_name

--- a/app/views/admin/_box.html.haml
+++ b/app/views/admin/_box.html.haml
@@ -1,5 +1,5 @@
 #admin_box.box
   %h1
     = link_to "Admin", '/admin'
-  %h2 Abusers
+  %h2 Abuseurs
   = abusers

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -1,9 +1,9 @@
-=h1 "Les derniers comptes utilisateurs créés"
+=h1 "Les derniers comptes créés"
 
 = form_tag admin_accounts_path, method: :get do
   %input(type="text" name="login" value="#{@login}" placeholder="Filtrer par pseudo")
   %input(type="date" name="date" value="#{@date}" placeholder="Filtrer par date (YYYY-MM-DD)")
-  %input(type="text" name="ip" value="#{@ip}" placeholder="Filtrer par IP")
+  %input(type="text" name="ip" value="#{@ip}" placeholder="Filtrer par adresse IP")
   %input(type="text" name="email" value="#{@email}" placeholder="Filtrer par courriel")
   = check_box_tag 'inactive', 'inactive', @inactive=="inactive"
   %label(for="inactive") Inactifs
@@ -13,7 +13,7 @@
   %tr
     %th Pseudo / Courriel
     %th Karma
-    %th IP courante / précédente
+    %th Adresse IP courante / précédente
     %th Commentaires publics / tous
     %th Contenus publics / tous
     %th Date de création
@@ -44,7 +44,7 @@
         - if account.inactive? && account.user_id != 1
           = button_to "Activer",   [:admin, account], method: :put, class: "ok_button"
         - elsif !account.inactive?
-          = button_to "Renvoi mot de passe", password_admin_account_path(account), class: "reset_password"
+          = button_to "Réinitialisation de mot de passe", password_admin_account_path(account), class: "reset_password"
           = button_to "Suspendre", [:admin, account], method: :put, class: "delete_button"
       %td
         - if account.editor?
@@ -56,6 +56,6 @@
         - elsif !account.inactive?
           = button_to "→ modérateur", admin_account_moderator_path(account.id)
           = button_to "→ animateur", admin_account_editor_path(account.id)
-          = button_to "→ admin", admin_account_admin_path(account.id)
+          = button_to "→ administrateur", admin_account_admin_path(account.id)
 
 = paginate @accounts

--- a/app/views/admin/applications/_form.html.haml
+++ b/app/views/admin/applications/_form.html.haml
@@ -1,7 +1,7 @@
 = messages_on_error @application
 
 %p
-  = form.label :name, "Nom de l'application"
+  = form.label :name, "Nom de l’application"
   = form.text_field :name, required: 'required'
 %p
   = form.label :redirect_uri, "URI de redirection"

--- a/app/views/admin/applications/index.html.haml
+++ b/app/views/admin/applications/index.html.haml
@@ -1,4 +1,4 @@
-=h1 "Les applications pour l'API"
+=h1 "Les applications pour l’API"
 
 %table
   %tr
@@ -14,6 +14,6 @@
       %td
         = link_to "Afficher", admin_application_path(app), class: "show_client_app"
         = link_to "Modifier", edit_admin_application_path(app), class: "edit_client_app"
-        = button_to "Supprimer", admin_application_path(app), method: :delete, class: "delete_button", data: { confirm: "Êtes-vous sûr de vouloir supprimer cette application ?" }
+        = button_to "Supprimer", admin_application_path(app), method: :delete, class: "delete_button", data: { confirm: "Confirmez‑vous vouloir supprimer cette application ?" }
 
 = paginate @applications

--- a/app/views/admin/applications/show.html.haml
+++ b/app/views/admin/applications/show.html.haml
@@ -1,10 +1,10 @@
 =h1 "Application #{@application.name}"
 
 %ul
-  %li Nom de l'application : <strong>#{@application.name}</strong>
-  %li Identifiant : <var>#{@application.uid}</var>
-  %li Secret : <var>#{@application.secret}</var>
-  %li URI de redirection : #{@application.redirect_uri}
+  %li Nom de l’application : <strong>#{@application.name}</strong>
+  %li Identifiant : <var>#{@application.uid}</var>
+  %li Secret : <var>#{@application.secret}</var>
+  %li URI de redirection : #{@application.redirect_uri}
 
 %p
   = link_to "Revenir à la liste des applications", admin_applications_path

--- a/app/views/admin/banners/_warning.html.haml
+++ b/app/views/admin/banners/_warning.html.haml
@@ -1,4 +1,4 @@
 .notice
   %p
-    %strong Attention :
-    il faut éviter les contenus inclus en HTTP (non-HTTPS) dans les bannières !
+    %strong Attention :
+    il faut éviter les contenus inclus en HTTP (non‑HTTPS) dans les bannières !

--- a/app/views/admin/banners/index.html.haml
+++ b/app/views/admin/banners/index.html.haml
@@ -1,10 +1,10 @@
-=h1 "Bannière de la page d'accueil"
+=h1 "Bannière de la page d’accueil"
 
 %p
-  On affiche sur la page d'accueil une bannière choisie aléatoirement parmi les bannières suivantes :
+  On affiche sur la page d’accueil une bannière choisie aléatoirement parmi les bannières suivantes :
 
 - if @banners.empty?
-  %p Pas de bannières
+  %p Aucune bannière
 - else
   %table
     %tr
@@ -22,7 +22,7 @@
           = banner.active ? "Oui" : "Non"
         %td
           = link_to "Modifier", edit_admin_banner_path(banner)
-          = button_to "Supprimer", [:admin, banner], method: :delete, data: { confirm: "Supprimer la bannière ?" }, class: "delete_button"
+          = button_to "Supprimer", [:admin, banner], method: :delete, data: { confirm: "Supprimer la bannière ?" }, class: "delete_button"
 
 %p
   = link_to "Ajouter une bannière", new_admin_banner_path

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -3,7 +3,7 @@
 %p= link_to "Créer une catégorie", new_admin_category_path
 
 - if @categories.empty?
-  %p Pas de catégories
+  %p Aucune catégorie
 - else
   %table
     %tr
@@ -15,4 +15,4 @@
           = category.title
         %th
           = link_to "Modifier", edit_admin_category_path(category)
-          = button_to "Supprimer", [:admin, category], method: :delete, data: { confirm: "Supprimer la catégorie ?" }, class: "delete_button"
+          = button_to "Supprimer", [:admin, category], method: :delete, data: { confirm: "Supprimer la catégorie ?" }, class: "delete_button"

--- a/app/views/admin/debug.html.haml
+++ b/app/views/admin/debug.html.haml
@@ -1,8 +1,8 @@
 =h1 "Administration"
 %ul
-  %li Environnement&nbsp;: #{Rails.env}
-  %li Rails root&nbsp;: #{Rails.root}
-  %li Révision git&nbsp;: #{`git log -1 --pretty=format:"%h"`}
-  %li PID&nbsp;: #{Process.pid}
-  %li Connexion Redis&nbsp;: #{$redis.__id__} #{$redis.inspect}
-  %li Connexion MySQL&nbsp;: #{ActiveRecord::Base.connection.__id__} #{ActiveRecord::Base.connection.inspect}
+  %li Environnement : #{Rails.env}
+  %li Rails root : #{Rails.root}
+  %li Révision Git : #{`git log -1 --pretty=format:"%h"`}
+  %li PID : #{Process.pid}
+  %li Connexion Redis : #{$redis.__id__} #{$redis.inspect}
+  %li Connexion MySQL : #{ActiveRecord::Base.connection.__id__} #{ActiveRecord::Base.connection.inspect}

--- a/app/views/admin/forums/index.html.haml
+++ b/app/views/admin/forums/index.html.haml
@@ -3,7 +3,7 @@
 %p= link_to "Créer un forum", new_admin_forum_path
 
 - if @forums.empty?
-  %p Pas de forums
+  %p Aucun forum
 - else
   %table
     %tr
@@ -14,11 +14,11 @@
         %td
           = link_to forum.title, forum
         %td
-          = button_to "&uarr;".html_safe, higher_admin_forum_path(forum)
-          = button_to "&darr;".html_safe, lower_admin_forum_path(forum)
+          = button_to "↑", higher_admin_forum_path(forum)
+          = button_to "↓", lower_admin_forum_path(forum)
           = link_to "Modifier", edit_admin_forum_path(forum)
           - if forum.active?
-            = button_to "Archiver", archive_admin_forum_path(forum), data: { confirm: "Archiver le forum ?" }, class: "archive_button"
+            = button_to "Archiver", archive_admin_forum_path(forum), data: { confirm: "Archiver le forum ?" }, class: "archive_button"
           - else
-            = button_to "Ré-ouvrir", reopen_admin_forum_path(forum), data: { confirm: "Ré-ouvrir le forum ?" }, class: "reopen_button"
-          = button_to "Supprimer", [:admin, forum], method: :delete, data: { confirm: "Supprimer le forum ?" }, class: "delete_button"
+            = button_to "Réouvrir", reopen_admin_forum_path(forum), data: { confirm: "Réouvrir le forum ?" }, class: "reopen_button"
+          = button_to "Supprimer", [:admin, forum], method: :delete, data: { confirm: "Supprimer le forum ?" }, class: "delete_button"

--- a/app/views/admin/friend_sites/index.html.haml
+++ b/app/views/admin/friend_sites/index.html.haml
@@ -3,7 +3,7 @@
 %p= link_to "Ajouter un site ami", new_admin_friend_site_path
 
 - if @friend_sites.empty?
-  %p Pas de site ami
+  %p Aucun site ami
 - else
   %table
     %tr
@@ -15,7 +15,7 @@
         %td= site.title
         %td= link_to site.url, site.url
         %td
-          = button_to "&uarr;".html_safe, higher_admin_friend_site_path(site)
-          = button_to "&darr;".html_safe, lower_admin_friend_site_path(site)
+          = button_to "↑", higher_admin_friend_site_path(site)
+          = button_to "↓", lower_admin_friend_site_path(site)
           = link_to "Modifier", edit_admin_friend_site_path(site)
-          = button_to "Supprimer", [:admin, site], method: :delete, data: { confirm: "Supprimer le site ami ?" }, class: "delete_button"
+          = button_to "Supprimer", [:admin, site], method: :delete, data: { confirm: "Supprimer le site ami ?" }, class: "delete_button"

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -1,6 +1,6 @@
 =h1 "Administration"
 %ul
-  %li= link_to "Derniers comptes utilisateurs", admin_accounts_path
+  %li= link_to "Derniers comptes utilisateur", admin_accounts_path
   %li= link_to "Réponses de refus (pour les dépêches)", admin_responses_path
   %li= link_to "Sections (pour les dépêches)", admin_sections_path
   %li= link_to "Forums", admin_forums_path
@@ -10,5 +10,5 @@
   %li= link_to "Feuilles de style", admin_stylesheet_path
   %li= link_to "Sites amis", admin_friend_sites_path
   %li= link_to "Pages statiques", admin_pages_path
-  %li= link_to "Applications de l'API", admin_applications_path
-  %li= link_to "Debug", "/admin/debug"
+  %li= link_to "Applications de l’API", admin_applications_path
+  %li= link_to "Débogage", "/admin/debug"

--- a/app/views/admin/pages/index.html.haml
+++ b/app/views/admin/pages/index.html.haml
@@ -15,4 +15,4 @@
         = link_to page.slug, static_path(page)
       %td
         = link_to "Modifier", edit_admin_page_path(page)
-        = button_to "Supprimer", [:admin, page], method: :delete, data: { confirm: "Supprimer la page ?" }, class: "delete_button"
+        = button_to "Supprimer", [:admin, page], method: :delete, data: { confirm: "Supprimer la page ?" }, class: "delete_button"

--- a/app/views/admin/responses/index.html.haml
+++ b/app/views/admin/responses/index.html.haml
@@ -12,4 +12,4 @@
         = resp.title
       %th
         = link_to "Modifier", edit_admin_response_path(resp)
-        = button_to "Supprimer", [:admin, resp], method: :delete, data: { confirm: "Supprimer la réponse ?" }, class: "delete_button"
+        = button_to "Supprimer", [:admin, resp], method: :delete, data: { confirm: "Supprimer la réponse ?" }, class: "delete_button"

--- a/app/views/admin/sections/edit.html.haml
+++ b/app/views/admin/sections/edit.html.haml
@@ -1,8 +1,8 @@
 =h1 "Modifier cette section"
 
 %p
-  L'image associée à cette section est versionnée dans le dépôt git.
-  C'est le fichier <kbd>public/images/sections/#{@section.id}.png</kbd>
+  L’image associée à cette section est versionnée dans le dépôt Git.
+  C’est le fichier <kbd>public/images/sections/#{@section.id}.png</kbd>
 
 = form_for [:admin, @section] do |form|
   = render form

--- a/app/views/admin/sections/index.html.haml
+++ b/app/views/admin/sections/index.html.haml
@@ -3,7 +3,7 @@
 %p= link_to "Créer une section", new_admin_section_path
 
 - if @sections.empty?
-  %p Pas de sections
+  %p Aucune section
 - else
   %table
     %tr
@@ -21,4 +21,4 @@
           = section.state == "published" ? "publiée" : "archivée"
         %td
           = link_to "Modifier", edit_admin_section_path(section)
-          = button_to "Archiver", [:admin, section], method: :delete, data: { confirm: "Archiver la section ?" }, class: "delete_button"
+          = button_to "Archiver", [:admin, section], method: :delete, data: { confirm: "Archiver la section ?" }, class: "delete_button"

--- a/app/views/admin/sections/new.html.haml
+++ b/app/views/admin/sections/new.html.haml
@@ -1,8 +1,8 @@
 =h1 "Nouvelle section"
 
 %p
-  %strong Note :
-  L'image associée à cette section doit être placée dans le dépôt git
+  %strong Note :
+  L’image associée à cette section doit être placée dans le dépôt Git
   avec le nom de fichier <kbd>public/images/sections/#{Section.maximum(:id).to_i + 1}.png</kbd>
 
 = form_for [:admin, @section] do |form|

--- a/app/views/admin/stylesheets/show.html.haml
+++ b/app/views/admin/stylesheets/show.html.haml
@@ -3,18 +3,18 @@
 .instructions_new_stylesheet
   %h2 Instructions pour ajouter une feuille de style alternative
   %ol
-    %li Ajouter le fichier <code>&lt;nom_de_la_feuille&gt;.css</code> dans le répertoire <code>app/assets/stylesheets/contrib/</code>
-    %li Prendre une capture d'écran et sous le nom <code>&lt;public/stylesheets/contrib/nom_de_la_feuille&gt;.png</code>
-    %li Commiter le tout avec git&nbsp;: <code>git add app/assets/stylesheets public/stylesheets &amp;&amp; git ci -m "New stylesheet: &lt;nom_de_la_feuille&gt;"</code>
+    %li ajouter le fichier <code>&lt;nom_de_la_feuille&gt;.css</code> dans le répertoire <code>app/assets/stylesheets/contrib/</code> ;
+    %li prendre une capture d’écran et l’enregistrer sous <code>&lt;public/stylesheets/contrib/nom_de_la_feuille&gt;.png</code> ;
+    %li faire un commit du tout avec Git : <code>git add app/assets/stylesheets public/stylesheets &amp;&amp; git ci -m "New stylesheet: &lt;nom_de_la_feuille&gt;"</code>.
 
 .capture_new_stylesheet
-  %h2 Prendre une capture d'écran d'une feuille de style
+  %h2 Prendre une capture d’écran d’une feuille de style
   %p.note
-    %strong Important :
-    Image Magick et <a href="http://phantomjs.org/">phantomjs</a> doivent être installés sur le serveur&nbsp;!
+    %strong Important :
+    <a href="https://imagemagick.org/">ImageMagick</a> et <a href="https://phantomjs.org/">PhantomJS</a> doivent être installés sur le serveur !
   %p.note
-    %strong Important :
-    Cela ne fonctionne en local qu'à condition de lancer un 2ème thin avec <code>./script/rails s thin -p 3001 -P tmp/pids/other.pid</code>
+    %strong Important :
+    Cela ne fonctionne en local qu’à condition de lancer un deuxième « thin » avec <code>./script/rails s thin -p 3001 -P tmp/pids/other.pid</code>.
     = form_tag admin_stylesheet_path do
       %label(for="url") URL de la feuille de style
       %input(type="url" id="url" name="url")

--- a/app/views/api/applications/_form.html.haml
+++ b/app/views/api/applications/_form.html.haml
@@ -1,7 +1,7 @@
 = messages_on_error @application
 
 %p
-  = form.label :name, "Nom de l'application"
+  = form.label :name, "Nom de l’application"
   = form.text_field :name, required: 'required'
 %p
   = form.label :redirect_uri, "URI de redirection"

--- a/app/views/api/applications/index.html.haml
+++ b/app/views/api/applications/index.html.haml
@@ -1,14 +1,14 @@
-=h1 "Mes applications pour l'API"
+=h1 "Mes applications pour l’API"
 
 %p
   Cette page est destinée aux développeurs.
-  Elle permet de gérer des applications clientes de l'API en OAuth2.
+  Elle permet de gérer des applications clientes de l’API en OAuth2.
 
 %p
   = link_to "Créer une application", new_api_application_path
 
 - if @applications.empty?
-  %p Vous n'avez pas encore enregistrer d'applications.
+  %p Vous n’avez pas encore enregistré d’application.
 - else
   %table
     %tr
@@ -24,4 +24,4 @@
         %td
           = link_to "Afficher", api_application_path(app), class: "show_client_app"
           = link_to "Modifier", edit_api_application_path(app), class: "edit_client_app"
-          = button_to "Supprimer", api_application_path(app), method: :delete, class: "delete_button", data: { confirm: "Êtes-vous sûr de vouloir supprimer cette application ?" }
+          = button_to "Supprimer", api_application_path(app), method: :delete, class: "delete_button", data: { confirm: "Confirmez‑vous vouloir supprimer cette application ?" }

--- a/app/views/api/applications/show.html.haml
+++ b/app/views/api/applications/show.html.haml
@@ -1,10 +1,10 @@
 =h1 "Application #{@application.name}"
 
 %ul
-  %li Nom de l'application : <strong>#{@application.name}</strong>
-  %li Identifiant : <var>#{@application.uid}</var>
-  %li Secret : <var>#{@application.secret}</var>
-  %li URI de redirection : #{@application.redirect_uri}
+  %li Nom de l’application : <strong>#{@application.name}</strong>
+  %li Identifiant : <var>#{@application.uid}</var>
+  %li Secret : <var>#{@application.secret}</var>
+  %li URI de redirection : #{@application.redirect_uri}
 
 %p
   = link_to "Revenir à la liste des applications", api_applications_path

--- a/app/views/boards/_board.html.haml
+++ b/app/views/boards/_board.html.haml
@@ -12,7 +12,7 @@
       %div{class: "board-left"}
         %time.norloge{datetime: board.created_at.iso8601, norloge: norloge(board, box)}
           - if board.created_at.today?
-            Aujourd'hui,
+            Aujourd’hui,
           - else
             = "Il y a #{time_ago_in_words board.created_at},"
           = board.created_at.strftime('%Hh%M')

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -3,15 +3,15 @@
   = link_to "Version XML", "/board/index.xml"
   = link_to "Version TSV", "/board/index.tsv"
   %p
-    %strong Conditions d'utilisation :
-    cette tribune est un espace de discussion soumis aux lois en vigueur
-    en France. En conséquence nous vous remercions de surveiller vos
+    %strong Conditions d’utilisation :<br/><br/>
+    Cette tribune est un espace de discussion soumis aux lois en vigueur
+    en France. En conséquence, nous vous remercions de surveiller vos
     écrits et de ne pas tenir de propos pénalement répréhensibles. Les
-    visiteurs ne tenant pas compte de ces conditions d'utilisation
+    visiteurs ne tenant pas compte de ces conditions d’utilisation
     verront leurs comptes supprimés. Les propos tenus ici sont publiés
     sous la responsabilité de leurs auteurs respectifs.
   %p
-    Vous pouvez choisir le type d'affichage pour les photos&nbsp;:
+    Vous pouvez choisir le type d’affichage pour les photos :
     %a{onclick: "$.cookie('totoz-type', 'popup', {path: '/', expires: new Date('01/01/2042')});" } en surimpression,
     %a{onclick: "$.cookie('totoz-type', 'inline', {path: '/', expires: new Date('01/01/2042')});" } insérées avec le texte
     ou

--- a/app/views/bookmarks/edit.html.haml
+++ b/app/views/bookmarks/edit.html.haml
@@ -8,4 +8,4 @@
     = render form
 
   %h2 Modération
-  = button_to "Supprimer", [@bookmark.owner, @bookmark], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce lien ?" }, class: "delete_button"
+  = button_to "Supprimer", [@bookmark.owner, @bookmark], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer ce lien ?" }, class: "delete_button"

--- a/app/views/bookmarks/index.atom.builder
+++ b/app/views/bookmarks/index.atom.builder
@@ -1,8 +1,8 @@
 atom_feed(:root_url => bookmarks_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
   if @user
-    feed.title("LinuxFr.org : les liens de #{@user.name}")
+    feed.title("LinuxFr.org : les liens de #{@user.name}")
   else
-    feed.title("LinuxFr.org : les liens")
+    feed.title("LinuxFr.org : les liens")
   end
   feed.updated(@nodes.first.try :created_at)
   feed.icon("/favicon.png")

--- a/app/views/bookmarks/new.html.haml
+++ b/app/views/bookmarks/new.html.haml
@@ -2,8 +2,8 @@
   =h1 "Partager un lien"
 
   %p
-    La rubrique « liens » est destinée à recevoir les, euh…, liens vers des contenus en rapport avec la ligne éditoriale de LinuxFr.org.
-    En particulier, et de manière non exhaustive, les articles concernant Linux, les logiciels libres, le matériel libre, les arts libres, sont les bienvenus.
+    La rubrique « liens » est destinée à recevoir les euh… liens vers des contenus en rapport avec la ligne éditoriale de LinuxFr.org.
+    En particulier, et de manière non exhaustive, les articles concernant Linux, les logiciels libres, le matériel libre et les arts libres sont les bienvenus.
     Vous pouvez aussi partager ici des liens vers vos propres contenus hébergés ailleurs.
 
   %p

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -7,7 +7,7 @@
   = posted_by(comment)
   - unless defined? hide_content_title
     En réponse #{translate_to_content_type comment.content_type} #{link_to comment.content.title, path_for_content(comment.content)}.
-  Évalué à&nbsp;
+  Évalué à
   %span.score><
     = comment.bound_score
     - unless comment.content.too_old_for_comments?
@@ -19,7 +19,7 @@
 %figure.image= avatar_img(comment.user)
 - if comment.deleted?
   .content.deleted
-    %p Ce commentaire a été supprimé par l'équipe de modération.
+    %p Ce commentaire a été supprimé par l’équipe de modération.
 - else
   .content
     = comment.body
@@ -34,8 +34,8 @@
   - if current_account
     - if current_account.can_vote?(comment)
       %div.vote
-        Ce commentaire est-il #{button_to "pertinent", "/nodes/#{comment.node_id}/comments/#{comment.id}/relevance/for", remote: true, class: "relevant"}
-        ou #{button_to "inutile", "/nodes/#{comment.node_id}/comments/#{comment.id}/relevance/against", remote: true, class: "useless"} ?
+        Ce commentaire est‑il #{button_to "pertinent", "/nodes/#{comment.node_id}/comments/#{comment.id}/relevance/for", remote: true, class: "relevant"}
+        ou #{button_to "inutile", "/nodes/#{comment.node_id}/comments/#{comment.id}/relevance/against", remote: true, class: "useless"} ?
     - elsif v = comment.vote_by?(current_account.id)
       %div.vote.done
         Vous avez jugé ce commentaire #{v == "for" ? "pertinent" : "inutile"}.

--- a/app/views/comments/_preview.html.haml
+++ b/app/views/comments/_preview.html.haml
@@ -4,7 +4,7 @@
       = link_to spellcheck(preview.title), "#", class: "title"
     %p.meta
       = posted_by(preview)
-      Évalué à&nbsp;
+      Évalué à
       %span.score>= preview.bound_score
     %figure.image
       = avatar_img(current_user)
@@ -17,6 +17,6 @@
       &nbsp;
 
 - if preview.parent.try(:user_id) == current_account.user_id
-  = image_tag "/images/dessins/geekscottes_005.png", alt: "Autosatisfaction récursive", title: "Autosatisfaction récursive - © Johann 'nojhan' Dréo : 2005-03-25 - Licence CC By-Sa 2.5"
+  = image_tag "/images/dessins/geekscottes_005.png", alt: "Autosatisfaction récursive", title: "Autosatisfaction récursive — © Johann « nojhan » Dréo, 25 mars 2005 — Licence CC By‑SA 2.5"
 - elsif preview.parent.try(:depth).to_i > 10
-  = image_tag "/images/dessins/discussion.png", alt: "Discussion", title: "Discussion - © Boug metoogotmy.net : 2012 - Licence CC By-Sa 2.0 Fr"
+  = image_tag "/images/dessins/discussion.png", alt: "Discussion", title: "Discussion — © Boug metoogotmy.net : 2012 — Licence CC By‑SA 2.0 Fr"

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -9,6 +9,6 @@
 
   - if current_account && current_account.can_destroy?(@comment)
     %p
-      = button_to "Supprimer ce commentaire", [@comment.node, @comment], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce commentaire ?" }, class: "delete_button"
+      = button_to "Supprimer ce commentaire", [@comment.node, @comment], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer ce commentaire ?" }, class: "delete_button"
 
   = render 'shared/wiki_help'

--- a/app/views/comments/index.atom.builder
+++ b/app/views/comments/index.atom.builder
@@ -1,5 +1,5 @@
 atom_feed do |feed|
-  feed.title("LinuxFr.org : les commentaires pour #{@user.try(:name) || @node.content.title}")
+  feed.title("LinuxFr.org : les commentaires pour « #{@user.try(:name) || @node.content.title} »")
   feed.updated((@comments.last || @node || @user).created_at)
   feed.icon("/favicon.png")
 

--- a/app/views/comments/show.html.haml
+++ b/app/views/comments/show.html.haml
@@ -9,7 +9,7 @@
       = link_to "Modifier ce commentaire", "/nodes/#{@comment.node_id}/comments/#{@comment.id}/modifier"
   - if current_account.can_destroy?(@comment)
     %p
-      = button_to "Supprimer ce commentaire", [@comment.node, @comment], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce commentaire ?" }, class: "delete_button"
+      = button_to "Supprimer ce commentaire", [@comment.node, @comment], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer ce commentaire ?" }, class: "delete_button"
 
 %main#contents(role="main")
   %div#comments

--- a/app/views/dashboard/_comments.html.haml
+++ b/app/views/dashboard/_comments.html.haml
@@ -2,7 +2,7 @@
   Vos derniers commentaires
 - if @comments.empty?
   %p
-    Vous n'avez posté aucun commentaire
+    Vous n’avez posté aucun commentaire
 - else
   - if @self_answer
     = link_to "Ne pas inclure les réponses à mes commentaires", self: nil
@@ -15,18 +15,18 @@
       %th Sujet du commentaire
       %th Date
       %th Note
-      %th <abbr title="Nb de réponses">Rép.</abbr>
+      %th <abbr title="Nombre de réponses">Rép.</abbr>
       %th Dernière réponse
     - @comments.each do |comment|
       - next if comment.node.nil?
       - answer = comment.last_answer
       %tr
-        %td #{translate_content_type comment.content_type}&nbsp;: #{link_to_content comment.content}
+        %td #{translate_content_type comment.content_type} : #{link_to_content comment.content}
         %td= link_to comment.title, path_for_content(comment.node.content) + "#comment-#{comment.id}"
         %td.date= comment.created_at.to_s(:posted)
         %td.number= comment.bound_score
         %td.number
           - if answer && !answer.read_by?(current_account)
-            = image_tag "/images/icones/comment.png", alt: "Nouveaux commentaires !", class: "thread-new-comments"
+            = image_tag "/images/icones/comment.png", alt: "Nouveaux commentaires !", class: "thread-new-comments"
           = comment.nb_answers
-        %td.date= answer ? answer.created_at.to_s(:posted) : "&nbsp;".html_safe
+        %td.date= answer ? answer.created_at.to_s(:posted) : " "

--- a/app/views/dashboard/_drafts.html.haml
+++ b/app/views/dashboard/_drafts.html.haml
@@ -1,7 +1,7 @@
 %h2
-  Vos dépêches dans l'espace de rédaction
+  Vos dépêches dans l’espace de rédaction
 - if @drafts.empty?
-  Vous n'êtes à l'origine d'aucune dépêche dans l'espace de rédaction.
+  Vous n’êtes à l’origine d’aucune dépêche dans l’espace de rédaction.
 - else
   %table#my_drafts
     %tr

--- a/app/views/dashboard/_news.html.haml
+++ b/app/views/dashboard/_news.html.haml
@@ -1,7 +1,7 @@
 %h2
   Vos dépêches en attente de modération
 - if @news.empty?
-  Vous n'avez aucune dépêche en cours de modération
+  Vous n’avez aucune dépêche en cours de modération
 - else
   %table#my_news
     %tr

--- a/app/views/dashboard/_posts.html.haml
+++ b/app/views/dashboard/_posts.html.haml
@@ -2,7 +2,7 @@
   Vos derniers messages dans les forums
 - if @posts.empty?
   %p
-    Vous n'avez posté aucun message dans les forums
+    Vous n’avez posté aucun message dans les forums
 - else
   %table#my_posts
     %tr

--- a/app/views/dashboard/_trackers.html.haml
+++ b/app/views/dashboard/_trackers.html.haml
@@ -2,7 +2,7 @@
   Vos dernières entrées dans le suivi
 - if @trackers.empty?
   %p
-    Vous n'avez posté aucune entrée dans le suivi
+    Vous n’avez posté aucune entrée dans le suivi
 - else
   %table#my_trackers
     %tr

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,6 +1,6 @@
 %main#contents(role="main")
   .notice
-    La page de wiki <a href="/wiki/decouvrir-linuxfr">Découvrir LinuxFr</a> donne quelques astuces pour mieux utiliser le site.
+    La page de wiki <a href="/wiki/decouvrir-linuxfr">Découvrir LinuxFr.org</a> donne quelques astuces pour mieux utiliser le site.
 
   =h1 "Votre tableau de bord"
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,22 +1,22 @@
-<p>Bienvenue <%= @resource.login %>  sur <a href="https://linuxfr.org/">LinuxFr.org</a> !</p>
+<p>Bienvenue sur <a href="https://linuxfr.org/">LinuxFr.org</a> <%= @resource.login %> !</p>
 
 <% if @resource.password %>
-<p>Le mot de passe aléatoirement généré est : <%= @resource.password %></p>
+<p>Le mot de passe aléatoirement généré est : <%= @resource.password %></p>
 
 <p>Nous vous conseillons de remplacer ce mot de passe à votre première
-connexion. Les mots de passe que vous définirez ne sont jamais transmis par
-courriel.</p>
+connexion. Les mots de passe que vous définirez ne seront jamais transmis
+par courriel.</p>
 <% else %>
-<p>Un mot de passe généré aléatoirement vous a été envoyé lors d'un précédent
-courriel. En cas de problème, vous pouvez demander le renvoi d'un nouveau mot
-de passe sur :<br/>
+<p>Un mot de passe généré aléatoirement vous a été envoyé lors d’un précédent
+courriel. En cas de problème, vous pouvez demander l’envoi d’un nouveau mot
+de passe via :<br/>
 <%= url_for new_password_url(@resource) %></p>
 <% end %>
 
-<p>Vous devez confirmer la création de votre compte en suivant ce lien :</p>
+<p>Vous devez confirmer la création de votre compte en suivant ce lien :</p>
 
 <p><%= link_to 'Confirmer mon compte', confirmation_url(@resource, :confirmation_token => @token) %></p>
 
 <p>Avoir un compte sur le site vous donne accès à certaines fonctionnalités
-supplémentaires facilitant la lecture. N'hésitez pas à lire
-<a href="https://linuxfr.org/wiki/decouvrir-linuxfr">Découvrir LinuxFR</a> pour en savoir plus.</p>
+supplémentaires facilitant la lecture. N’hésitez pas à lire
+<a href="https://linuxfr.org/wiki/decouvrir-linuxfr">Découvrir LinuxFr.org</a> pour en savoir plus.</p>

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,21 +1,21 @@
-Bienvenue <%= @resource.login %> sur https://linuxfr.org/ !
+Bienvenue sur LinuxFr.org <%= @resource.login %> !
 
 <% if @resource.password %>
-Le mot de passe aléatoirement généré est : <%= raw @resource.password %>
+Le mot de passe aléatoirement généré est : <%= raw @resource.password %>
 
 Nous vous conseillons de remplacer ce mot de passe à votre première connexion.
 Les mots de passe que vous définirez ne sont jamais transmis par courriel.
 <% else %>
-Un mot de passe généré aléatoirement vous a été envoyé lors d'un précédent
-courriel. En cas de problème, vous pouvez demander le renvoi d'un nouveau mot
-de passe sur :
+Un mot de passe généré aléatoirement vous a été envoyé lors d’un précédent
+courriel. En cas de problème, vous pouvez demander l’envoi d’un nouveau mot
+de passe via :
 <%= url_for new_password_url(@resource) %>
 <% end %>
 
-Vous devez confirmer la création de votre compte en suivant ce lien :
+Vous devez confirmer la création de votre compte en suivant ce lien :
 
 <%= url_for confirmation_url(@resource, :confirmation_token => @token) %>
 
 Avoir un compte sur le site vous donne accès à certaines fonctionnalités
-supplémentaires facilitant la lecture. N'hésitez pas à lire
+supplémentaires facilitant la lecture. N’hésitez pas à lire
 https://linuxfr.org/wiki/decouvrir-linuxfr pour en savoir plus.

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,7 +1,7 @@
 <p>Bonjour <%= @resource.login %>,</p>
 
-<p>Quelqu'un a demandé un lien pour changer votre mot de passe, et vous pouvez faire cela avec le lien ci-dessous :</p>
+<p>Quelqu’un a demandé un lien pour changer votre mot de passe, et vous pouvez faire cela avec le lien ci‑dessous :</p>
 
 <p><%= link_to 'Changer de mot de passe', edit_password_url(@resource, :reset_password_token => @token) %></p>
 
-<p>Votre mot de passe ne sera pas modifié tant que vous ne suivrez pas ce lien et que vous en créez un autre.</p>
+<p>Votre mot de passe ne sera pas modifié tant que vous n’aurez pas suivi ce lien et que vous n’en aurez pas créé un nouveau.</p>

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,9 +1,9 @@
 Bonjour <%= @resource.login %>,
 
-Quelqu'un a demandé un lien pour changer votre mot de passe, et vous pouvez
-faire cela avec le lien ci-dessous :
+Quelqu’un a demandé un lien pour changer votre mot de passe, et vous pouvez
+faire cela avec le lien ci‑dessous :
 
 <%= url_for edit_password_url(@resource, :reset_password_token => @token) %>
 
-Votre mot de passe ne sera pas modifié tant que vous ne suivrez pas ce lien et
-que vous en créez un autre.
+Votre mot de passe ne sera pas modifié tant que vous n’aurez pas suivi ce lien et
+que vous n’en aurez pas créé un nouveau.

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Bonjour <%= @resource.email %> !</p>
+<p>Bonjour <%= @resource.email %>,</p>
 
-<p>Votre compte a été bloqué en raison d'un nombre excessif de tentatives infructueuses de connexions.</p>
+<p>Votre compte a été bloqué en raison d’un nombre excessif de tentatives infructueuses de connexions.</p>
 
-<p>Veuillez cliquer sur le lien ci-dessous pour débloquer votre compte :</p>
+<p>Veuillez cliquer sur le lien ci‑dessous pour débloquer votre compte :</p>
 
 <p><%= link_to 'Débloquer mon compte', unlock_url(@resource, :unlock_token => @token) %></p>

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,7 +1,7 @@
-Bonjour <%= @resource.email %> !
+Bonjour <%= @resource.email %>,
 
-Votre compte a été bloqué en raison d'un nombre excessif de tentatives infructueuses de connexions.
+Votre compte a été bloqué en raison d’un nombre excessif de tentatives infructueuses de connexions.
 
-Veuillez cliquer sur le lien ci-dessous pour débloquer votre compte :
+Veuillez cliquer sur le lien ci‑dessous pour débloquer votre compte :
 
 <%= url_for unlock_url(@resource, :unlock_token => @token) %>

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,5 +1,5 @@
 %main#contents(role="main")
-  %h2 Mot de passe oublié ?
+  %h2 Mot de passe oublié ?
 
   = form_for @account, url: password_path(:account) do |f|
     = devise_error_messages!

--- a/app/views/devise/registrations/_applications.html.haml
+++ b/app/views/devise/registrations/_applications.html.haml
@@ -1,13 +1,13 @@
 %h2 Applications OAuth
 %p
-  Si vous êtes un développeur d'applications web, vous pouvez
+  Si vous êtes un développeur d’applications Web, vous pouvez
   = link_to "enregistrer votre application", api_applications_path
-  pour bénéficier de l'API OAuth2 de LinuxFr.org.
+  pour bénéficier de l’API OAuth2 de LinuxFr.org.
 
 - if current_account.authorized_applications.any?
   %p
     Vous pouvez révoquer les autorisations données aux applications avant
-    leur expiration :
+    leur expiration :
 
   %table#authorized_applications
     %tr
@@ -18,7 +18,6 @@
       %tr
         %td= app.name
         %td= app.created_at.to_s(:posted)
-        %td= button_to "Révoquer", api_authorized_application_path(app), method: :delete, data: { confirm: "Révoquer cette autorisation ?" }, class: "delete_button"
+        %td= button_to "Révoquer", api_authorized_application_path(app), method: :delete, data: { confirm: "Révoquer cette autorisation ?" }, class: "delete_button"
 - else
-  %p Vous n'avez donné aucune autorisation à des applications.
-
+  %p Vous n’avez donné aucune autorisation à des applications.

--- a/app/views/devise/registrations/_avatar.html.haml
+++ b/app/views/devise/registrations/_avatar.html.haml
@@ -1,4 +1,4 @@
-%h2 Changer d'avatar
+%h2 Changer d’avatar
 = form_for @account, url: registration_path(:account), method: :put do |f|
   = messages_on_error @account
   = f.fields_for :user do |u|
@@ -8,8 +8,8 @@
       = u.label :avatar, 'Avatar'
       = u.file_field :avatar, accept: "image/*"
     %p
-      = u.label :custom_avatar_url, 'Je préfère que mon avatar soit téléchargé depuis cette URL&nbsp;: '.html_safe
+      = u.label :custom_avatar_url, 'Je préfère que mon avatar soit téléchargé depuis cette URL : '.html_safe
       = u.url_field :custom_avatar_url, value: ""
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"

--- a/app/views/devise/registrations/_close.html.haml
+++ b/app/views/devise/registrations/_close.html.haml
@@ -1,4 +1,4 @@
 %h2 Fermer son compte
 %p
-  Vous souhaitez fermer votre compte ?
-  =button_to "Fermer mon compte", registration_path(:account), data: { confirm: "Êtes-vous sûr de vouloir fermer votre compte ?" }, method: :delete, class: "delete_button"
+  Vous souhaitez fermer votre compte ?
+  =button_to "Fermer mon compte", registration_path(:account), data: { confirm: "Confirmez‑vous vouloir fermer votre compte ?" }, method: :delete, class: "delete_button"

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -7,7 +7,7 @@
     = f.label :password, 'Nouveau mot de passe'
     = f.password_field :password
     %span.help
-      laissez ce champ vide si vous ne souhaitez pas changer de mot de passe
+      Laissez ce champ vide si vous ne souhaitez pas changer de mot de passe
   %p
     = f.label :password_confirmation, 'Confirmation du mot de passe'
     = f.password_field :password_confirmation
@@ -15,7 +15,7 @@
     = f.label :current_password, 'Mot de passe actuel'
     = f.password_field :current_password
     %span.help
-      votre mot de passe actuel est nécessaire pour valider ce changement
+      Votre mot de passe actuel est nécessaire pour valider ce changement
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -5,10 +5,10 @@
       = u.label :name, "Prénom et nom"
       = u.text_field :name, maxlength: 40
     %p
-      = u.label :homesite, 'Site web personnel'
+      = u.label :homesite, 'Site Web personnel'
       = u.url_field :homesite, maxlength: 100
     %p
-      = u.label :jabber_id, 'Jabber ID'
+      = u.label :jabber_id, 'Adresse XMPP'
       %span.prefix xmpp:
       = u.text_field :jabber_id, placeholder: "me@example.net", maxlength: 32
     %p
@@ -25,12 +25,12 @@
     = f.label :show_negative_nodes, "Afficher les journaux avec un score négatif"
   %p
     = check_box_tag :account_visible_toolbar, 1, true
-    = f.label :visible_toolbar, "Afficher la barre d'outils dans ce navigateur"
+    = f.label :visible_toolbar, "Afficher la barre d’outils dans ce navigateur"
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"
 
-%h2 Choisir les contenus affichés sur la page d'accueil
+%h2 Choisir les contenus affichés sur la page d’accueil
 = form_for @account, url: registration_path(:account), method: :put do |f|
   %p
     = f.check_box :news_on_home
@@ -57,7 +57,7 @@
     = f.check_box :sort_by_date_on_home
     = f.label :sort_by_date_on_home, "Trier par ordre antéchronologique"
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"
 
 %h2 Choisir vos préférences pour la tribune
@@ -68,7 +68,7 @@
     = f.label :totoz_style_inline, "En ligne"
   %p
     = f.radio_button :totoz_style, "popup"
-    = f.label :totoz_style_popup, "En popup"
+    = f.label :totoz_style_popup, "En fenêtre surgissante"
   %p
     = f.radio_button :totoz_style, "none"
     = f.label :totoz_style_none, "Ne pas afficher"
@@ -76,7 +76,7 @@
   %p
     = f.select :totoz_source, {"totoz.eu" => "https://totoz.eu/img/", "totoz.eu (NSFW)" => "https://nsfw.totoz.eu/img/", "claudex.be/sfwttz" => "https://claudex.be/sfwttz/", "claudex.be/ttz (NSFW)" => "https://claudex.be/ttz/"}
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"
 
 %h2 Choisir les contenus affichés sur la barre latérale
@@ -85,5 +85,5 @@
     = f.check_box :board_in_sidebar
     = f.label :board_in_sidebar, "Tribune"
   %p
-    %label.factice Sûr de vos modifications ?
+    %label.factice Confirmez‑vous ces modifications ?
     = f.submit "Enregistrer"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,7 +1,7 @@
 %main#contents(role="main")
   =h1 "Modifier son compte utilisateur"
   %p
-    Ce formulaire permet de changer vos parametres utilisateurs. Votre login ne peut pas être modifié.
+    Ce formulaire permet de changer vos paramètres d’utilisateur. Votre nom d’utilsateur ne peut pas être modifié.
 
   = render 'form'
   = render 'avatar'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %main#contents(role="main")
-  =h1 "S'inscrire"
+  =h1 "S’inscrire"
 
   = form_for @account, :as =>:account, url: registration_path(:account) do |f|
     = messages_on_error @account
@@ -10,26 +10,26 @@
       = f.label :email, "Adresse de courriel"
       = f.email_field :email, required: "required"
     %p
-      = f.submit "S'inscrire"
+      = f.submit "S’inscrire"
 
   %article.notes
     %p
       Ce formulaire permet de créer un compte utilisateur.
-      Un compte utilisateur vous permet par exemple de poster des commentaires, il est le premier pas pour participer d'une manière ou d'une autre à LinuxFr.org.
+      Un compte utilisateur vous permet par exemple de poster des commentaires, il est le premier pas pour participer d’une manière ou d’une autre à LinuxFr.org.
     %p
-      Le système utilisé lors de l'identification est basé sur les cookies.
+      Le système utilisé lors de l’identification est basé sur les cookies.
       Vous recevrez un message pour confirmer la création de votre compte.
     %p
-      Si le compte existe déjà, cela signifie que l'adresse électronique proposée est déjà dans notre base.
+      Si le compte existe déjà, cela signifie que l’adresse électronique proposée est déjà dans notre base.
       Veuillez alors demander un nouveau mot de passe.
     %p
-      %strong IMPORTANT&nbsp;:
+      %strong IMPORTANT :
       une seule création de compte par personne physique est autorisée.
-      Toute création de comptes multiples par une même personne, qu'elle qu'en soit la raison, sera considérée comme un abus de ressources.
-      De plus, il est interdit d'utiliser une adresse de courriel temporaire, qui ne permet pas aux administrateurs de vous contacter en cas de problèmes avec votre compte.
-      Lorsqu'une telle adresse est découverte, les administrateurs se réservent le droit de fermer ou supprimer le compte.
+      Toute création de comptes multiples par une même personne, quelle qu’en soit la raison, sera considérée comme un abus de ressources.
+      De plus, il est interdit d’utiliser une adresse de courriel temporaire, qui ne permet pas aux administrateurs de vous contacter en cas de problème avec votre compte.
+      Lorsqu’une telle adresse est découverte, les administrateurs se réservent le droit de fermer ou supprimer le compte.
       Les comptes, contenus et commentaires du site sont soumis à un ensemble de #{link_to "règles de modération", "/regles_de_moderation"}.
     %p
-      Conformément à la loi informatique et liberté, vous pouvez modifier vos informations personnelles par le biais du formulaire web de gestion de vos paramètres utilisateurs.
+      Conformément à la loi informatique et liberté, vous pouvez modifier vos informations personnelles par le biais du formulaire Web de gestion de vos paramètres d’utilisateur.
 
   = render partial: "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,7 +1,7 @@
 %main#contents(role="main")
   %h1 Se connecter
   %p
-    %strong Attention :
-    l'identifiant et le mot de passe sont <strong>sensibles à la casse</strong>. Respectez les majuscules et minuscules pour ces 2 champs.
+    %strong Attention :
+    l’identifiant et le mot de passe sont <strong>sensibles à la casse</strong>. Respectez les majuscules et minuscules pour ces deux champs.
   = render "devise/sessions/new", id_suffix: ""
   = render "devise/shared/links"

--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -2,14 +2,14 @@
   = link_to "Se connecter", new_session_path(:account)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "S'inscrire", new_registration_path(:account)
+  = link_to "S’inscrire", new_registration_path(:account)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords'
-  = link_to "Mot de passe oublié ?", new_password_path(:account)
+  = link_to "Mot de passe oublié ?", new_password_path(:account)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Pas encore reçu les instructions de confirmation ?", new_confirmation_path(:account)
+  = link_to "Pas encore reçu les instructions de confirmation ?", new_confirmation_path(:account)
   %br/
 - if devise_mapping.lockable? && controller_name != 'unlocks'
-  = link_to "Pas encore reçu les instructions pour déverrouillé votre compte ?", new_unlock_path(:account)
+  = link_to "Pas encore reçu les instructions pour déverrouiller votre compte ?", new_unlock_path(:account)
   %br/

--- a/app/views/diaries/_diary.atom.builder
+++ b/app/views/diaries/_diary.atom.builder
@@ -2,9 +2,9 @@ url = polymorphic_url([diary.owner, diary])
 feed.entry(diary, :url => url) do |entry|
   entry.title(diary.title)
   if diary.node.cc_licensed
-    entry.rights("Licence CC by-sa #{cc_url diary}")
+    entry.rights("Licence CC By‑SA #{cc_url diary}")
   end
-  epub = content_tag(:div, link_to("Télécharger ce contenu au format Epub", "#{url}.epub"))
+  epub = content_tag(:div, link_to("Télécharger ce contenu au format EPUB", "#{url}.epub"))
   entry.content(diary.body + epub + atom_comments_link(diary, url), :type => 'html')
   entry.author do |author|
     author.name(diary.owner.name)

--- a/app/views/diaries/_diary.html.haml
+++ b/app/views/diaries/_diary.html.haml
@@ -4,4 +4,4 @@
   - if current_account && current_account.can_update?(diary)
     - c.actions = link_to("Modifier", edit_user_diary_path(user_id: diary.owner, id: diary), class: 'action')
   - if diary.converted_news
-    - c.notice = "Ce journal a été promu en dépêche : #{link_to_content diary.converted_news}.".html_safe
+    - c.notice = "Ce journal a été promu en dépêche : #{link_to_content diary.converted_news}.".html_safe

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -12,7 +12,7 @@
     = text_field_tag :tags, nil, class: 'autocomplete', 'data-url' => autocomplete_tags_path, value: params[:tags], size: 100
   %p
     = form.check_box :cc_licensed
-    = form.label :cc_licensed, 'Je place ce document sous licence Creative Commons Paternité-Partage des Conditions Initiales à l\'Identique 4.0 (<a href="http://creativecommons.org/licenses/by-sa/4.0/deed.fr">licence CC by-sa</a>)'.html_safe
+    = form.label :cc_licensed, 'Je place ce document sous licence Creative Commons Attribution et Partage dans les mêmes conditions, version 4.0 (<a href="http://creativecommons.org/licenses/by-sa/4.0/deed.fr">licence CC By‑SA 4.0</a>)'.html_safe
 %p
   = form.submit "Prévisualiser", id: "diary_preview"
   = form.submit "Poster le journal", 'data-disable-with' => "Enregistrement en cours" if @preview_mode

--- a/app/views/diaries/edit.html.haml
+++ b/app/views/diaries/edit.html.haml
@@ -13,8 +13,8 @@
       = form.label :forum_id, "Forum"
       = form.select :forum_id, forums_select_list, { include_blank: true }, { required: "required" }
     %p
-      = form.submit "Déplacer vers les forums", data: { confirm: "Êtes-vous sûr de vouloir déplacer ce journal ?" }
+      = form.submit "Déplacer vers les forums", data: { confirm: "Confirmez‑vous vouloir déplacer ce journal ?" }
   = button_to "Proposer en dépêche", convert_user_diary_path(user_id: @diary.owner, id: @diary), class: "ok_button"
-  = button_to "Supprimer", [@diary.owner, @diary], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce journal ?" }, class: "delete_button"
+  = button_to "Supprimer", [@diary.owner, @diary], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer ce journal ?" }, class: "delete_button"
 
   = render 'shared/wiki_help'

--- a/app/views/diaries/index.atom.builder
+++ b/app/views/diaries/index.atom.builder
@@ -1,8 +1,8 @@
 atom_feed(:root_url => diaries_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
   if @user
-    feed.title("LinuxFr.org : les journaux de #{@user.name}")
+    feed.title("LinuxFr.org : les journaux de #{@user.name}")
   else
-    feed.title("LinuxFr.org : les journaux")
+    feed.title("LinuxFr.org : les journaux")
   end
   feed.updated(@nodes.first.try :created_at)
   feed.icon("/favicon.png")

--- a/app/views/doorkeeper/authorizations/new.html.haml
+++ b/app/views/doorkeeper/authorizations/new.html.haml
@@ -1,11 +1,11 @@
 %h1 Autorisation requise
 
 %p
-  Autoriser l'application <strong>#{@pre_auth.client.name}</strong> à utiliser votre compte ?
+  Autoriser l’application <strong>#{@pre_auth.client.name}</strong> à utiliser votre compte ?
 
 - if @pre_auth.scopes.any?
   #oauth-permissions
-    %p Cette application pourra faire les actions suivantes :
+    %p Cette application pourra effectuer les actions suivantes :
     %ul
       - @pre_auth.scopes.each do |scope|
         %li= t scope, scope: [:doorkeeper, :scopes]

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,2 +1,2 @@
-<h1>Code d'autorisation</h1>
+<h1>Code d’autorisation</h1>
 <code id="authorization_code"><%= params[:code] %></code>

--- a/app/views/forums/index.atom.builder
+++ b/app/views/forums/index.atom.builder
@@ -1,8 +1,8 @@
 atom_feed(:root_url => forums_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
   if @user
-    feed.title("LinuxFr.org : les posts de #{@user.name}")
+    feed.title("LinuxFr.org : les publications de #{@user.name}")
   else
-    feed.title("LinuxFr.org : les forums")
+    feed.title("LinuxFr.org : les forums")
   end
   feed.updated(@nodes.first.try :created_at)
   feed.icon("/favicon.png")

--- a/app/views/forums/show.atom.builder
+++ b/app/views/forums/show.atom.builder
@@ -1,5 +1,5 @@
 atom_feed(:root_url => forum_url(@forum), "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : le forum #{@forum.title}")
+  feed.title("LinuxFr.org : le forum #{@forum.title}")
   feed.updated(@posts.first.try :created_at)
   feed.icon("/favicon.png")
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -20,8 +20,8 @@
     %h2 Faites vivre LinuxFr.org
     %p
       Tous les articles sont le fruit du travail de la communauté. Grâce au
-      système de rédaction collaborative du site, on peut s’aider les uns les
-      autres. Pas besoin d'être un expert pour participer.
+      système de rédaction coopérative du site, on peut s’aider les uns les
+      autres. Pas besoin d’être un expert pour participer.
     %ul.people-list
       %li
         %a(href="/redaction") Participer

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -5,7 +5,7 @@
       - @last_comments.each do |comment|
         %li= link_to comment.title, path_for_content(comment.node.content) + "#comment-#{comment.id}"
   %nav#popular_tags
-    %h1 Tags populaires
+    %h1 Étiquettes (tags) populaires
     %ul.tag_cloud
       - @popular_tags.each do |tag|
         %li= link_to tag.name, "/tags/#{tag.name}/public"
@@ -19,10 +19,10 @@
     %ul
       %li= link_to "Mentions légales", '/mentions_legales'
       %li= link_to "Faire un don", '/faire_un_don'
-      %li= link_to "L'équipe LinuxFr.org", '/team'
+      %li= link_to "L’équipe de LinuxFr.org", '/team'
       %li= link_to "Informations sur le site", '/informations'
       %li= link_to "Aide / Foire aux questions", '/aide'
-      %li= link_to "Suivi des suggestions et bugs", '/suivi'
+      %li= link_to "Suivi des suggestions et bogues", '/suivi'
       %li= link_to "Règles de modération", '/regles_de_moderation'
       %li= link_to "Statistiques", '/statistiques'
       %li= link_to "API pour les développeurs", '/developpeur'

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -14,15 +14,15 @@
           - if current_account.has_answers?
             = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Vous avez reçu des réponses à vos commentaires", width: "16px"
           = link_to "Mon tableau de bord", '/tableau-de-bord'
-        %li= link_to "Mes contenus taggés", '/tags'
-        %li= link_to "Les contenus que j'ai lus", '/readings'
+        %li= link_to "Mes contenus étiquetés", '/tags'
+        %li= link_to "Les contenus que j’ai lus", '/readings'
         %li= link_to "Modifier mes préférences", '/compte/modifier'
         %li= link_to "Changer de style", '/stylesheet/modifier'
         %li= button_to "Se déconnecter", '/compte/deconnexion', method: :post, id: "logout"
     - else
-      = render "devise/sessions/new", id_suffix: "_sidebar"
+       render "devise/sessions/new", id_suffix: "_sidebar"
       %ul
-        %li= link_to "Pas de compte&nbsp;? S'inscrire&nbsp;!".html_safe, '/compte/inscription'
+        %li= link_to "Pas de compte ? S’inscrire…".html_safe, '/compte/inscription'
   - if current_account
     = render 'redaction/box'
     - if current_account.try(:board_in_sidebar)

--- a/app/views/layouts/_site.html.haml
+++ b/app/views/layouts/_site.html.haml
@@ -4,15 +4,15 @@
     %a(href="#sidebar") Aller au menu
   %ul
     - if home
-      %li= link_to "Accueil", '/', title: "Page d'accueil du site"
+      %li= link_to "Accueil", '/', title: "Page d’accueil du site"
     %li{class: ("active" if controller_name == "news" || controller_name == "sections")}= link_to "Dépêches", '/news', title: "Actualités, événements et autres nouveautés"
     %li{class: ("active" if controller_name == "diaries" || (controller_name == "users" && action_name == "show"))}= link_to "Journaux", '/journaux', title: "Journaux personnels de nos visiteurs"
     %li{class: ("active" if controller_name == "bookmarks" || (controller_name == "users" && action_name == "show"))}= link_to "Liens", '/liens', title: "Liens remarquables"
-    %li{class: ("active" if controller_name == "forums" || controller_name == "posts")}= link_to "Forums", '/forums', title: "Questions/réponses, petites annonces"
+    %li{class: ("active" if controller_name == "forums" || controller_name == "posts")}= link_to "Forums", '/forums', title: "Questions‑réponses, petites annonces"
     %li{class: ("active" if controller_name == "wiki_pages" || controller_name == "wiki_versions")}= link_to "Wiki", '/wiki', title: "Pages wiki"
     %li{class: ("active" if current_page?("/redaction"))}= link_to "Rédaction", '/redaction', title: "Participez à la rédaction des dépêches"
   = form_tag '/recherche', method: :get do
     .searchbox(role="search")
-      <label for="query" id="label_query">Recherche :</label>
+      <label for="query" id="label_query">Recherche :</label>
       <input id="query" name="q" type="search" placeholder="Rechercher" />
       = submit_tag "Rechercher", name: nil, id: "search_submit", title: "Lancer la recherche sur le site"

--- a/app/views/moderation/_box.html.haml
+++ b/app/views/moderation/_box.html.haml
@@ -3,14 +3,14 @@
     = link_to "Modération", '/moderation'
   - @candidate_news = News.candidate.sorted
   - if @candidate_news.empty?
-    %p Pas de dépêche à modérer
+    %p Aucune dépêche à modérer
   - else
     %ul
       = list_of(@candidate_news) do |news|
         - if news.node.board_status(current_account) != :read
-          = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l'activité sur cette dépêche", width: "16px"
+          = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l’activité sur cette dépêche", width: "16px"
         - if !news.node.vote_by?(current_account.id) && news.node.user_id != current_account.user_id
-          = image_tag "/images/icones/bolt.svg", alt: "Pas de vote", title: "Tu n'as pas voté sur cette dépêche", width: "16px"
+          = image_tag "/images/icones/bolt.svg", alt: "Pas de vote", title: "Tu n’as pas voté sur cette dépêche", width: "16px"
         - if news.acceptable?
           = image_tag "/images/icones/check.svg", alt: "Acceptable", title: "La dépêche est acceptable", width: "16px"
         - elsif news.refusable?

--- a/app/views/moderation/images/index.html.haml
+++ b/app/views/moderation/images/index.html.haml
@@ -3,4 +3,4 @@
 - @images.each do |image|
   .image
     = image.to_html.html_safe
-    = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir bloquer cette image ?" }
+    = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Confirmez‑vous vouloir bloquer cette image ?" }

--- a/app/views/moderation/news/_vote.html.haml
+++ b/app/views/moderation/news/_vote.html.haml
@@ -1,16 +1,16 @@
 #news_vote
   %h1 Votes
   %p
-    Nombre n de admin+modérateurs&nbsp;: #{Account.amr.count}
+    Nombre d’administrateurs+modérateurs : n = #{Account.amr.count}
     %br
-    Seuil d'acceptation (n/6)&nbsp;: &gt; #{News.accept_threshold}
+    Seuil d’acceptation (n/6 votes) : &gt; #{News.accept_threshold}
     %br
-    Seuil de refus (n/5)&nbsp;: &lt; #{News.refuse_threshold}
+    Seuil de refus (n/5 votes) : &lt; #{News.refuse_threshold}
   %p
-    %strong Pour&nbsp;:
+    %strong Pour :
     = @news.voters_for
   %p
-    %strong Contre&nbsp;:
+    %strong Contre :
     = @news.voters_against
   - if current_account.can_vote?(@news)
     %div
@@ -34,12 +34,12 @@
     - elsif @news.refusable? && current_account.can_refuse?(@news)
       = button_to "Refuser", refuse_moderation_news_path(@news), class: "refuse_news"
       - if @news.node.cc_licensed?
-        = button_to "Re-rédaction", rewrite_moderation_news_path(@news), class: "rewrite_news"
+        = button_to "Renvoyer en rédaction", rewrite_moderation_news_path(@news), class: "rewrite_news"
     - elsif current_account.admin?
       %button#admin_49_3.more 49.3 autoritaire
       .more_actions(style="display: none;")
         = button_to "Publier", accept_moderation_news_path(@news), class: "publish_news"
         = button_to "Refuser", refuse_moderation_news_path(@news), class: "refuse_news"
-        = button_to "Revoter", reset_moderation_news_path(@news), class: "reset_news"
+        = button_to "Voter à nouveau", reset_moderation_news_path(@news), class: "reset_news"
         - if @news.node.cc_licensed?
-          = button_to "Re-rédaction", rewrite_moderation_news_path(@news), class: "rewrite_news"
+          = button_to "Retour en rédaction", rewrite_moderation_news_path(@news), class: "rewrite_news"

--- a/app/views/moderation/news/index.html.haml
+++ b/app/views/moderation/news/index.html.haml
@@ -17,7 +17,7 @@
     = list_of(@drafts) do |news|
       = link_to news.title, [:redaction, news]
 
-%h2 15 dernières dépêches refusées
+%h2 Quinze dernières dépêches refusées
 %ul
   = list_of(@refused) do |news|
     = link_to news.title, [:moderation, news]
@@ -26,7 +26,7 @@
   = link_to "Images externes", moderation_images_path
 
 %h2
-  = link_to "Tags publics", moderation_tags_path
+  = link_to "Étiquettes publiques", moderation_tags_path
 
 %h2
   = link_to "Sondages", moderation_polls_path

--- a/app/views/moderation/news/refuse.html.haml
+++ b/app/views/moderation/news/refuse.html.haml
@@ -24,7 +24,7 @@
   = hidden_field_tag :message, 'en'
   = submit_tag "Refuser"
 
-%h2 Ne pas envoyer de courriel (spam)
+%h2 Ne pas envoyer de courriel (indésirable)
 = form_tag refuse_moderation_news_path(@news) do
   = hidden_field_tag :message, 'no'
   = submit_tag "Refuser"

--- a/app/views/moderation/news/show.html.haml
+++ b/app/views/moderation/news/show.html.haml
@@ -32,11 +32,11 @@
         = button_to "Ajouter un paragraphe", redaction_news_paragraphs_path(news_id: @news), remote: true, class: "add_para"
   = link_to "Réorganiser", reorganize_redaction_news_path(@news), class: "reorganize"
   - if @news.urgent?
-    = button_to "Enlever l'urgence", cancel_urgent_redaction_news_path(@news), class: "urgent_news"
+    = button_to "Enlever l’urgence", cancel_urgent_redaction_news_path(@news), class: "urgent_news"
   - else
-    = button_to "Marquer comme urgent", urgent_redaction_news_path(@news), class: "urgent_news", data: { confirm: "Cette dépêche est urgente et doit être publiée au plus tôt ?" }
+    = button_to "Marquer comme urgent", urgent_redaction_news_path(@news), class: "urgent_news", data: { confirm: "Cette dépêche est‑elle urgente et doit‑elle être publiée au plus tôt ?" }
 - else
-  %h2 Dépêche importée !
+  %h2 Dépêche importée !
   = form_for [:moderation, @news] do |form|
     %p
       = form.label :title, "Titre de la dépêche"
@@ -50,7 +50,7 @@
     #form_links
       %fieldset
         %label#label-link-name Nom du lien
-        %label#label-link-url URL
+        %label#label-link-url Adresse
         %label#label-link-lang langue
         %label#label-link-actions actions
       = form.fields_for :links do |lform|

--- a/app/views/moderation/polls/_edition.html.haml
+++ b/app/views/moderation/polls/_edition.html.haml
@@ -3,5 +3,5 @@
   %p
     = link_to "Modifier", edit_moderation_poll_path(id: @poll)
   %h1 Modération
-  = button_to "Publier", accept_moderation_poll_path(@poll), data: { confirm: "Publier le sondage ?" }, class: "ok_button"
-  = button_to "Refuser", refuse_moderation_poll_path(@poll), data: { confirm: "Refuser le sondage ?" }, class: "delete_button"
+  = button_to "Publier", accept_moderation_poll_path(@poll), data: { confirm: "Publier le sondage ?" }, class: "ok_button"
+  = button_to "Refuser", refuse_moderation_poll_path(@poll), data: { confirm: "Refuser le sondage ?" }, class: "delete_button"

--- a/app/views/moderation/polls/edit.html.haml
+++ b/app/views/moderation/polls/edit.html.haml
@@ -2,8 +2,8 @@
   =h1 "Éditer un sondage"
 
   - if @poll.draft?
-    = button_to "Publier", accept_moderation_poll_path(@poll), data: { confirm: "Publier le sondage ?" }, class: "ok_button"
-    = button_to "Refuser", refuse_moderation_poll_path(@poll), data: { confirm: "Refuser le sondage ?" }, class: "delete_button"
+    = button_to "Publier", accept_moderation_poll_path(@poll), data: { confirm: "Publier le sondage ?" }, class: "ok_button"
+    = button_to "Refuser", refuse_moderation_poll_path(@poll), data: { confirm: "Refuser le sondage ?" }, class: "delete_button"
   - else
     = button_to "Mettre en phare", ppp_moderation_poll_path(@poll), class: "ppp_poll"
 

--- a/app/views/moderation/tags/index.html.haml
+++ b/app/views/moderation/tags/index.html.haml
@@ -1,4 +1,4 @@
-%h2 Tags publics par nombre croissant d'occurences
+%h2 Étiquettes (tags) publiques par nombre croissant d’occurences
 
 - @tags.each do |tag|
   .tag

--- a/app/views/news/_form.html.haml
+++ b/app/views/news/_form.html.haml
@@ -23,7 +23,7 @@
 #form_links
   %fieldset
     %label#label-link-name Nom du lien
-    %label#label-link-url URL
+    %label#label-link-url Adresse URL
     %label#label-link-lang langue
     %label#label-link-actions actions
   = form.fields_for :links do |lform|
@@ -38,17 +38,17 @@
   = label_tag :tags
   = text_field_tag :tags, nil, class: 'autocomplete', 'data-url' => autocomplete_tags_path, value: params[:tags], size: 100
 %p
-  Votre dépêche peut être publiée au plus tôt (événement à court terme, envie ou besoin de mise en ligne rapide) ou différée pour régulation du flot de dépêches (meilleure visibilité pour une dépêche longue, moins de dispersion d'attention) :
+  Votre dépêche peut être publiée au plus tôt (événement à court terme, envie ou besoin de mise en ligne rapide) ou différée pour régulation du flot de dépêches (meilleure visibilité pour une dépêche longue, moins de dispersion d’attention) :
 %p
   = form.check_box :urgent
-  = form.label :urgent, 'Cette dépêche est urgente, merci de publier au plus tôt.'
+  = form.label :urgent, 'Cette dépêche est urgente, merci de la publier au plus tôt.'
 %p
-  = form.label :message, "Si vous le souhaitez, vous pouvez laisser un message à l'équipe de modération"
+  = form.label :message, "Si vous le souhaitez, vous pouvez laisser un message à l’équipe de modération"
   <br/>
   = form.text_area :message, spellcheck: 'true', rows: 2
 %p
   = form.check_box :cc_licensed
-  = form.label :cc_licensed, 'Je place ce document sous licence Creative Commons Paternité-Partage des Conditions Initiales à l\'Identique 4.0 (<a href="http://creativecommons.org/licenses/by-sa/4.0/deed.fr">licence CC by-sa</a>). Ceci est conseillé, car cela permet l\'édition collaborative de la dépêche si elle doit être complétée.'.html_safe
+  = form.label :cc_licensed, 'Je place ce document sous licence Creative Commons Paternité - Partage des conditions initiales à l’identique, version 4.0 (<a href="http://creativecommons.org/licenses/by-sa/4.0/deed.fr">licence CC By-SA 4.0</a>). Ceci est conseillé afin de permettre l’édition coopérative de la dépêche si elle doit être complétée.'.html_safe
 %p
   = form.submit "Prévisualiser", id:  "news_preview"
   = form.submit "Soumettre cette dépêche", 'data-disable-with' => "Enregistrement en cours" if @preview_mode

--- a/app/views/news/_news.atom.builder
+++ b/app/views/news/_news.atom.builder
@@ -2,16 +2,16 @@ feed.entry(news, :published => news.node.created_at) do |entry|
   url = news_url news
   entry.title(news.title)
   if news.node.cc_licensed
-    entry.rights("Licence CC by-sa #{cc_url news}")
+    entry.rights("Licence CC By‑SA #{cc_url news}")
   end
   first  = content_tag(:div, news.body)
   links  = content_tag(:ul, news.links.map.with_index do |l,i|
-             content_tag(:li, "lien n°#{i+1} : ".html_safe +
+             content_tag(:li, "lien nᵒ #{i+1} : ".html_safe +
                               link_to(l.title, "https://#{MY_DOMAIN}/redirect/#{l.id}", :title => l.url, :hreflang => l.lang))
            end.join.html_safe)
   second = content_tag(:div, news.second_part)
   if news.published?
-    epub = content_tag(:div, link_to("Télécharger ce contenu au format Epub", "#{url}.epub"))
+    epub = content_tag(:div, link_to("Télécharger ce contenu au format EPUB", "#{url}.epub"))
   else
     epub = ""
   end

--- a/app/views/news/index.atom.builder
+++ b/app/views/news/index.atom.builder
@@ -1,9 +1,9 @@
 # encoding: utf-8
 atom_feed(:root_url => news_index_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
   if @user
-    feed.title("LinuxFr.org : les dépêches de #{@user.name}")
+    feed.title("LinuxFr.org : les dépêches de #{@user.name}")
   else
-    feed.title("LinuxFr.org : les dépêches")
+    feed.title("LinuxFr.org : les dépêches")
   end
   feed.updated(@nodes.first.try :updated_at)
   feed.icon("/favicon.png")

--- a/app/views/news/new.html.haml
+++ b/app/views/news/new.html.haml
@@ -2,11 +2,11 @@
   =h1 "Proposer une dépêche"
 
   %p
-    Les dépêches proposées sont relues et modérées a priori par l'équipe de LinuxFr.org.
-    La ligne éditoriale est expliquée sur la page «&nbsp;<a href="/regles_de_moderation">Règles de modération</a>&nbsp;».
+    Les dépêches proposées sont relues et modérées a priori par l’équipe de LinuxFr.org.
+    La ligne éditoriale est expliquée sur la page « <a href="/regles_de_moderation">Règles de modération</a> ».
 
   - if (news = News.draft.limit(10)).any?
-    %p Les dépêches suivantes sont déjà en cours de rédaction. Vous pouvez y contribuer directement si vous le souhaitez :
+    %p Les dépêches suivantes sont déjà en cours de rédaction. Vous pouvez y contribuer directement si vous le souhaitez :
     %ul
       = list_of(news) do |news|
         = link_to news.title, [:redaction, news]

--- a/app/views/news_notifications/accept.text.erb
+++ b/app/views/news_notifications/accept.text.erb
@@ -1,8 +1,8 @@
 Bonjour,
 
-votre dépêche a été acceptée par l'équipe de modération.
+votre dépêche a été acceptée par l’équipe de modération.
 
-Vous pouvez suivre les commentaires sur :
+Vous pouvez suivre les commentaires sur :
 <%= news_url @news %>
 
 Merci pour votre contribution.
@@ -10,4 +10,4 @@ Merci pour votre contribution.
 Cordialement,
 
 -- 
-L'équipe LinuxFr.org
+L’équipe de LinuxFr.org

--- a/app/views/news_notifications/followup.text.erb
+++ b/app/views/news_notifications/followup.text.erb
@@ -1,13 +1,13 @@
 Bonjour,
 
-vous avez créé ou contribué à la dépêche en rédaction :
+vous avez créé ou contribué à la dépêche en rédaction :
 <%= @news.title %>
 
-Il semblerait qu'elle nécessite encore un peu de travail pour être finalisée.
-Vous pouvez la compléter à cette URL :
+Il semblerait qu’elle nécessite encore un peu de travail pour être finalisée.
+Vous pouvez la compléter à cette URL :
 <%= redaction_news_url @news %>
 
-Merci d'avance.
+Merci d’avance.
 <%= @message %>
 -- 
-L'équipe LinuxFr.org
+L’équipe de LinuxFr.org

--- a/app/views/news_notifications/refuse.text.erb
+++ b/app/views/news_notifications/refuse.text.erb
@@ -1,6 +1,6 @@
 <%= @message %>
 
-Pour rappel, le contenu de la dépêche est copié ci-dessous :
+Pour rappel, le contenu de la dépêche est copié ci‑dessous :
 
 <%= @news.wiki_body %>
 
@@ -11,4 +11,4 @@ Pour rappel, le contenu de la dépêche est copié ci-dessous :
 <%= @news.wiki_second_part %>
 
 -- 
-L'équipe de modération.
+L’équipe de modération.

--- a/app/views/news_notifications/refuse_en.text.erb
+++ b/app/views/news_notifications/refuse_en.text.erb
@@ -2,7 +2,7 @@ Hi,
 
 This is an automatic message.
 
-LinuxFr.org is a French speaking only web site.
+LinuxFr.org is a French speaking only website.
 
 The proposed news was:
 

--- a/app/views/news_notifications/refuse_template.text.erb
+++ b/app/views/news_notifications/refuse_template.text.erb
@@ -3,14 +3,14 @@ Bonjour,
 ceci est un message automatique.
 
 Nous vous remercions pour votre proposition de dépêche, et vous
-encourageons à en proposer d'autres. Cependant votre proposition ne
-peut être publiée telle que.
+encourageons à en proposer d’autres. Cependant, votre proposition ne
+peut être publiée en l’état.
 
 <%= @response.content.html_safe %>
 
 <%= @message -%>
 
-Pour rappel, le contenu de la dépêche est copié ci-dessous :
+Pour rappel, le contenu de la dépêche est copié ci‑dessous :
 
 <%= @news.wiki_body %>
 
@@ -23,4 +23,4 @@ Pour rappel, le contenu de la dépêche est copié ci-dessous :
 Cordialement,
 
 -- 
-L'équipe de modération.
+L’équipe de modération.

--- a/app/views/news_notifications/rewrite.text.erb
+++ b/app/views/news_notifications/rewrite.text.erb
@@ -1,12 +1,12 @@
 Bonjour,
 
-une dépêche à laquelle vous avez contribuée a été renvoyée dans l'espace de
-rédaction par l'équipe de modération.
+Une dépêche à laquelle vous avez contribué a été renvoyée dans l’espace de
+rédaction par l’équipe de modération.
 
-Vous pouvez complétez votre dépêche à cette URL :
+Vous pouvez compléter votre dépêche en vous rendant à cette adresse :
 <%= redaction_news_url @news %>
 
 Cordialement,
 
 -- 
-L'équipe LinuxFr.org
+L’équipe de LinuxFr.org

--- a/app/views/nodes/_actions.html.haml
+++ b/app/views/nodes/_actions.html.haml
@@ -1,8 +1,8 @@
 - if node.content.alternative_formats
   .formats
-    = link_to "Markdown", "#{path_for_content node.content}.md", title: "Télécharger ce contenu au format markdown", class: "action download"
-    = link_to "Epub", "#{path_for_content node.content}.epub", title: "Télécharger ce contenu au format epub", class: "action download"
+    = link_to "Markdown", "#{path_for_content node.content}.md", title: "Télécharger ce contenu au format Markdown", class: "action download"
+    = link_to "EPUB", "#{path_for_content node.content}.epub", title: "Télécharger ce contenu au format EPUB", class: "action download"
 - if current_account && current_account.can_vote?(node.content)
   .vote
-    Ce contenu est-il #{button_to "pertinent", "/nodes/#{node.id}/vote/for", remote: true, class: "relevant"}
-    ou #{button_to "inutile", "/nodes/#{node.id}/vote/against", remote: :true, class: "useless"} ?
+    Ce contenu est‑il #{button_to "pertinent", "/nodes/#{node.id}/vote/for", remote: true, class: "relevant"}
+    ou #{button_to "inutile", "/nodes/#{node.id}/vote/against", remote: :true, class: "useless"} ?

--- a/app/views/nodes/_content.html.haml
+++ b/app/views/nodes/_content.html.haml
@@ -4,10 +4,10 @@
     .meta
       = meta
       - if record.node.cc_licensed?
-        = link_to "Licence CC by-sa.", cc_url(record), rel: 'license'
+        = link_to "Licence CC By‑SA.", cc_url(record), rel: 'license'
       - unless hidden
         %div.tags
-          Tags :
+          Étiquettes :
           - if tags.any?
             %ul.tag_cloud(itemprop="keywords")
               = list_of tags do |tag|
@@ -22,10 +22,10 @@
               = list_of record.node.preview_tags do |tag|
                 = link_to tag, "/tags/#{tag}/public", rel: 'tag'
           - else
-            aucun
+            aucune
           - if current_account && current_account.can_tag?(record)
             .tag_in_place{"data-url" => "/nodes/#{record.node.id}/tags/nouveau"}
-              = link_to "Tagger", "/nodes/#{record.node.id}/tags/nouveau", class: 'action'
+              = link_to "Étiqueter", "/nodes/#{record.node.id}/tags/nouveau", class: 'action'
   .figures
     %meta{itemprop: "interactionCount", content: "UserLikes:#{record.score}"}
     %figure.score(title="Note de ce contenu")= record.score

--- a/app/views/nodes/_front_matter.md.erb
+++ b/app/views/nodes/_front_matter.md.erb
@@ -6,7 +6,7 @@ Authors: <%= raw content.node.user.try(:name) %>
 <%- end -%>
 Date:    <%= raw content.created_at.iso8601 %>
 <%- if content.node.cc_licensed? -%>
-License: CC by-sa
+License: CC By-SA
 <%- end -%>
 Tags:    <%= raw content.node.popular_tags.map(&:name).to_sentence %>
 Score:   <%= raw content.score %>

--- a/app/views/nodes/_node.html.haml
+++ b/app/views/nodes/_node.html.haml
@@ -1,6 +1,6 @@
 #comments
   - feed_of_comments_url = "/nodes/#{node.id}/comments.atom"
-  - feed "Flux Atom des commentaires #{node.content.title}", feed_of_comments_url
+  - feed "Flux Atom des commentaires sur « #{node.content.title} »", feed_of_comments_url
   - unless node.threads.empty?
     %ul.threads
       - node.threads.each do |thread|
@@ -12,5 +12,5 @@
     - caption = "Suivre le flux des commentaires"
     = link_to "#{caption}", feed_of_comments_url, title: "#{caption}"
   %p
-    %strong Note :
-    les commentaires appartiennent à ceux qui les ont postés. Nous n'en sommes pas responsables.
+    %strong Note :
+    les commentaires appartiennent à ceux qui les ont postés. Nous n’en sommes pas responsables.

--- a/app/views/polls/_poll.atom.builder
+++ b/app/views/polls/_poll.atom.builder
@@ -1,7 +1,7 @@
 feed.entry(poll, :published => poll.node.created_at) do |entry|
   url = poll_url(poll)
   entry.title(poll.title)
-  epub = content_tag(:div, link_to("Télécharger ce contenu au format Epub", "#{url}.epub"))
+  epub = content_tag(:div, link_to("Télécharger ce contenu au format EPUB", "#{url}.epub"))
   entry.content(poll_body(poll) + epub + atom_comments_link(poll, url), :type => 'html')
   entry.author do |author|
     author.name(poll.node.user.name)

--- a/app/views/polls/index.atom.builder
+++ b/app/views/polls/index.atom.builder
@@ -1,5 +1,5 @@
 atom_feed(:root_url => polls_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : les sondages")
+  feed.title("LinuxFr.org : les sondages")
   feed.updated(@polls.first.try :created_at)
   feed.icon("/favicon.png")
 

--- a/app/views/polls/show.html.haml
+++ b/app/views/polls/show.html.haml
@@ -4,9 +4,9 @@
   = render @poll
 
   %article.poll-notice
-    La liste des options proposées est volontairement limitée&nbsp;: tout l'intérêt (ou son absence) de ce type de sondage réside dans le fait de forcer les participants à faire un choix.
+    La liste des options proposées est volontairement limitée : tout l’intérêt (ou son absence) de ce type de sondage réside dans le fait de forcer les participants à faire un choix.
     Les réponses multiples sont interdites pour les mêmes raisons.
-    Il est donc inutile de se plaindre au sujet du faible nombre de réponses proposées, ou de l'impossibilité de choisir plusieurs réponses.
-    76,78% des sondés estiment que ces sondages sont ineptes.
+    Il est donc inutile de se plaindre au sujet du faible nombre de réponses proposées ou de l’impossibilité de choisir plusieurs réponses.
+    76,78 % des personnes sondées estiment que ces sondages sont ineptes.
 
   = render @poll.node

--- a/app/views/posts/_post.atom.builder
+++ b/app/views/posts/_post.atom.builder
@@ -1,7 +1,7 @@
 url = forum_post_url(:forum_id => post.forum, :id => post)
 feed.entry(post, :url => url) do |entry|
   entry.title(post.title)
-  epub = content_tag(:div, link_to("Télécharger ce contenu au format Epub", "#{url}.epub"))
+  epub = content_tag(:div, link_to("Télécharger ce contenu au format EPUB", "#{url}.epub"))
   entry.content(post.body + epub + atom_comments_link(post, url), :type => 'html')
   entry.author do |author|
     author.name(post.user.name)

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -8,6 +8,6 @@
     = render form
 
   - if current_account && current_account.can_destroy?(@post)
-    = button_to "Supprimer", [@post.forum, @post], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" }, class: "delete_button"
+    = button_to "Supprimer", [@post.forum, @post], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer ce message ?" }, class: "delete_button"
 
   = render 'shared/wiki_help'

--- a/app/views/readings/index.html.haml
+++ b/app/views/readings/index.html.haml
@@ -3,7 +3,7 @@
     %h1 Mes lectures
     = button_to "Tout oublier", readings_path, method: :delete, class: "delete_button"
 
-=h1 "Les derniers contenus que j'ai lus"
+=h1 "Les derniers contenus que j’ai lus"
 = paginated_section @nodes do
   %main#contents(role="main")
     = render @nodes.map(&:content)

--- a/app/views/redaction/_box.html.haml
+++ b/app/views/redaction/_box.html.haml
@@ -4,6 +4,6 @@
   %ul
     = list_of News.draft.sorted.limit(10) do |news|
       - if news.node.board_status(current_account) == :new_board
-        = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l'activité sur cette dépêche", width: "16px"
+        = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l’activité sur cette dépêche", width: "16px"
       = link_to news.title, [:redaction, news]
-    %li= link_to "(...)", "/redaction#news"
+    %li= link_to "(…)", "/redaction#news"

--- a/app/views/redaction/index.html.haml
+++ b/app/views/redaction/index.html.haml
@@ -8,22 +8,22 @@
       = link_to "Autres statistiques sur la rédaction", "/statistiques/redaction"
 
   #redaction_board
-    =h1 "Tribune rédacteurs"
+    =h1 "Tribune des rédacteurs"
     = render 'boards/large', boards: @boards, box: false
 
 #main_board
   .notice
     - case rand 5
     - when 0
-      = link_to "Êtes-vous inscrit à la liste de diffusion des rédacteurs ?", "/news/une-liste-de-diffusion-pour-les-redacteurs-de-linuxfr-org"
+      = link_to "Avez‑vous pensé à vous abonner à la liste de diffusion des rédacteurs ?", "/news/une-liste-de-diffusion-pour-les-redacteurs-de-linuxfr-org"
     - when 1
-      = link_to "Avez-vous lu la page d'aide à la rédaction ?", "/wiki/redaction"
+      = link_to "Avez‑vous lu la page d’aide à la rédaction ?", "/wiki/redaction"
     - when 2
-      = link_to "Certains auteurs sont récompensés par des livres. Pensez à vérifier votre adresse de courriel (c'est le seul moyen pour le site de vous contacter)", "/compte/modifier"
+      = link_to "Certains auteurs et certaines autrices sont récompensés par des livres. Pensez à vérifier votre adresse de courriel (c’est le seul moyen de vous contacter depuis le site)", "/compte/modifier"
     - when 3
-      = link_to "Connaissez-vous les règles de modération ?", "/regles_de_moderation"
+      = link_to "Connaissez‑vous les règles de modération ?", "/regles_de_moderation"
     - else
-      = link_to "Connaissez-vous le moteur de recherche de photos sous licence Creative Commons ?", "https://ccsearch.creativecommons.org/?search=tux&licenses=ALL-%24&licenses=ALL-MOD&search_fields=title&search_fields=creator&search_fields=tags&per_page=20&work_types=photos&providers=500px&providers=flickr"
+      = link_to "Connaissez‑vous le moteur de recherche de photos sous licence Creative Commons ?", "https://ccsearch.creativecommons.org/?search=tux&licenses=ALL-%24&licenses=ALL-MOD&search_fields=title&search_fields=creator&search_fields=tags&per_page=20&work_types=photos&providers=500px&providers=flickr"
 
   %h2 #{pluralize @drafts.count, "dépêche"} en cours de rédaction
   - feed "Flux atom des dépêches en cours de rédaction", "/redaction/news.atom"
@@ -40,7 +40,7 @@
               %img{src: "/images/icones/pen.svg", alt: "Éditer la dépêche"}
           .meta
             - if activity
-              = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l'activité sur cette dépêche", width: "16px"
+              = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l’activité sur cette dépêche", width: "16px"
             = n.user.try(:name) || n.author_name
             - if n.nb_editors > 0
               = "& #{pluralize n.nb_editors, "participant"}"
@@ -48,9 +48,9 @@
           Modifiée le #{n.updated_at.to_s :date} à #{n.updated_at.to_s :time}
 
   %h2 #{pluralize @news.count, "dépêche"} en cours de modération
-  - feed "Flux atom des dépêches en cours de modération", "/redaction/news/moderation.atom"
+  - feed "Flux Atom des dépêches en cours de modération", "/redaction/news/moderation.atom"
   .notice
-    L'accès à l'espace de modération est réservé aux modérateurs et aux administrateurs.
+    L’accès à l’espace de modération est réservé aux modérateurs et aux administrateurs.
     Seuls les titres des dépêches en modération sont visibles des autres utilisateurs authentifiés.
   - if @news.empty?
     Aucune dépêche.

--- a/app/views/redaction/news/_metadata.html.haml
+++ b/app/views/redaction/news/_metadata.html.haml
@@ -6,5 +6,4 @@
   .second_part_toc
     #{news.second_part_toc}
 - else
-  %p Un sommaire sera automatiquement crée quand le texte sera assez grand.
-
+  %p Un sommaire sera automatiquement créé quand le texte sera assez grand.

--- a/app/views/redaction/news/_toolbar.html.haml
+++ b/app/views/redaction/news/_toolbar.html.haml
@@ -4,7 +4,7 @@
       .second_part_toc
         #{news.second_part_toc}
     - else
-      %p Un sommaire sera automatiquement crée quand le texte sera assez grand.
+      %p Un sommaire sera automatiquement créé quand le texte sera assez grand.
 = image_tag("icones/toc.svg", id: "toolbar-show-toc-button", class: "button popup-event", "data-popup-id": "toolbar-toc", alt: "Sommaire", title: "Sommaire")
 = image_tag("icones/slight_x.svg", id: "toolbar-hide-toc-button", class: "button popup-event", "data-popup-id": "toolbar-toc", alt: "Sommaire", title: "Sommaire")
 = image_tag("icones/right_sidebar.svg", class: "button popup-event", "data-popup-id": "toolpanel", "data-popup-shown": true, alt: "Afficher les détails", title: "Afficher les détails")

--- a/app/views/redaction/news/_toolpanel.html.haml
+++ b/app/views/redaction/news/_toolpanel.html.haml
@@ -17,22 +17,22 @@
     = render 'boards/large', boards: boards, box: false
   #tab-details.tab-content
     %p
-      Titre:
+      Titre :
       = news.title
     %p
-      Rédaction:
+      Rédaction :
       - if news.node.cc_licensed?
         collective
     %p
-      Licence:
+      Licence :
       - if news.node.cc_licensed?
-        = link_to "CC by-sa", cc_url(news), rel: 'license'
+        = link_to "CC By‑SA", cc_url(news), rel: 'license'
     %p
-      Catégorie:
+      Catégorie :
       = link_to(news.section.title, news.section)
     - if news.urgent?
       %p.urgent
-        %b Dépêche urgente !
+        %b Dépêche urgente !
     %hr
     - news_content = strip_tags(news.body + ' ' + news.second_part).strip()
     - sentences = news_content.split(/[…!\.\?]{1,3}/).count - 1
@@ -63,9 +63,9 @@
     = render 'editions', news: news
   #tab-help.tab-content
     - if current_page?(moderation_news_path(news))
-      %p Pour ajouter une note des modérateurs, commencez simplement une ligne par <code>NdM :</code>.
+      %p Pour ajouter une note des modérateurs, commencez simplement une ligne par « <code>N. D. M. :</code> ».
       %p
-        L'icone
+        L’icône
         = image_tag "/images/icones/edit-cut.png", alt: "Suggestion de découpe"
         sert à suggérer où découper entre les première et seconde parties de la dépêche.
     = render 'wiki_help'

--- a/app/views/redaction/news/_topbar.html.haml
+++ b/app/views/redaction/news/_topbar.html.haml
@@ -1,7 +1,7 @@
 #topbar
   - if show_backlink
     .backlink
-      = link_to image_tag("feather-icons/dist/icons/arrow-left.svg", alt: "Retour à l'espace de rédaction"), '/redaction'
+      = link_to image_tag("feather-icons/dist/icons/arrow-left.svg", alt: "Retour à l’espace de rédaction"), '/redaction'
   .lastmodifications
     - revision = news.versions.first
     .revision-table
@@ -11,5 +11,5 @@
       dernière modification
       %br
       %span.revision-date
-        = "le #{I18n.l(revision.created_at, :format => '%d %B %Y à %H:%M:%S')}"
+        = "le #{I18n.l(revision.created_at, :format => '%d %B %Y à %H:%M:%S')}"
   = render 'attendees', attendees: news.attendees, enable_reassign: false

--- a/app/views/redaction/news/_wiki_help.html.haml
+++ b/app/views/redaction/news/_wiki_help.html.haml
@@ -1,20 +1,20 @@
 %p
   Le contenu peut être rédigé avec la syntaxe <a href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>.
 %p
-  Une aide avancée est disponible <a href="/wiki/aide-edition" title="Aide à l'édition">sur le wiki</a>.
+  Une aide avancée est disponible sur <a href="/wiki/aide-edition" title="Aide à l’édition">le wiki</a>.
 %table.vertical-align-top
   %tbody
     %tr.tr-title
       %th{'colspan' => 2} Sections
     %tr
       %td H1
-      %td # Titre de niveau 1
+      %td # Titre de niveau 1
     %tr
       %td H2
-      %td ## Titre de niveau 2
+      %td ## Titre de niveau 2
     %tr
       %td H3
-      %td ### Titre de niveau 3
+      %td ### Titre de niveau 3
     %tr
       %td ---
       %td Ligne de séparation
@@ -31,7 +31,7 @@
       %td ~~barré~~
     %tr
       %td
-      %td `teletype`
+      %td `télétype`
     %tr.tr-title
       %th{'colspan' => 2} Liens
     %tr
@@ -46,13 +46,13 @@
     %tr.tr-title
       %th{'colspan' => 2} Images
     %tr
-      %td <img style="width:40px;" src="https://linuxfr.org/images/sections/27.png" alt="DLFP">
-      %td ![DLFP](https://linuxfr.org/images/sections/27.png)
+      %td <img style="width:40px;" src="https://linuxfr.org/images/sections/27.png" alt="LinuxFr.org">
+      %td ![LinuxFr.org](https://linuxfr.org/images/sections/27.png)
     %tr.tr-title
       %th{'colspan' => 2} Blocs
     %tr
       %td
-      %td * Liste à point
+      %td * Liste à puces
     %tr
       %td
       %td 1. Liste numérotée
@@ -67,7 +67,7 @@
     %tr.tr-title
       %th{'colspan' => 2} Mathématiques
     %tr
-      %td <img style="height: 1em;" src="data:image/svg+xml;base64,PHN2ZyB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGlu%0AayIgc3R5bGU9IndpZHRoOiAyZXg7IGhlaWdodDogMS44NzVleDsgdmVydGlj%0AYWwtYWxpZ246IC0wLjM3NWV4OyBtYXJnaW4tdG9wOiAxcHg7IG1hcmdpbi1y%0AaWdodDogMHB4OyBtYXJnaW4tYm90dG9tOiAxcHg7IG1hcmdpbi1sZWZ0OiAw%0AcHg7IHBvc2l0aW9uOiBzdGF0aWM7ICIgdmlld0JveD0iMCAtNjUxLjU4MDcx%0AMjI5MTYwNTcgODQ3IDc5OS4xNjE0MjQ1ODMyMTE0IiB4bWxucz0iaHR0cDov%0AL3d3dy53My5vcmcvMjAwMC9zdmciPjxkZWZzIGlkPSJNYXRoSmF4X1NWR19n%0AbHlwaHMiPjxwYXRoIGlkPSJTVElYV0VCTUFJTi0yMjk1IiBzdHJva2Utd2lk%0AdGg9IjEwIiBkPSJNNzkyIDI1MmMwIC0yMDUgLTE2NiAtMzcxIC0zNzEgLTM3%0AMXMtMzcxIDE2NiAtMzcxIDM3MXMxNjYgMzcxIDM3MSAzNzFzMzcxIC0xNjYg%0AMzcxIC0zNzF6TTQ1NCAyODVoMjcwYy0xNSAxNDIgLTEyOCAyNTUgLTI3MCAy%0ANzB2LTI3MHpNMzg4IDI4NXYyNzBjLTE0MiAtMTUgLTI1NSAtMTI4IC0yNzAg%0ALTI3MGgyNzB6TTcyNCAyMTloLTI3MHYtMjcwYzE0MiAxNSAyNTUgMTI4IDI3%0AMCAyNzB6TTM4OCAtNTF2MjcwaC0yNzAgYzE1IC0xNDIgMTI4IC0yNTUgMjcw%0AIC0yNzBaIj48L3BhdGg+PC9kZWZzPjxnIHN0cm9rZT0iYmxhY2siIGZpbGw9%0AImJsYWNrIiBzdHJva2Utd2lkdGg9IjAiIHRyYW5zZm9ybT0ibWF0cml4KDEg%0AMCAwIC0xIDAgMCkiPjx1c2UgaHJlZj0iI1NUSVhXRUJNQUlOLTIyOTUiIHhs%0AaW5rOmhyZWY9IiNTVElYV0VCTUFJTi0yMjk1Ij48L3VzZT48L2c+PC9zdmc+%0A" alt="\oplus">
+      %td <img style="height: 1em;" src="data:image/svg+xml;base64,PHN2ZyB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGlu%0AayIgc3R5bGU9IndpZHRoOiAyZXg7IGhlaWdodDogMS44NzVleDsgdmVydGlj%0AYWwtYWxpZ246IC0wLjM3NWV4OyBtYXJnaW4tdG9wOiAxcHg7IG1hcmdpbi1y%0AaWdodDogMHB4OyBtYXJnaW4tYm90dG9tOiAxcHg7IG1hcmdpbi1sZWZ0OiAw%0AcHg7IHBvc2l0aW9uOiBzdGF0aWM7ICIgdmlld0JveD0iMCAtNjUxLjU4MDcx%0AMjI5MTYwNTcgODQ3IDc5OS4xNjE0MjQ1ODMyMTE0IiB4bWxucz0iaHR0cDov%0AL3d3dy53My5vcmcvMjAwMC9zdmciPjxkZWZzIGlkPSJNYXRoSmF4X1NWR19n%0AbHlwaHMiPjxwYXRoIGlkPSJTVElYV0VCTUFJTi0yMjk1IiBzdHJva2Utd2lk%0AdGg9IjEwIiBkPSJNNzkyIDI1MmMwIC0yMDUgLTE2NiAtMzcxIC0zNzEgLTM3%0AMXMtMzcxIDE2NiAtMzcxIDM3MXMxNjYgMzcxIDM3MSAzNzFzMzcxIC0xNjYg%0AMzcxIC0zNzF6TTQ1NCAyODVoMjcwYy0xNSAxNDIgLTEyOCAyNTUgLTI3MCAy%0ANzB2LTI3MHpNMzg4IDI4NXYyNzBjLTE0MiAtMTUgLTI1NSAtMTI4IC0yNzAg%0ALTI3MGgyNzB6TTcyNCAyMTloLTI3MHYtMjcwYzE0MiAxNSAyNTUgMTI4IDI3%0AMCAyNzB6TTM4OCAtNTF2MjcwaC0yNzAgYzE1IC0xNDIgMTI4IC0yNTUgMjcw%0AIC0yNzBaIj48L3BhdGg+PC9kZWZzPjxnIHN0cm9rZT0iYmxhY2siIGZpbGw9%0AImJsYWNrIiBzdHJva2Utd2lkdGg9IjAiIHRyYW5zZm9ybT0ibWF0cml4KDEg%0AMCAwIC0xIDAgMCkiPjx1c2UgaHJlZj0iI1NUSVhXRUJNQUlOLTIyOTUiIHhs%0AaW5rOmhyZWY9IiNTVElYV0VCTUFJTi0yMjk1Ij48L3VzZT48L2c+PC9zdmc+%0A" alt="\oplus"/>
       %td $\oplus$
     %tr
       %td <svg style="width: 2ex; height: 4.875ex; vertical-align: -1.75ex; margin-top: 1px; margin-bottom: 1px; position: static; " viewBox="0 -1381.0887122916058 865 2106.6204245832114" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs id="MathJax_SVG_glyphs"><path id="STIXWEBMAIN-31" stroke-width="10" d="M394 0h-276v15c74 4 95 25 95 80v449c0 34 -9 49 -30 49c-10 0 -27 -5 -45 -12l-27 -10v14l179 91l9 -3v-597c0 -43 20 -61 95 -61v-15Z"></path><path id="STIXWEBMAINI-78" stroke-width="10" d="M243 355l12 -57c70 107 107 143 151 143c24 0 41 -15 41 -37c0 -21 -14 -36 -34 -36c-19 0 -28 17 -52 17c-18 0 -54 -44 -98 -121c0 -7 2 -21 8 -45l32 -134c7 -28 16 -41 30 -41c13 0 24 10 47 40c9 12 13 18 21 28l15 -9c-58 -90 -84 -114 -122 -114 c-32 0 -47 18 -59 68l-29 119l-88 -119c-44 -59 -64 -68 -95 -68s-50 16 -50 42c0 20 14 36 34 36c9 0 19 -4 32 -11c10 -6 20 -9 26 -9c11 0 30 19 51 49l82 116l-28 124c-14 60 -21 68 -46 68c-8 0 -20 -2 -39 -7l-18 -5l-3 16l11 4c61 22 94 29 117 29 c25 0 37 -18 51 -86Z"></path></defs><g stroke="black" fill="black" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g transform="translate(120,0)"><rect stroke="none" width="625" height="60" x="0" y="220"></rect><use href="#STIXWEBMAIN-31" x="60" y="676" xlink:href="#STIXWEBMAIN-31"></use><use href="#STIXWEBMAINI-78" x="86" y="-686" xlink:href="#STIXWEBMAINI-78"></use></g></g></svg>
@@ -76,53 +76,64 @@
       %th{'colspan' => 2} Racourcis claviers
     %tr
       %td ’
-      %td AltGr+Maj+B
+      %td Alt Gr + Maj + B
     %tr
       %td ”
-      %td AltGr+B
+      %td Alt Gr + B
     %tr
       %td «
-      %td AltGr+Z
+      %td Alt Gr + Z
     %tr
       %td »
-      %td AltGr+X
+      %td Alt Gr + X
     %tr
       %td ×
-      %td AltGr+.
+      %td Alt Gr + .
     %tr
       %td ·
-      %td AltGr+:
+      %td Alt Gr + :
     %tr
       %td ÷
-      %td AltGr+Maj+:
+      %td Alt Gr + Maj + :
     %tr
       %td æ et Æ
-      %td AltGr(+Maj)+a
+      %td Alt Gr (+ Maj) + A
     %tr
       %td œ et Œ
-      %td AltGr(+Maj)+o
+      %td Alt Gr (+ Maj) + o
+    %tr
+      %td …
+      %td Compose (Windows droite) puis . puis .
     %tr.tr-title
       %th{'colspan' => 2} Caractères spéciaux
     %tr
-      %td{'colspan' => 2} ½ «  » ’ … ‰ € – — ‐ ⸮
+      %td{'colspan' => 2} ½ ⅓ ¼ ⅕ ⅙ ⅐ ⅛ ⅑ ⅔ ¾
     %tr
-      %td{'colspan' => 2} ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁰
+      %td{'colspan' => 2} ⁽ ⁾ ⁺ ⁻ ⁰ ¹ ²  ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ᵃ ᵇ ᶜ ᵈ ᵉ ᶠ ᵍ ʰ ⁱ ʲ ᵏ ˡ ᵐ ⁿ ᵒ ᵖ ʳ ˢ ᵗ ᵘ ᵛ ʷ ˣ ʸ ᶻ
     %tr
-      %td{'colspan' => 2} æ Æ à À â Â ä Ä
+      %td{'colspan' => 2} « » “ ” ‘ ’ ¿ ¡ ‽ ⸘ …
     %tr
-      %td{'colspan' => 2} ç Ç
+      %td{'colspan' => 2} ‰ × ÷ € ¢ © ® ™ ← ↓ ↑ →
     %tr
-      %td{'colspan' => 2} € é É è È ê Ê ë Ë
+      %td{'colspan' => 2} á Á à À â Â ä Ä ã Ã å Å ā Ā æ Æ
     %tr
-      %td{'colspan' => 2} î Î ï Ï
+      %td{'colspan' => 2} ć Ć ç Ç ĉ Ĉ č Ž
     %tr
-      %td{'colspan' => 2} œ Œ ô Ô ö Ö
+      %td{'colspan' => 2} é É è È ê Ê ě Ě ë Ë ē Ē ẽ Ẽ
     %tr
-      %td{'colspan' => 2} ù Ù û Û ü Ü
+      %td{'colspan' => 2} î Î ï Ï ī Ī
     %tr
-      %td{'colspan' => 2} Espaces fine (&thinsp;) normal (&#32;)
+      %td{'colspan' => 2} ñ Ñ ň Ň ř Ř
     %tr
-      %td{'colspan' => 2} demi-cadratin (&ensp;) <a href="https://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)
+      %td{'colspan' => 2} ô Ô ö Ö ó Ó ò Ò ō Ō õ Õ œ Œ
     %tr
-      %td{'colspan' => 2} Insécables fine (&#8239;) normal (&nbsp;)
+      %td{'colspan' => 2} ú Ú ù Ù û Û ü Ü ů Ů ū Ū
+    %tr
+      %td{'colspan' => 2} ý Ý ÿ Ÿ ȳ Ȳ ž Ž
+    %tr
+      %td{'colspan' => 2} Espaces fine (&thinsp;) et normale (&#32;)
+    %tr
+      %td{'colspan' => 2} Demi‑cadratin (&ensp;) et <a href="https://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)
+    %tr
+      %td{'colspan' => 2} Insécables fine (&#8239;) et normale (&nbsp;)
 

--- a/app/views/redaction/news/index.atom.builder
+++ b/app/views/redaction/news/index.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => redaction_news_index_url) do |feed|
-  feed.title("LinuxFr.org : les dépêches en cours de rédaction")
+  feed.title("LinuxFr.org : les dépêches en cours de rédaction")
   feed.updated(@news.first.try :updated_at)
   feed.icon("/favicon.png")
 

--- a/app/views/redaction/news/index.html.haml
+++ b/app/views/redaction/news/index.html.haml
@@ -1,7 +1,7 @@
 =h1 "Nouvelles dépêches"
 
 - if @news.empty?
-  Aucune dépêche dans l'espace de rédaction.
+  Aucune dépêche dans l’espace de rédaction.
 - else
   = render @news
 

--- a/app/views/redaction/news/moderation.atom.builder
+++ b/app/views/redaction/news/moderation.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => moderation_redaction_news_index_url) do |feed|
-  feed.title("LinuxFr.org : les dépêches en cours de modération")
+  feed.title("LinuxFr.org : les dépêches en cours de modération")
   feed.updated(@news.first.try :updated_at)
   feed.icon("/favicon.png")
 
@@ -8,7 +8,7 @@ atom_feed(:root_url => moderation_redaction_news_index_url) do |feed|
     feed.entry(news, :published => news.node.created_at, :url => redaction_url) do |entry|
       entry.title(news.title)
       if news.node.cc_licensed
-        entry.rights("Licence CC by-sa http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
+        entry.rights("Licence CC By‑SA http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
       end
       entry.content(" ", :type => 'html')
       entry.author do |author|

--- a/app/views/redaction/news/revision.html.haml
+++ b/app/views/redaction/news/revision.html.haml
@@ -9,7 +9,7 @@
   = link_to h1(@news.title), [@news.draft? ? :redaction : :moderation, @news]
 
   %h2
-    #{@version.author_name}&nbsp;: #{@version.message} (#{l @version.created_at})
+    #{@version.author_name} : #{@version.message} (#{l @version.created_at})
   - if @version.title != @previous.title
     %h3 Titre
     %pre

--- a/app/views/redaction/news/show.html.haml
+++ b/app/views/redaction/news/show.html.haml
@@ -32,27 +32,26 @@
 
 = link_to "Réorganiser", reorganize_redaction_news_path(@news), class: "reorganize"
 - if current_account.amr? || current_account.editor? || @news.submitted_by?(current_account)
-  = button_to "Soumettre la dépêche", submit_redaction_news_path(@news), class: "submit_news", data: { confirm: "Une fois la dépêche soumise en modération, vous ne pourrez plus la modifier avant sa publication. Êtes-vous sûr ?" }
+  = button_to "Soumettre la dépêche", submit_redaction_news_path(@news), class: "submit_news", data: { confirm: "Une fois la dépêche soumise en modération, vous ne pourrez plus la modifier avant sa publication. Confirmez‑vous sa soumission ?" }
   - if @news.urgent?
-    = button_to "Enlever l'urgence", cancel_urgent_redaction_news_path(@news), class: "urgent_news"
+    = button_to "Enlever l’urgence", cancel_urgent_redaction_news_path(@news), class: "urgent_news"
   - else
-    = button_to "Marquer comme urgent", urgent_redaction_news_path(@news), class: "urgent_news", data: { confirm: "Cette dépêche est urgente et doit être publiée au plus tôt ?" }
+    = button_to "Marquer comme urgent", urgent_redaction_news_path(@news), class: "urgent_news", data: { confirm: "Cette dépêche est‑elle urgente et doit‑elle être publiée au plus tôt ?" }
 - if current_account.can_erase? @news
-  = button_to "Effacer la dépêche", erase_redaction_news_path(@news), class: "erase_news", data: { confirm: "Effacer cette dépêche créée par erreur ?" }
+  = button_to "Effacer la dépêche", erase_redaction_news_path(@news), class: "erase_news", data: { confirm: "Confirmez‑vous vouloir supprimer cette dépêche ?" }
 - if current_account.can_followup? @news
   %button#followup.more Relancer les rédacteurs
   .more_actions(style="display: none;")
     = form_tag followup_redaction_news_path(@news) do
       %p
         Vous pouvez envoyer un message de relance aux participants de cette dépêche
-        pour leur demander de finaliser cette dépêche. N'hésitez pas à leur donner
-        des précisions (date de sortie imminente, demande de précisions, etc.).
+        pour leur demander de la finaliser. N’hésitez pas à leur donner des 
+        précisions (date de sortie imminente, demande de précisions, etc.).
       = text_area_tag :message, nil, rows: 10
       = submit_tag 'Envoyer'
 
 %article
-  %strong Attention :
+  %strong Attention :
   pour éviter les conflits, une seule personne à la fois peut éditer un paragraphe donné.
-  En pratique, cela veut dire qu'un verrou est posé sur le paragraphe dès qu'une personne passe en mode édition pour ce paragraphe.
-  Le verrou est relaché quand la personne a fini de modifier le paragraphe ou expirera au bout de 20 minutes.
-
+  En pratique, cela veut dire qu’un verrou est posé sur le paragraphe dès qu’une personne passe en mode édition pour ce paragraphe.
+  Le verrou est relâché quand la personne a fini de modifier le paragraphe ou il expirera au bout de vingt minutes.

--- a/app/views/sections/show.atom.builder
+++ b/app/views/sections/show.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => section_url(@section), "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : les dépêches de #{@section.title}")
+  feed.title("LinuxFr.org : les dépêches de #{@section.title}")
   feed.updated(@news.first.try :updated_at)
   feed.icon("/favicon.png")
 

--- a/app/views/sections/show.html.haml
+++ b/app/views/sections/show.html.haml
@@ -2,5 +2,5 @@
   = render 'box'
 
 =h1 @section.title
-- feed "Flux Atom des dépêches de #{@section.title}"
+- feed "Flux Atom des dépêches de « #{@section.title} »"
 = paginated_contents @news, link_to("Proposer une dépêche", "/news/nouveau")

--- a/app/views/shared/_order_navbar.html.haml
+++ b/app/views/shared/_order_navbar.html.haml
@@ -1,5 +1,5 @@
 .order_navbar
-  Trier par :
+  Trier par :
   %ul
     %li= link_to_unless @order == 'created_at', "date", order: 'created_at', page: nil
     %li= link_to_unless @order == 'score', "note", order: 'score', page: nil

--- a/app/views/shared/_wiki_help.html.haml
+++ b/app/views/shared/_wiki_help.html.haml
@@ -1,36 +1,36 @@
 .markdown_cheatsheet
   = image_tag "/images/markdown.png", alt: "Markdown", title: "Ce site prend en charge la syntaxe Markdown", class: "markdown"
-  %h2 Aide mémoire sur la syntaxe Markdown
-  Voir <a href="/wiki/aide-edition" title="Lien du wiki interne LinuxFr.org">la documentation</a> sur le wiki.
+  %h2 Aide‑mémoire sur la syntaxe Markdown
+  Voir la <a href="/wiki/aide-edition" title="Lien du wiki interne LinuxFr.org">documentation</a> sur le wiki.
 
   %table#wiki_help
     %tbody
       %tr
-        %td Caractères spéciaux à copier-coller
-        %td ½ «  » ’ … ‰ € – — ‐ ⸮<br/>¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁰<br/>æ Æ à À â Â ä Ä<br/>ç Ç<br/>€ é É è È ê Ê ë Ë<br/>î Î ï Ï<br/>œ Œ ô Ô ö Ö<br/>ù Ù û Û ü Ü<br/>Espaces fine (&thinsp;) normal (&#32;) demi-cadratin (&ensp;) <a href="https://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)<br/>Insécables fine (&#8239;) normal (&nbsp;)
+        %td Caractères spéciaux à copier‑coller
+        %td ½ ⅓ ¼ ⅕ ⅙ ⅐ ⅛ ⅑ ⅔ ¾<br/>⁽ ⁾ ⁺ ⁻ ⁰ ¹ ²  ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ᵃ ᵇ ᶜ ᵈ ᵉ ᶠ ᵍ ʰ ⁱ ʲ ᵏ ˡ ᵐ ⁿ ᵒ ᵖ ʳ ˢ ᵗ ᵘ ᵛ ʷ ˣ ʸ ᶻ<br/> « » “ ” ‘ ’ ¿ ¡ ‽ ⸘ …<br/>‰ × ÷ € ¢ © ® ™ ← ↓ ↑ →<br/>á Á à À â Â ä Ä ã Ã å Å ā Ā æ Æ<br/>ć Ć ç Ç ĉ Ĉ č Ž<br/>é É è È ê Ê ě Ě ë Ë ē Ē ẽ Ẽ<br/>î Î ï Ï ī Ī<br/>ñ Ñ ň Ň ř Ř<br/>ô Ô ö Ö ó Ó ò Ò ō Ō õ Õ œ Œ<br/>ú Ú ù Ù û Û ü Ü ů Ů ū Ū<br/>ý Ý ÿ Ÿ ȳ Ȳ ž Ž<br/>Espaces fine (&thinsp;) et normale (&#32;) demi‑cadratin (&ensp;) <a href="https://fr.wikipedia.org/wiki/Cadratin">cadratin</a> (&emsp;)<br/>Insécables fine (&#8239;) et normale (&nbsp;)
       %tr
         %td Raccourcis clavier
         %td 
       %tr
-        %td AltGr+Maj+B et AltGr+B
+        %td Alt Gr + Maj + B et Alt Gr + B
         %td apostrophe / guillemet fermant ’ et “
       %tr
-        %td AltGr+Z et AltGr+X
+        %td Alt Gr + Z et Alt Gr + X
         %td guillemets français « et »
       %tr
-        %td AltGr+.
+        %td Alt Gr + .
         %td multiplication ×
       %tr
-        %td AltGr+:
+        %td Alt Gr + :
         %td ·
       %tr
-        %td AltGr+Maj+:
+        %td Alt Gr + Maj + :
         %td division ÷
       %tr
-        %td AltGr(+Maj)+a
+        %td Alt Gr (+ Maj) + A
         %td æ et Æ
       %tr
-        %td AltGr(+Maj)+o
+        %td Alt Gr (+ Maj) + O
         %td œ et Œ
       %tr
         %td _italique_
@@ -39,14 +39,14 @@
         %td **gras**
         %td <strong>gras</strong>
       %tr
-        %td `teletype`
+        %td `télétype`
         %td <code>teletype</code>
       %tr
         %td ~~barré~~
         %td <del>barré</del>
       %tr
         %td $\oplus$
-        %td <img style="max-height: 1em;" src="data:image/svg+xml;base64,PHN2ZyB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGlu%0AayIgc3R5bGU9IndpZHRoOiAyZXg7IGhlaWdodDogMS44NzVleDsgdmVydGlj%0AYWwtYWxpZ246IC0wLjM3NWV4OyBtYXJnaW4tdG9wOiAxcHg7IG1hcmdpbi1y%0AaWdodDogMHB4OyBtYXJnaW4tYm90dG9tOiAxcHg7IG1hcmdpbi1sZWZ0OiAw%0AcHg7IHBvc2l0aW9uOiBzdGF0aWM7ICIgdmlld0JveD0iMCAtNjUxLjU4MDcx%0AMjI5MTYwNTcgODQ3IDc5OS4xNjE0MjQ1ODMyMTE0IiB4bWxucz0iaHR0cDov%0AL3d3dy53My5vcmcvMjAwMC9zdmciPjxkZWZzIGlkPSJNYXRoSmF4X1NWR19n%0AbHlwaHMiPjxwYXRoIGlkPSJTVElYV0VCTUFJTi0yMjk1IiBzdHJva2Utd2lk%0AdGg9IjEwIiBkPSJNNzkyIDI1MmMwIC0yMDUgLTE2NiAtMzcxIC0zNzEgLTM3%0AMXMtMzcxIDE2NiAtMzcxIDM3MXMxNjYgMzcxIDM3MSAzNzFzMzcxIC0xNjYg%0AMzcxIC0zNzF6TTQ1NCAyODVoMjcwYy0xNSAxNDIgLTEyOCAyNTUgLTI3MCAy%0ANzB2LTI3MHpNMzg4IDI4NXYyNzBjLTE0MiAtMTUgLTI1NSAtMTI4IC0yNzAg%0ALTI3MGgyNzB6TTcyNCAyMTloLTI3MHYtMjcwYzE0MiAxNSAyNTUgMTI4IDI3%0AMCAyNzB6TTM4OCAtNTF2MjcwaC0yNzAgYzE1IC0xNDIgMTI4IC0yNTUgMjcw%0AIC0yNzBaIj48L3BhdGg+PC9kZWZzPjxnIHN0cm9rZT0iYmxhY2siIGZpbGw9%0AImJsYWNrIiBzdHJva2Utd2lkdGg9IjAiIHRyYW5zZm9ybT0ibWF0cml4KDEg%0AMCAwIC0xIDAgMCkiPjx1c2UgaHJlZj0iI1NUSVhXRUJNQUlOLTIyOTUiIHhs%0AaW5rOmhyZWY9IiNTVElYV0VCTUFJTi0yMjk1Ij48L3VzZT48L2c+PC9zdmc+%0A" alt="\oplus">
+        %td <img style="max-height: 1em;" src="data:image/svg+xml;base64,PHN2ZyB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGlu%0AayIgc3R5bGU9IndpZHRoOiAyZXg7IGhlaWdodDogMS44NzVleDsgdmVydGlj%0AYWwtYWxpZ246IC0wLjM3NWV4OyBtYXJnaW4tdG9wOiAxcHg7IG1hcmdpbi1y%0AaWdodDogMHB4OyBtYXJnaW4tYm90dG9tOiAxcHg7IG1hcmdpbi1sZWZ0OiAw%0AcHg7IHBvc2l0aW9uOiBzdGF0aWM7ICIgdmlld0JveD0iMCAtNjUxLjU4MDcx%0AMjI5MTYwNTcgODQ3IDc5OS4xNjE0MjQ1ODMyMTE0IiB4bWxucz0iaHR0cDov%0AL3d3dy53My5vcmcvMjAwMC9zdmciPjxkZWZzIGlkPSJNYXRoSmF4X1NWR19n%0AbHlwaHMiPjxwYXRoIGlkPSJTVElYV0VCTUFJTi0yMjk1IiBzdHJva2Utd2lk%0AdGg9IjEwIiBkPSJNNzkyIDI1MmMwIC0yMDUgLTE2NiAtMzcxIC0zNzEgLTM3%0AMXMtMzcxIDE2NiAtMzcxIDM3MXMxNjYgMzcxIDM3MSAzNzFzMzcxIC0xNjYg%0AMzcxIC0zNzF6TTQ1NCAyODVoMjcwYy0xNSAxNDIgLTEyOCAyNTUgLTI3MCAy%0ANzB2LTI3MHpNMzg4IDI4NXYyNzBjLTE0MiAtMTUgLTI1NSAtMTI4IC0yNzAg%0ALTI3MGgyNzB6TTcyNCAyMTloLTI3MHYtMjcwYzE0MiAxNSAyNTUgMTI4IDI3%0AMCAyNzB6TTM4OCAtNTF2MjcwaC0yNzAgYzE1IC0xNDIgMTI4IC0yNTUgMjcw%0AIC0yNzBaIj48L3BhdGg+PC9kZWZzPjxnIHN0cm9rZT0iYmxhY2siIGZpbGw9%0AImJsYWNrIiBzdHJva2Utd2lkdGg9IjAiIHRyYW5zZm9ybT0ibWF0cml4KDEg%0AMCAwIC0xIDAgMCkiPjx1c2UgaHJlZj0iI1NUSVhXRUJNQUlOLTIyOTUiIHhs%0AaW5rOmhyZWY9IiNTVElYV0VCTUFJTi0yMjk1Ij48L3VzZT48L2c+PC9zdmc+%0A" alt="\oplus"/>
       %tr
         %td $$\frac{1}{x}$$
         %td <svg style="width: 2ex; height: 4.875ex; vertical-align: -1.75ex; margin-top: 1px; margin-bottom: 1px; position: static; " viewBox="0 -1381.0887122916058 865 2106.6204245832114" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs id="MathJax_SVG_glyphs"><path id="STIXWEBMAIN-31" stroke-width="10" d="M394 0h-276v15c74 4 95 25 95 80v449c0 34 -9 49 -30 49c-10 0 -27 -5 -45 -12l-27 -10v14l179 91l9 -3v-597c0 -43 20 -61 95 -61v-15Z"></path><path id="STIXWEBMAINI-78" stroke-width="10" d="M243 355l12 -57c70 107 107 143 151 143c24 0 41 -15 41 -37c0 -21 -14 -36 -34 -36c-19 0 -28 17 -52 17c-18 0 -54 -44 -98 -121c0 -7 2 -21 8 -45l32 -134c7 -28 16 -41 30 -41c13 0 24 10 47 40c9 12 13 18 21 28l15 -9c-58 -90 -84 -114 -122 -114 c-32 0 -47 18 -59 68l-29 119l-88 -119c-44 -59 -64 -68 -95 -68s-50 16 -50 42c0 20 14 36 34 36c9 0 19 -4 32 -11c10 -6 20 -9 26 -9c11 0 30 19 51 49l82 116l-28 124c-14 60 -21 68 -46 68c-8 0 -20 -2 -39 -7l-18 -5l-3 16l11 4c61 22 94 29 117 29 c25 0 37 -18 51 -86Z"></path></defs><g stroke="black" fill="black" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g transform="translate(120,0)"><rect stroke="none" width="625" height="60" x="0" y="220"></rect><use href="#STIXWEBMAIN-31" x="60" y="676" xlink:href="#STIXWEBMAIN-31"></use><use href="#STIXWEBMAINI-78" x="86" y="-686" xlink:href="#STIXWEBMAINI-78"></use></g></g></svg>
@@ -54,14 +54,14 @@
         %td &gt; citation
         %td <blockquote>citation</blockquote>
       %tr
-        %td * Liste à puces<br/>* Deuxième élément<br/>&nbsp;&nbsp;* indentation avec 2 espaces au début
-        %td <ul><li>Liste à puces</li><li>Deuxième élément<ul><li>2 espaces au début</li></ul></li></ul>
+        %td * Liste à puces<br/>* Deuxième élément<br/>&nbsp;&nbsp;* indentation avec deux espaces au début
+        %td <ul><li>liste à puces ;</li><li>deuxième élément ;<ul><li>deux espaces au début.</li></ul></li></ul>
       %tr
         %td 1. Liste numérotée<br/>1. Deuxième élément
-        %td <ol><li>Liste numérotée</li><li>Deuxième élément</li></ol>
+        %td <ol><li>liste numérotée ;</li><li>deuxième élément.</li></ol>
       %tr
-        %td ![DLFP](https://linuxfr.org/images/sections/27.png)
-        %td <img src="https://linuxfr.org/images/sections/27.png" alt="DLFP">
+        %td ![LinuxFr.org](https://linuxfr.org/images/sections/27.png)
+        %td <img src="https://linuxfr.org/images/sections/27.png" alt="LinuxFr.org"/>
       %tr
         %td [Kernel](https://www.kernel.org/)
         %td <a href="https://www.kernel.org/">Kernel</a>
@@ -72,8 +72,8 @@
         %td [[[Wiki]]] interne
         %td <a href="/wiki/Wiki">Wiki</a> interne
       %tr
-        %td # Titre de section #<br/><br/>## Sous-titre ##<br/><br/>### Intertitre ###
-        %td <h2>Titre de section</h2><h3>Sous-titre</h3><h4>Intertitre</h4>
+        %td # Titre de section #<br/><br/>## Sous‑titre ##<br/><br/>### Intertitre ###
+        %td <h2>Titre de section</h2><h3>Sous‑titre</h3><h4>Intertitre</h4>
       %tr
         %td ```ruby<br/># Du code avec coloration syntaxique<br/>class Ruby<br/>end<br/>```
         %td

--- a/app/views/static/changelog.html.haml
+++ b/app/views/static/changelog.html.haml
@@ -1,5 +1,5 @@
 %main#contents(role="main")
-  =h1 "Changelog"
+  =h1 "Journal des modifications"
 
   #changelog.body
     %pre
@@ -7,6 +7,6 @@
     %nav
       - if @page > 0
         %span
-          = link_to "Commits plus récents", { page: @page - 1 }, { rel: 'prev' }
+          = link_to "Commits les plus récents", { page: @page - 1 }, { rel: 'prev' }
       %span
-        = link_to "Commits plus anciens", { page: @page + 1 }, { rel: 'next' }
+        = link_to "Commits les plus anciens", { page: @page + 1 }, { rel: 'next' }

--- a/app/views/static/submit_content.html.haml
+++ b/app/views/static/submit_content.html.haml
@@ -3,58 +3,58 @@
 
   .body
     %p
-      Le site vit grâce aux contributions des lecteurs, vous !
+      Le site vit grâce aux contributions des lecteurs : vous !
       Vous pouvez participer en écrivant différents contenus, allant du simple commentaire à la longue dépêche rédigée.
-      Voici de manière plus détaillée les types de contenus que vous pouvez proposer&nbsp;:
+      Voici de manière plus détaillée les types de contenus que vous pouvez proposer :
 
     .free_for_all
       %h2 Les dépêches
       %p
-        Les dépêches servent à publier de l'information sur les thèmes principaux de LinuxFr.org, à savoir Linux et les Logiciels Libres.
-        D'autres thèmes peuvent être abordés, sous réserve que l'équipe de modération juge qu'ils intéressent suffisamment les lecteurs du site.
-        Les dépêches purement commerciales et publicitaires seront rejetées (voir l'ensemble des #{link_to "règles de modération", "/regles_de_moderation" }).
+        Les dépêches servent à publier de l’information sur les thèmes principaux de LinuxFr.org, à savoir Linux et les logiciels libres.
+        D’autres thèmes peuvent être abordés, sous réserve que l’équipe de modération juge qu’ils intéressent suffisamment les lecteurs du site.
+        Les dépêches purement commerciales et publicitaires seront rejetées (voir l’ensemble des #{link_to "règles de modération", "/regles_de_moderation" }).
       %p
         = link_to "Je souhaite proposer une dépêche et la soumettre directement à la modération.", "/news/nouveau"
 
       .authenticated_only
         %p
-          Il est également possible pour les utilisateurs authentifiés de proposer des sujets de dépêches et de les rédiger collaborativement sur l'espace de rédaction.
+          Il est également possible pour les utilisateurs authentifiés de proposer des sujets de dépêches et de les rédiger en coopération sur l’espace de rédaction.
         %p
-          = link_to "Je souhaite commencer une dépêche dans l'espace collaboratif et pouvoir être aidé(e) par d'autres personnes.", "/redaction"
+          = link_to "Je souhaite commencer une dépêche dans l’espace coopératif et pouvoir bénéficier de l’aide d’autres personnes.", "/redaction"
         %p
-          Et il est donc possible pour les utilisateurs authentifiés d'aller dans l'espace de rédaction pour participer à l'écriture des dépêches proposées par d'autres visiteurs.
+          Et il est donc possible pour les utilisateurs authentifiés de se rendre dans l’espace de rédaction afin de participer à l’écriture des dépêches proposées par d’autres visiteurs.
         %p
-          = link_to "Je souhaite participer à l'écriture collaborative d'une dépêche.", "/redaction"
+          = link_to "Je souhaite participer à l’écriture coopérative d’une dépêche.", "/redaction"
 
     .free_for_all
-      %h2 Le suivi des suggestions/bugs
+      %h2 Le suivi des suggestions et bogues
       %p
-        Si vous avez rencontré un bug en parcourant le site web LinuxFr.org, c'est le bon endroit pour le remonter.
+        Si vous avez rencontré un bogue en parcourant le site Web LinuxFr.org, c’est le bon endroit pour en informer les développeurs.
         Vous pouvez également suggérer des évolutions pour le site.
       %p
-        = link_to "Je souhaite remonter un bug ou proposer une évolution", "/suivi/nouveau"
+        = link_to "Je souhaite remonter un bogue ou proposer une évolution", "/suivi/nouveau"
 
     %hr
     %p
-      %strong Note :
+      %strong Note :
       -if account_signed_in?
-        en tant qu'utilisateur authentifié, vous pouvez également déposer les contenus suivants&nbsp;:
+        en tant qu’utilisateur authentifié, vous pouvez également déposer les contenus suivants :
       -else
-        les utilisateurs authentifiés peuvent également proposer les contenus suivants&nbsp;:
+        les utilisateurs authentifiés peuvent également proposer les contenus suivants :
     %hr
 
     .authenticated_only
       %h2 Les journaux
       %p
-        Les journaux sont destinés aux discussions et aux informations qui n'auraient pas leur place en dépêches.
+        Les journaux sont destinés aux discussions et aux informations qui n’auraient pas leur place en tant que dépêches.
       %p
         = link_to "Je souhaite écrire un journal", "/journaux/nouveau"
 
     .authenticated_only
       %h2 Les forums
       %p
-        Les forums servent pour demander de l'aide, poser des questions diverses et variées.
-        C'est aussi le bon endroit pour poster des petites annonces.
+        Les forums servent à demander de l’aide, poser des questions diverses et variées.
+        Ils sont aussi le bon endroit pour poster des petites annonces.
       %p
         = link_to "Je souhaite poster dans les forums", "/posts/nouveau"
 
@@ -62,15 +62,15 @@
       %h2 Les sondages
       %p
         Vous pouvez suggérer un sondage.
-        Si celui-ci retient l'attention de l'équipe de modération (voir les #{link_to "règles de modération","/regles_de_moderation"}), il sera publié.
+        Si celui‑ci retient l’attention de l’équipe de modération (voir les #{link_to "règles de modération","/regles_de_moderation"}), il sera publié.
       %p
         = link_to "Je souhaite suggérer un sondage", "/sondages/nouveau"
 
     .authenticated_only
       %h2 Les liens
       %p
-        La rubrique « liens » est destinée à recevoir les, euh…, liens vers des contenus en rapport avec la ligne éditoriale de LinuxFr.org.
-        En particulier, et de manière non exhaustive, les articles concernant Linux, les logiciels libres, le matériel libre, les arts libres, sont les bienvenus.
+        La rubrique « liens » est destinée à recevoir les… euh… liens vers des contenus en rapport avec la ligne éditoriale de LinuxFr.org.
+        En particulier, et de manière non exhaustive, les articles concernant GNU/Linux, les logiciels libres, le matériel libre, les arts libres, sont les bienvenus.
         Vous pouvez aussi partager ici des liens vers vos propres contenus hébergés ailleurs.
       %p
         = link_to "Je souhaite partager un lien", "/liens/nouveau"
@@ -78,6 +78,6 @@
     .authenticated_only
       %h2 Le wiki
       %p
-        Le wiki est un espace fourre-tout plus ou moins organisé, dont les pages gardent de l'intérêt dans le temps.
+        Le wiki est un espace fourre‑tout plus ou moins organisé, dont les pages gardent de l’intérêt dans le temps.
       %p
         = link_to "Je souhaite écrire une nouvelle page de wiki", "/wiki/nouveau"

--- a/app/views/statistics/anonymous.html.haml
+++ b/app/views/statistics/anonymous.html.haml
@@ -1,25 +1,25 @@
 %main#contents.statistics(role="main")
-  =h1 "Statistiques sur l'utilisateur Anonyme"
+  =h1 "Statistiques sur l’utilisateur Anonyme"
   - width_stats = 400
 
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
-    %p L'utilisateur #{link_to("Anonyme", "/users/anonyme")} est un compte particulier auquel sont rattachés les contenus, commentaires, tags, etc. qui ont été publiés par des comptes supprimés depuis. Cela est différent d'une soumission de dépêche ou ticket de suivi soumis directement sans compte sur le site.
+    %p L’utilisateur #{link_to("Anonyme", "/users/anonyme")} est un compte particulier auquel sont rattachés les contenus, commentaires, étiquettes, etc. qui ont été publiés par des comptes supprimés depuis. Cela est différent des dépêches ou des tickets de suivi soumis directement sans compte sur le site.
 
     %h2 Sommaire
     %ul
       %li=link_to("contenus par type","#contenus_type")
       %li=link_to("contenus par an","#contenus_annee")
       %li=link_to("commentaires par type","#commentaires_type")
-      %li=link_to("tags par type","#tags_type")
-      %li=link_to("tags par an","#tags_annee")
+      %li=link_to("étiquettes par type","#tags_type")
+      %li=link_to("étiquettes par an","#tags_annee")
 
     - if @stats.contents_per_type["Total"] > 1
-      %h2#contenus_type Répartition par type des #{@stats.contents_per_type["Total"]} contenus attribués à Anonyme
+      %h2#contenus_type Répartition par type des #{@stats.contents_per_type["Total"]} contenus attribués à Anonyme
     - else
       %h2#contenus_type Répartition par type des contenus attribués à Anonyme
     %ul
@@ -32,7 +32,7 @@
       %li #{pluralize @stats.contents_per_type["Bookmark"], "lien"}
 
     - if @stats.contents_per_type["Total"] > 1
-      %h2#contenus_annee Répartition annuelle des #{@stats.contents_per_type["Total"]} contenus attribués à Anonyme
+      %h2#contenus_annee Répartition annuelle des #{@stats.contents_per_type["Total"]} contenus attribués à Anonyme
     - else
       %h2#contenus_annee Répartition annuelle des contenus attribués à Anonyme
 
@@ -64,24 +64,24 @@
       %li #{pluralize @stats.comments_per_type["WikiPage"].to_i, "commentaire"} dans les pages de wiki
       %li #{pluralize @stats.comments_per_type["Bookmark"].to_i, "commentaire"} dans les liens
 
-    %h2#tags_type Répartition par type des saisies de tags attribués à Anonyme
+    %h2#tags_type Répartition par type des étiquetages attribués à Anonyme
     %ul
-      %li #{pluralize @stats.taggings_per_type["Diary"].to_i, "tag"} dans les journaux
-      %li #{pluralize @stats.taggings_per_type["Post"].to_i, "tag"} dans les entrées de forums
-      %li #{pluralize @stats.taggings_per_type["News"].to_i, "tag"} dans les dépêches
-      %li #{pluralize @stats.taggings_per_type["Tracker"].to_i, "tag"} dans le système de suivi
-      %li #{pluralize @stats.taggings_per_type["Poll"].to_i, "tag"} dans les sondages
-      %li #{pluralize @stats.taggings_per_type["WikiPage"].to_i, "tag"} dans les pages de wiki
-      %li #{pluralize @stats.taggings_per_type["Bookmark"].to_i, "tag"} dans les liens
+      %li #{pluralize @stats.taggings_per_type["Diary"].to_i, "étiquette"} dans les journaux
+      %li #{pluralize @stats.taggings_per_type["Post"].to_i, "étiquette"} dans les entrées de forums
+      %li #{pluralize @stats.taggings_per_type["News"].to_i, "étiquette"} dans les dépêches
+      %li #{pluralize @stats.taggings_per_type["Tracker"].to_i, "étiquette"} dans le système de suivi
+      %li #{pluralize @stats.taggings_per_type["Poll"].to_i, "étiquette"} dans les sondages
+      %li #{pluralize @stats.taggings_per_type["WikiPage"].to_i, "étiquette"} dans les pages de wiki
+      %li #{pluralize @stats.taggings_per_type["Bookmark"].to_i, "étiquette"} dans les liens
 
-    %h2#tags_annee Répartition annuelle des saisies de tags attribuées à Anonyme
+    %h2#tags_annee Répartition annuelle des étiquetages attribués à Anonyme
 
     %table
       - maxval = @stats.taggings_per_year.values.map(&:values).flatten.max
       %tr
         %th Année
         %th Type
-        %th Tags publiés
+        %th Étiquettes publiées
       - @stats.taggings_per_year.each do |year,tag|
         - newyear = true
         - tag.each do |type,cnt|

--- a/app/views/statistics/applications.html.haml
+++ b/app/views/statistics/applications.html.haml
@@ -5,29 +5,29 @@
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
     %p
-      Des #{link_to("API pour les développeurs", "/developpeur")} sont disponibles pour réaliser des applications/sites interagissant le site.
+      Des #{link_to("API pour les développeurs", "/developpeur")} sont disponibles pour réaliser des applications ou des sites Web interagissant avec le site LinuxFr.org.
 
     %h2 Sommaire
     %ul
       %li=link_to("général","#general")
       %li=link_to("applications par année","#anneejetons")
       %li=link_to("autorisations par année","#anneeautorisations")
-      %li=link_to("jetons d'applications par année","#anneejetons")
+      %li=link_to("jetons d’applications par année","#anneejetons")
 
     %h2#general Général
     %ul
       %li #{pluralize @stats.applications, "application créée", "applications créées"} par #{pluralize @stats.applications_distinct_owners, "utilisateur", "utilisateurs distincts"}
       %li #{pluralize @stats.access_grants, "autorisation créée", "autorisations créées"} pour #{pluralize @stats.access_grants_distinct_applications, "application", "applications distinctes"}
-      %li #{pluralize @stats.access_tokens["total"], "jeton d'application créé", "jetons d'autorisation créés"} pour #{pluralize @stats.access_tokens_distinct_applications, "application", "applications distinctes"}, avec #{pluralize @stats.access_tokens["00"], "jeton actif (utilisé", "jetons actifs (utilisés"} au cours des 24 dernières heures), #{pluralize @stats.access_tokens["10"], "utilisable", "utilisables"} et #{pluralize @stats.access_tokens["11"], "périmé", "périmés"}
+      %li #{pluralize @stats.access_tokens["total"], "jeton d’application créé", "jetons d’applications créés"} pour #{pluralize @stats.access_tokens_distinct_applications, "application", "applications distinctes"}, avec #{pluralize @stats.access_tokens["00"], "jeton actif (utilisé", "jetons actifs (utilisés"} au cours des 24 dernières heures), #{pluralize @stats.access_tokens["10"], "utilisable", "utilisables"} et #{pluralize @stats.access_tokens["11"], "périmé", "périmés"}
 
-    %h2#annee Répartition annuelle des #{@stats.applications} applications
+    %h2#annee Répartition annuelle des #{@stats.applications} applications
     %table
       - maxval = @stats.applications_by_year.values.max
       %tr
         %th Année
-        %th Applications
+        %th Nombre d’applications
       - @stats.applications_by_year.each do |year,cnt|
         %tr
           %td
@@ -35,12 +35,12 @@
           %td
             .stat.content(style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
-    %h2#anneeautorisations Répartition annuelle des #{pluralize @stats.access_grants, "autorisation", "autorisations"}
+    %h2#anneeautorisations Répartition annuelle des #{pluralize @stats.access_grants, "autorisation", "autorisations"}
     %table
       - maxval = @stats.access_grants_by_year.values.max
       %tr
         %th Année
-        %th Autorisations
+        %th Nombre d’autorisations
       - @stats.access_grants_by_year.each do |year,cnt|
         %tr
           %td
@@ -48,13 +48,13 @@
           %td
             .stat.content(style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
-    %h2#anneejetons Répartition annuelle des #{pluralize @stats.access_tokens["total"], "jeton d'application", "jetons d'application"}
+    %h2#anneejetons Répartition annuelle des #{pluralize @stats.access_tokens["total"], "jeton d’application", "jetons d’applications"}
     %table
       - maxval = @stats.access_tokens_by_year.values.map(&:values).flatten.max
       %tr
         %th Année
         %th État
-        %th Tokens
+        %th Nombre de jetons
       - @stats.access_tokens_by_year.each do |year,token|
         - newyear = true
         - token.each do |inactive,cnt|

--- a/app/views/statistics/collective.html.haml
+++ b/app/views/statistics/collective.html.haml
@@ -1,32 +1,32 @@
 %main#contents.statistics(role="main")
-  =h1 "Statistiques sur l'utilisateur Collectif"
+  =h1 "Statistiques sur l’utilisateur Collectif"
   - width_stats = 400
 
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
-    %p L'utilisateur #{link_to("Collectif", "/users/collectif")} est un compte particulier auquel peuvent être attribués les contenus rédigés collaborativement.
+    %p L’utilisateur #{link_to("Collectif", "/users/collectif")} est un compte particulier auquel peuvent être attribués les contenus rédigés collaborativement.
 
     %h2 Sommaire
     %ul
       %li=link_to("contenus par type","#contenus_type")
       %li=link_to("contenus par an","#contenus_annee")
       %li=link_to("commentaires par type","#commentaires_type")
-      %li=link_to("tags par type","#tags_type")
-      %li=link_to("tags par an","#tags_annee")
+      %li=link_to("étiquettes par type","#tags_type")
+      %li=link_to("étiquettes par an","#tags_annee")
 
     - if @stats.contents_per_type["Total"] > 1
-      %h2#contenus_type Répartition par type des #{@stats.contents_per_type["Total"]} contenus attribués à Collectif
+      %h2#contenus_type Répartition par type des #{@stats.contents_per_type["Total"]} contenus attribués à Collectif
     - else
       %h2#contenus_type Répartition par type des contenus attribués à Collectif
     %ul
       %li #{pluralize @stats.contents_per_type["News"], "dépêche"}
 
     - if @stats.contents_per_type["Total"] > 1
-      %h2#contenus_annee Répartition annuelle des #{@stats.contents_per_type["Total"]} contenus attribués à Collectif
+      %h2#contenus_annee Répartition annuelle des #{@stats.contents_per_type["Total"]} contenus attribués à Collectif
     - else
       %h2#contenus_annee Répartition annuelle des contenus attribués à Collectif
 

--- a/app/views/statistics/comments.html.haml
+++ b/app/views/statistics/comments.html.haml
@@ -6,7 +6,7 @@
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     - if @stats.comments["Total"] == 0
       Aucun commentaire
@@ -19,42 +19,41 @@
         %li=link_to("par jour de la semaine","#jour")
 
       - if @stats.comments["Total"] > 1
-        %h2#type Répartition par type des #{@stats.comments["Total"]} commentaires
+        %h2#type Répartition par type des #{@stats.comments["Total"]} commentaires
       - else
         %h2#type Répartition par type
       %ul
         %li
           #{pluralize @stats.comments["Diary"].to_i, "commentaire"} dans #{pluralize @contents.contents["Diary"], "journal", "journaux"}
           -if @contents.contents["Diary"].to_i > 0
-            = "soit #{pluralize (@stats.comments["Diary"]/@contents.contents["Diary"]).round(2), "commentaire"}/journal publié"
+            = ", soit #{pluralize (@stats.comments["Diary"]/@contents.contents["Diary"]).round(2), "commentaire"} par journal publié"
         %li
           #{pluralize @stats.comments["Post"].to_i, "commentaire"} dans #{pluralize @contents.contents["Post"], "entrée"} de forums
           -if @contents.contents["Post"].to_i > 0
-            = "soit #{pluralize (@stats.comments["Post"].to_f/@contents.contents["Post"]).round(2), "commentaire"}/entrée publiée"
+            = ", soit #{pluralize (@stats.comments["Post"].to_f/@contents.contents["Post"]).round(2), "commentaire"} par entrée publiée"
         %li
           #{pluralize @stats.comments["News"].to_i, "commentaire"} dans #{pluralize @contents.contents["News"], "dépêche"}
           -if @contents.contents["News"].to_i > 0
-            = "soit #{pluralize (@stats.comments["News"].to_f/@contents.contents["News"]).round(2), "commentaire"}/dépêche publiée"
+            = ", soit #{pluralize (@stats.comments["News"].to_f/@contents.contents["News"]).round(2), "commentaire"} par dépêche publiée"
         %li
           #{pluralize @stats.comments["Tracker"].to_i, "commentaire"} dans #{pluralize @contents.contents["Tracker"], "entrée"} dans le système de suivi
           -if @contents.contents["Tracker"].to_i > 0
-            = "soit #{pluralize (@stats.comments["Tracker"].to_f/@contents.contents["Tracker"]).round(2), "commentaire"}/entrée publiée"
+            = ", soit #{pluralize (@stats.comments["Tracker"].to_f/@contents.contents["Tracker"]).round(2), "commentaire"} par entrée publiée"
         %li
           #{pluralize @stats.comments["Poll"].to_i, "commentaire"} dans #{pluralize @contents.contents["Poll"], "sondage"}
           -if @contents.contents["Poll"].to_i > 0
-            = "soit #{pluralize (@stats.comments["Poll"].to_f/@contents.contents["Poll"]).round(2), "commentaire"}/sondage publié"
+            = ", soit #{pluralize (@stats.comments["Poll"].to_f/@contents.contents["Poll"]).round(2), "commentaire"} par sondage publié"
         %li
           #{pluralize @stats.comments["WikiPage"].to_i, "commentaire"} dans #{pluralize @contents.contents["WikiPage"], "page"} de wiki
           -if @contents.contents["WikiPage"].to_i > 0
-            = "soit #{pluralize (@stats.comments["WikiPage"].to_f/@contents.contents["WikiPage"]).round(2), "commentaire"}/page publiée"
-
+            = ",soit #{pluralize (@stats.comments["WikiPage"].to_f/@contents.contents["WikiPage"]).round(2), "commentaire"} par page publiée"
         %li
           #{pluralize @stats.comments["Bookmark"].to_i, "commentaire"} dans #{pluralize @contents.contents["Bookmark"], "lien"}
           -if @contents.contents["Bookmark"].to_i > 0
-            = "soit #{pluralize (@stats.comments["Bookmark"].to_f/@contents.contents["Bookmark"]).round(2), "commentaire"}/lien publié"
+            = ", soit #{pluralize (@stats.comments["Bookmark"].to_f/@contents.contents["Bookmark"]).round(2), "commentaire"} par lien publié"
 
       - if @stats.comments["Total"] > 1
-        %h2#annee Répartition annuelle des #{@stats.comments["Total"]} commentaires
+        %h2#annee Répartition annuelle des #{@stats.comments["Total"]} commentaires
       - else
         %h2#annee Répartition annuelle
       %table
@@ -62,7 +61,7 @@
         %tr
           %th Année
           %th Type
-          %th Commentaires
+          %th Nombre de commentaires
         - @stats.comments_by_year.each do |year,comment|
           - newyear=true
           - comment.each do |type,cnt|
@@ -76,7 +75,7 @@
                 .stat(class="content#{type.downcase()}" style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
       - if @stats.comments["Total"] > 1
-        %h2#mois Répartition mensuelle des #{@stats.comments["Total"]} commentaires
+        %h2#mois Répartition mensuelle des #{@stats.comments["Total"]} commentaires
       - else
         %h2#mois Répartition mensuelle
       %table
@@ -84,7 +83,7 @@
         %tr
           %th Mois
           %th Type
-          %th Commentaires
+          %th Nombre de commentaires
         - @stats.comments_by_month.each do |month,comment|
           - newyear=true
           - comment.each do |type,cnt|

--- a/app/views/statistics/contents.html.haml
+++ b/app/views/statistics/contents.html.haml
@@ -6,7 +6,7 @@
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %h2 Sommaire
     %ul
@@ -18,7 +18,7 @@
       %li=link_to("par licence","#licence")
 
     - if @stats.contents["Total"] > 1
-      %h2#type Répartition par type des #{@stats.contents["Total"]} contenus
+      %h2#type Répartition par type des #{@stats.contents["Total"]} contenus
     - else
       %h2#type Répartition par type
     %ul
@@ -34,7 +34,7 @@
       %li #{pluralize @stats.contents["Bookmark"], "lien"}
 
     - if @stats.contents["Total"] > 1
-      %h2#annee Répartition annuelle des #{@stats.contents["Total"]} contenus
+      %h2#annee Répartition annuelle des #{@stats.contents["Total"]} contenus
     - else
       %h2#annee Répartition annuelle
 
@@ -43,7 +43,7 @@
       %tr
         %th Année
         %th Type
-        %th Contenus publiés
+        %th Nombre de contenus publiés
       - @stats.contents_by_year.each do |year,content|
         - newyear = true
         - content.each do |type,cnt|
@@ -57,7 +57,7 @@
               .stat(class="content#{type.downcase()}" style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
     - if @stats.contents["Total"] > 1
-      %h2#mois Répartition mensuelle des #{@stats.contents["Total"]} contenus publiés
+      %h2#mois Répartition mensuelle des #{@stats.contents["Total"]} contenus publiés
     - else
       %h2#mois Répartition mensuelle
 
@@ -66,7 +66,7 @@
       %tr
         %th Mois
         %th Type
-        %th Contenus publiés
+        %th Nombre de contenus publiés
       - @stats.contents_by_month.each do |month,content|
         - newyear = true
         - content.each do |type,cnt|
@@ -79,7 +79,7 @@
             %td
               .stat(class="content#{type.downcase()}" style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
-    %h2#jour Répartition des contenus par jour de la semaine
+    %h2#jour Répartition du nombre de contenus par jour de la semaine
     - if @stats.contents["Total"] > 1
       - maxval = @stats.contents_by_day.map {|a| a["cnt"] }.max
       %table
@@ -100,7 +100,7 @@
       %table
       %table
         %tr
-          %th Années
+          %th Année
           %th Taille moyenne des dépêches (en octets, mise en forme comprise)
         - @stats.news_size.each do |entry|
           %tr
@@ -110,12 +110,12 @@
     - else
       Aucune dépêche publiée
 
-    %h2#licence Évolution du pourcentage de contenus sous licence CC By-Sa
+    %h2#licence Évolution du pourcentage de contenus sous licence CC By‑SA
     - if @stats.contents_by_license.any?
       %table
         %th Année
         %th Type
-        %th Pourcentage de dépêches et journaux sous licence Creative Commons By-Sa
+        %th Pourcentage de dépêches et journaux sous licence Creative Commons By‑SA
         - @stats.contents_by_license.each do |year,content|
           - newyear = true
           - content.each do |type,cnt|

--- a/app/views/statistics/moderation.html.haml
+++ b/app/views/statistics/moderation.html.haml
@@ -7,22 +7,22 @@
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
     %p
       Voir aussi #{link_to "les règles de modération", "/regles_de_moderation"}
 
     %h2 Sommaire
     %ul
       %li= link_to("Jour de modération","#jour")
-      %li= link_to("Critères de modération d'une dépêche", "#criteres")
-      %li= link_to("Temps d'édition et de modération d'une dépêche", "#temps_depeches")
+      %li= link_to("Critères de modération d’une dépêche", "#criteres")
+      %li= link_to("Temps d’édition et de modération d’une dépêche", "#temps_depeches")
       %li= link_to("Actes de modération","#actes")
       %li= link_to("Modération a priori des dépêches", "#apriori_news")
 
-    %h2#criteres Critères de modération d'une dépêche
+    %h2#criteres Critères de modération d’une dépêche
     %ul
-      %li +1 par avis positif et -1 par avis négatif
-      %li Seuil d'acceptation = #{News.accept_threshold}
+      %li +1 par avis positif et −1 par avis négatif
+      %li Seuil d’acceptation = #{News.accept_threshold}
       %li Seuil de refus = #{News.refuse_threshold}
 
     - if @stats.by_day.any?
@@ -42,16 +42,16 @@
             %td
               .stat(class="#{contentclass}" style="width: #{(width_stats * day["cnt"] / maxval).to_i}px;")= day["cnt"]
 
-      %h2#temps_depeches Temps d'édition et de modération d'une dépêche
+      %h2#temps_depeches Temps d’édition et de modération d’une dépêche
       %p
-        Temps passé entre la création d'une dépêche (temps d'édition compris) et sa modération finale&nbsp;:
+        Temps passé entre la création d’une dépêche (temps d’édition compris) et sa modération finale :
       %table.sortable
         %tr
           %th Année
           %th Médiane (h)
-          %th 95e percentile (h)
+          %th 95ᵉ percentile (h)
           %th Moyenne (h)
-          %th Écart-type (h)
+          %th Écart‑type (h)
           %th Minimum (min)
           %th Maximum (h)
         - @stats.average_time.each do |avg|
@@ -95,31 +95,31 @@
     %ul
       %li
         - extra = @stats.news_by_day * 365 / Date.today.yday()
-        = "#{pluralize @stats.news_by_day, "dépêche publiée", "dépêches publiées"} (extrapolation annuelle de #{extra} pour un objectif de #{@goals.news_by_year} "
+        = "#{pluralize @stats.news_by_day, "dépêche publiée", "dépêches publiées"} (extrapolation annuelle de #{extra} pour un objectif de #{@goals.news_by_year} "
         - if (extra >= @goals.news_by_year)
           = image_tag "/images/icones/check.svg", alt: "Objectif atteint", title: "Objectif atteint", width: "16px"
         \)
       %li
         - extra2 = @stats.amr_news_by_day * 365 / Date.today.yday()
-        = "#{pluralize @stats.amr_news_by_day, "dépêche publiée écrite", "dépêches publiées écrites"} par l'équipe du site (extrapolation annuelle de #{extra2} pour un objectif de #{@goals.amr_news_by_year} "
+        = "#{pluralize @stats.amr_news_by_day, "dépêche publiée écrite", "dépêches publiées écrites"} par l’équipe du site (extrapolation annuelle de #{extra2} pour un objectif de #{@goals.amr_news_by_year} "
         - if (extra2 >= @goals.amr_news_by_year)
           = image_tag "/images/icones/check.svg", alt: "Objectif atteint", title: "Objectif atteint", width: "16px"
         \)
 
     %h3#moderation Sur les derniers jours
 
-    %p Il y a eu #{pluralize @stats.moderated_news(7), "dépêche modérée", "dépêches modérées"} (acceptation ou rejet) sur les 7 derniers jours, et #{pluralize @stats.moderated_news(31), "dépêche modérée", "dépêches modérées"} sur les 31 derniers jours.
+    %p Il y a eu #{pluralize @stats.moderated_news(7), "dépêche modérée", "dépêches modérées"} (acceptation ou rejet) sur les sept derniers jours, et #{pluralize @stats.moderated_news(31), "dépêche modérée", "dépêches modérées"} sur les trente‑et‑un derniers jours.
 
     - if Account.amr.any?
       %h4 Équipe de modération actuelle (#{Account.amr.count})
       %table.sortable
         %tr
           %th
-          %th Modérations (7j)
-          %th Modérations (31j)
-          %th Éditions (7j)
-          %th Éditions (31j)
-          %th Votes (31j)
+          %th Modérations (7 j)
+          %th Modérations (31 j)
+          %th Éditions (7 j)
+          %th Éditions (31 j)
+          %th Votes (31 j)
           %th Dernière dépêche
           %th.sorttable_numeric Auteur de dépêches
         - Account.amr.each do |user|
@@ -139,12 +139,12 @@
                   = image_tag "/images/icones/check.svg", alt: "Objectif atteint", title: "Objectif atteint", width: "16px"
 
     - else
-      %h4 Pas d'équipe de modération actuellement
+      %h4 Il n’y a actuellement aucune équipe de modération
 
     %h3#moderationEpoch Depuis Epoch ou le début des données
 
     - if @stats.top_amr.any?
-      %h4 Membre passé ou présent de l'équipe de modération (#{@stats.top_amr.count})
+      %h4 Membre passé ou présent de l’équipe de modération (#{@stats.top_amr.count})
       %table.sortable
         %tr
           %th
@@ -158,4 +158,4 @@
             %td.stat= @stats.nb_votes(user["login"])
             %td.stat= @stats.nb_editions_x_days(user["moderator_id"])
     - else
-      %h4 Pas encore d'équipe de modération
+      %h4 Il n’y a actuellement aucune équipe de modération

--- a/app/views/statistics/prizes.html.haml
+++ b/app/views/statistics/prizes.html.haml
@@ -1,5 +1,5 @@
 %main#contents.statistics(role="main")
-  =h1 "Statistiques d'aide au choix des primables - #{@stats.month.strftime "%m/%Y"}"
+  =h1 "Statistiques d’aide au choix des primables — #{@stats.month.strftime "%m/%Y"}"
 
   .nav
     %span
@@ -8,7 +8,7 @@
       = link_to "Mois suivant", month: @stats.month.next_month.strftime("%m-%Y")
 
   .body
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %h2 Dépêches
 

--- a/app/views/statistics/redaction.html.haml
+++ b/app/views/statistics/redaction.html.haml
@@ -8,12 +8,12 @@
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %section
-      %h2 Nombre d'éditions
+      %h2 Nombre d’éditions
       .top_or_flop
-        %h3 Sur les 7 derniers jours
+        %h3 Sur les sept derniers jours
         %ol
           = list_of @stats.top_week(30) do |stat|
             [#{stat['cnt']}] #{link_to stat['name'], "/users/#{stat['cached_slug']}"}
@@ -26,7 +26,7 @@
     %section
       %h2 Dépêches créées
       .top_or_flop
-        %h3 Sur les 7 derniers jours
+        %h3 Sur les sept derniers jours
         %ol
           = list_of @stats.top_created(7, 30) do |stat|
             [#{stat['cnt']}] #{link_to stat['name'], "/users/#{stat['cached_slug']}"}
@@ -39,7 +39,7 @@
     %section
       %h2 Dépêches modifiées
       .top_or_flop
-        %h3 Sur les 7 derniers jours
+        %h3 Sur les sept derniers jours
         %ol
           = list_of @stats.top_edited(7, 30) do |stat|
             [#{stat['cnt']}] #{link_to stat['name'], "/users/#{stat['cached_slug']}"}

--- a/app/views/statistics/tags.html.haml
+++ b/app/views/statistics/tags.html.haml
@@ -1,12 +1,12 @@
 %main#tags.statistics
-  =h1 "Statistiques sur les tags"
+  =h1 "Statistiques sur les étiquettes (tags)"
   - width_stats = 400
 
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %h2 Sommaire
     %ul
@@ -19,48 +19,47 @@
     %h2#general Général
 
     %ul
-      %li #{@stats.tags} tags dont #{@stats.public_tags} tags publics
-      %li #{@stats.taggings["Total"]} saisies de tags
-      %li tagués en moyenne #{@stats.avg_taggings_count(1)} fois pour les tags publics et #{@stats.avg_taggings_count(0)} fois pour les tags privés
-      %li le plus tagué l'a été #{@stats.max_taggings_count(1)} fois pour les tags publics et #{@stats.max_taggings_count(0)} fois pour les tags privés
+      %li #{@stats.tags} étiquettes, dont #{@stats.public_tags} étiquettes publiques
+      %li #{@stats.taggings["Total"]} étiquetages
+      %li étiquetage en moyenne #{@stats.avg_taggings_count(1)} fois pour les étiquettes publiques et #{@stats.avg_taggings_count(0)} fois pour les étiquettes privées
+      %li le plus étiqueté l’a été #{@stats.max_taggings_count(1)} fois pour les étiquettes publiques et #{@stats.max_taggings_count(0)} fois pour les étiquettes privées
 
     - if @stats.taggings["Total"] > 1
-      %h2#type Répartition par type des #{@stats.taggings["Total"]} saisies de tags
+      %h2#type Répartition par type des #{@stats.taggings["Total"]} étiquetages
     - else
       %h2#type Répartition par type
     %ul
       %li
-        #{pluralize @stats.taggings["Diary"].to_i, "tag"} dans #{pluralize @contents.contents["Diary"], "journal", "journaux"}
+        #{pluralize @stats.taggings["Diary"].to_i, "étiquette"} dans #{pluralize @contents.contents["Diary"], "journal", "journaux"}
         -if @contents.contents["Diary"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["Diary"].to_f/@contents.contents["Diary"]).round(2), "tag"}/journal publié"
+          = "soit #{pluralize (@stats.taggings["Diary"].to_f/@contents.contents["Diary"]).round(2), "étiquette"} par journal publié"
       %li
-        #{pluralize @stats.taggings["Post"].to_i, "tag"} dans #{pluralize @contents.contents["Post"], "entrée"} de forums
+        #{pluralize @stats.taggings["Post"].to_i, "étiquette"} dans #{pluralize @contents.contents["Post"], "entrée"} de forums
         -if @contents.contents["Post"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["Post"].to_f/@contents.contents["Post"]).round(2), "tag"}/entrée publiée"
+          = "soit #{pluralize (@stats.taggings["Post"].to_f/@contents.contents["Post"]).round(2), "étiquette"} par entrée publiée"
       %li
-        #{pluralize @stats.taggings["News"].to_i, "tag"} dans #{pluralize @contents.contents["News"], "dépêche"}
+        #{pluralize @stats.taggings["News"].to_i, "étiquette"} dans #{pluralize @contents.contents["News"], "dépêche"}
         -if @contents.contents["News"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["News"].to_f/@contents.contents["News"]).round(2), "tag"}/dépêche publiée"
+          = "soit #{pluralize (@stats.taggings["News"].to_f/@contents.contents["News"]).round(2), "étiquette"} par dépêche publiée"
       %li
-        #{pluralize @stats.taggings["Tracker"].to_i, "tag"} dans #{pluralize @contents.contents["Tracker"], "entrée"} dans le système de suivi
+        #{pluralize @stats.taggings["Tracker"].to_i, "étiquette"} dans #{pluralize @contents.contents["Tracker"], "entrée"} dans le système de suivi
         -if @contents.contents["Tracker"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["Tracker"].to_f/@contents.contents["Tracker"]).round(2), "tag"}/entrée publiée"
+          = "soit #{pluralize (@stats.taggings["Tracker"].to_f/@contents.contents["Tracker"]).round(2), "étiquette"} par entrée publiée"
       %li
-        #{pluralize @stats.taggings["Poll"].to_i, "tag"} dans #{pluralize @contents.contents["Poll"], "sondage"}
+        #{pluralize @stats.taggings["Poll"].to_i, "étiquette"} dans #{pluralize @contents.contents["Poll"], "sondage"}
         -if @contents.contents["Poll"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["Poll"].to_f/@contents.contents["Poll"]).round(2), "tag"}/sondage publié"
+          = "soit #{pluralize (@stats.taggings["Poll"].to_f/@contents.contents["Poll"]).round(2), "étiquette"} par sondage publié"
       %li
-        #{pluralize @stats.taggings["WikiPage"].to_i, "tag"} dans #{pluralize @contents.contents["WikiPage"], "page"} de wiki
+        #{pluralize @stats.taggings["WikiPage"].to_i, "étiquette"} dans #{pluralize @contents.contents["WikiPage"], "page"} de wiki
         -if @contents.contents["WikiPage"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["WikiPage"].to_f/@contents.contents["WikiPage"]).round(2), "tag"}/page publiée"
-
+          = "soit #{pluralize (@stats.taggings["WikiPage"].to_f/@contents.contents["WikiPage"]).round(2), "étiquette"} par page publiée"
       %li
-        #{pluralize @stats.taggings["Bookmark"].to_i, "tag"} dans #{pluralize @contents.contents["Bookmark"], "lien"}
+        #{pluralize @stats.taggings["Bookmark"].to_i, "étiquette"} dans #{pluralize @contents.contents["Bookmark"], "lien"}
         -if @contents.contents["Bookmark"].to_i > 0
-          = "soit #{pluralize (@stats.taggings["Bookmark"].to_f/@contents.contents["Bookmark"]).round(2), "tag"}/lien publié"
+          = "soit #{pluralize (@stats.taggings["Bookmark"].to_f/@contents.contents["Bookmark"]).round(2), "étiquette"} par lien publié"
 
     - if @stats.taggings["Total"] > 1
-      %h2#annee Répartition annuelle des #{@stats.taggings["Total"]} saisies de tags
+      %h2#annee Répartition annuelle des #{@stats.taggings["Total"]} étiquetages
     - else
       %h2#annee Répartition annuelle
 
@@ -69,7 +68,7 @@
       %tr
         %th Année
         %th Type
-        %th Tags publiés
+        %th Nombre d’étiquetages
       - @stats.taggings_by_year.each do |year,tag|
         - newyear = true
         - tag.each do |type,cnt|
@@ -83,7 +82,7 @@
               .stat(class="content#{type.downcase()}" style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
     - if @stats.taggings["Total"] > 1
-      %h2#mois Répartition mensuelle des #{@stats.taggings["Total"]} saisies de tags
+      %h2#mois Répartition mensuelle des #{@stats.taggings["Total"]} étiquetages
     - else
       %h2#mois Répartition mensuelle
 
@@ -92,7 +91,7 @@
       %tr
         %th Mois
         %th Type
-        %th Tags publiés
+        %th Nombre d’étiquetages
       - @stats.taggings_by_month.each do |month,tag|
         - newyear = true
         - tag.each do |type,cnt|
@@ -105,17 +104,17 @@
             %td
               .stat(class="content#{type.downcase}" style="width: #{(width_stats * cnt / maxval).to_i}px;")= cnt
 
-    %h2#jour Répartition des saisies de tags par jour de la semaine
+    %h2#jour Répartition des étiquetages par jour de la semaine
     - if @stats.taggings["Total"] > 1
       - maxval = @stats.taggings_by_day.map {|a| a["cnt"] }.max
       %table
         %tr
           %th Jour
-          %th Tags publiés
+          %th Nombre d’étiquetages
         - @stats.taggings_by_day.each do |day|
           %tr
             %td.stat= day_name day["day"]
             %td
               .stat.misc(style="width: #{(width_stats * day["cnt"] / maxval).to_i}px;")= day["cnt"]
     - else
-      Aucune saisie de tag
+      Aucun étiquetage

--- a/app/views/statistics/top.html.haml
+++ b/app/views/statistics/top.html.haml
@@ -1,13 +1,13 @@
 %main#contents.statistics(role="main")
-  =h1 "Top ou flop du site"
+  =h1 "Classement des auteurs par nombre de publications"
 
   .body
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %section
       %h2 Nombre de dépêches publiées
       .top_or_flop
-        %h3 Sur les 3 derniers mois
+        %h3 Sur les trois derniers mois
         %ol
           = list_of @stats.top_authors(News, 30, true) do |user, score|
             = link_to_user_with_score(user, score)
@@ -20,7 +20,7 @@
     %section
       %h2 Nombre de journaux
       .top_or_flop
-        %h3 Sur les 3 derniers mois
+        %h3 Sur les trois derniers mois
         %ol
           = list_of @stats.top_authors(Diary, 15, true) do |user, score|
             = link_to_user_with_score(user, score)

--- a/app/views/statistics/tracker.html.haml
+++ b/app/views/statistics/tracker.html.haml
@@ -4,16 +4,16 @@
 
   .body
     %p
-      Ces statistiques ne prennent en compte que le système de suivi, en dehors du spam qui est supprimé, et des demandes envoyées par courriel, messagerie instantanée, lettres d'avocat, kernel panic et autres erreurs Nginx.
+      Ces statistiques ne prennent en compte que le système de suivi, en dehors des indésirables qui sont supprimés, et des demandes envoyées par courriel, messagerie instantanée, lettres d’avocat, kernel panic et autres erreurs Nginx.
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %p
       #{pluralize @stats.states["opened"], "entrée ouverte", "entrées ouvertes" },
       #{pluralize @stats.states["invalid"], "invalide"} et
-      #{pluralize @stats.states["fixed"], "fermée"}, total #{pluralize @stats.states["total"], "envoyée"}
+      #{pluralize @stats.states["fixed"], "fermée"}, soit un total de #{pluralize @stats.states["total"], "entrée envoyée", "entrées envoyées"}
       par #{pluralize @stats.distinct_users, "visiteur"} (en groupant les anonymes).
     %p
       Le temps moyen de résolution est de #{pluralize @stats.average_time, "jour"}.
@@ -22,11 +22,11 @@
 
     - if @stats.top_reporters.any?
       - maxval = @stats.top_reporters.map {|a| a["cnt"] }.max
-      %h2#nbouvertes Utilisateurs ayant ouvert le plus grand nombre d'entrées
+      %h2#nbouvertes Utilisateurs et utilisatrices ayant ouvert le plus grand nombre d’entrées
       %table
         %tr
           %th Personne
-          %th Entrées ouvertes
+          %th Nombre d’entrées ouvertes
         - @stats.top_reporters.each do |user|
           %tr
             %td.stat
@@ -36,11 +36,11 @@
 
     - if @stats.good_workers.any?
       - maxval = @stats.good_workers.map {|a| a["cnt"] }.max
-      %h2#nbfermees Nombre d'entrées fermées par les admins
+      %h2#nbfermees Nombre d’entrées fermées par les administrateurs
       %table
         %tr
           %th Personne
-          %th Entrées fermées
+          %th Nombre d’entrées fermées
         - @stats.good_workers.each do |worker|
           %tr
             %td.stat
@@ -49,16 +49,14 @@
               .stat.misc(style="width: #{(width_stats * worker["cnt"] / maxval).to_i}px;")= worker["cnt"]
 
     - if @stats.by_year.any?
-      %h2#an Entrées classées par année
-      %p
-        État des entrées dans le système de suivi (classées par date d'ouverture)
+      %h2#an Total des entrées par année d’ouverture et par état
       %table
         %tr
           %th Année
           %th Entrées ouvertes
           %th Entrées corrigées
           %th Entrées invalidées
-          %th Total
+          %th Total annuel
         - @stats.by_year.each do |year,states|
           %tr
             %td.stat= year
@@ -71,7 +69,7 @@
             %td.total= states.values.sum
 
     -if @stats.states["total"] > 0
-      %h2#mois Évolution du nombre d'entrées dans le système de suivi
+      %h2#mois Évolution mensuelle du nombre d’entrées dans le système de suivi par état
       - maxval = @stats.by_month.values.max {|a,b| a.values.max <=> b.values.max}.values.max
       %table
         %tr
@@ -100,12 +98,12 @@
             %td
               .stat.month_invalid(style="width:#{width_stats * invalid / maxval / 4}px;")= invalid
 
-      %h2#categorie État des entrées dans le système de suivi par catégorie
+      %h2#categorie Nombre d’entrées dans le système de suivi par catégorie
       - maxval = @stats.by_category.max {|a,b| a["cnt"] <=> b["cnt"]}["cnt"]
       %table
         %tr
           %th Catégorie
-          %th Nombre d'entrées
+          %th Nombre d’entrées
         - @stats.by_category.each do |category|
           %tr
             %td.stat= category["name"]

--- a/app/views/statistics/users.html.haml
+++ b/app/views/statistics/users.html.haml
@@ -1,59 +1,59 @@
 %main#contents.statistics(role="main")
-  =h1 "Statistiques sur les utilisateurs"
+  =h1 "Statistiques sur les utilisatrices et utilisateurs"
   - width_stats = 400
 
   .body
     %strong
       Statistiques mises à jour le #{l Time.now}
 
-    %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+    %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
     %h2 Sommaire
     %ul
       %li= link_to("Général", "#stats_general")
-      %li= link_to("Utilisateurs avec privilèges", "#stats_privileges")
-      %li= link_to("Contenus", "#stats_contenus")
+      %li= link_to("Comptes avec privilèges", "#stats_privileges")
+      %li= link_to("Contenus publiés", "#stats_contenus")
       %li= link_to("Commentaires", "#stats_commentaires")
-      %li= link_to("Tags", "#stats_tags")
+      %li= link_to("Étiquettes (tags)", "#stats_tags")
       %li= link_to("Informations personnelles", "#stats_infosperso")
-      %li= link_to("Domaines pour le courriel", "#stats_courriel")
+      %li= link_to("Domaines des courriels", "#stats_courriel")
       %li= link_to("Utilisation des fonctionnalités", "#stats_fonctionnalites")
       %li= link_to("Style (CSS)", "#stats_css")
-      %li= link_to("Karma des utilisateurs", "#stats_karma")
+      %li= link_to("Karmas des utilisatrices et utilisateurs", "#stats_karma")
       %li= link_to("Ancienneté des comptes", "#stats_anciennete")
-      %li= link_to("Statut des comptes utilisateurs", "#stats_state")
+      %li= link_to("Statuts des comptes", "#stats_state")
 
-      %p= link_to("Retour à l'ensemble des statistiques", "/statistiques")
+      %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
 
   %h2#stats_general Général
   %ul
     %li
-      #{pluralize @stats.nb_users, "utilisateur"} ayant ou ayant eu des comptes
+      #{pluralize @stats.nb_users, "utilisatrice ou utilisateur", "utilisatrices et utilisateurs"} ayant ou ayant eu des comptes
     %li
-      #{pluralize @stats.nb_accounts, "compte"} utilisateur
+      #{pluralize @stats.nb_accounts, "compte"}
     %li
-      #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois avec #{pluralize @stats.no_visit["avg"], "jour"} de moyenne sans visite et #{pluralize @stats.no_visit["stddev"], "jour"} d'écart-type
+      #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois avec #{pluralize @stats.no_visit["avg"], "jour"} de moyenne sans visite et #{pluralize @stats.no_visit["stddev"], "jour"} d’écart‑type
     %li
       #{pluralize @stats.nb_waiting_accounts, "compte"} en attente
     %li
       #{pluralize @stats.nb_closed_accounts, "compte fermé", "comptes fermés"}
 
-  %h2#stats_privileges Utilisateurs avec privilèges
+  %h2#stats_privileges Utilisatrices et utilisateurs avec privilèges
   %p
-    = link_to("Voir l'équipe du site", "/team")
+    = link_to("Voir l’équipe du site", "/team")
 
-  %h2#stats_contenus Contenus
+  %h2#stats_contenus Contenus publiés
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
-      %th Auteurs de
+      %th Type de contenu
       %th Depuis Epoch
       %th Actifs
       %th Depuis un an
       %th Actifs
-      %th Depuis 3 mois
+      %th Depuis trois mois
       %th Actifs
     - @stats.nb_content_authors.each do |authors|
       - last3Months = @stats.nb_content_authors(90, authors["content_type"])[0]
@@ -89,18 +89,18 @@
 
   %h2#stats_commentaires Commentaires
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - last3Months = @stats.nb_comment_authors(90)[0]
     - lastYear = @stats.nb_comment_authors(365)[0]
     - maxval = @stats.nb_recently_used_accounts
     %tr
-      %th Auteurs de
+      %th &nbsp;
       %th Depuis Epoch
       %th Actifs
       %th Depuis un an
       %th Actifs
-      %th Depuis 3 mois
+      %th Depuis trois mois
       %th Actifs
     - last3Months = @stats.nb_comment_authors(90)[0]
     - lastYear = @stats.nb_comment_authors(365)[0]
@@ -120,24 +120,24 @@
         %td
           #{@stats.pctrecent(last3Months["cnt"])}
 
-  %h2#stats_tags Tags
+  %h2#stats_tags Étiquettes (tags)
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
-      %th Auteurs de
+      %th &nbsp;
       %th Depuis Epoch
       %th Actifs
       %th Depuis un an
       %th Actifs
-      %th Depuis 3 mois
+      %th Depuis trois mois
       %th Actifs
     - last3Months = @stats.nb_tag_authors(90)[0]
     - lastYear = @stats.nb_tag_authors(365)[0]
     - @stats.nb_tag_authors.each do |authors|
       %tr
-        %td.stat Tags
+        %td.stat Étiquettes (tags)
         %td
           .stat.misc(style="width: #{(width_stats * authors["cnt"] / maxval).to_i}px;")= authors["cnt"]
         %td
@@ -153,20 +153,20 @@
 
   %h2#stats_infosperso Informations personnelles
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
       %th Information
-      %th Utilisateurs
+      %th Nombre de comptes
       %th Actifs
     %tr
-      %td.stat Site personnel
+      %td.stat Site Web personnel
       %td
         .stat.misc(style="width: #{(width_stats * @stats.filled("homesite") / maxval).to_i}px;")= @stats.filled("homesite")
       %td #{@stats.pctrecent(@stats.filled("homesite"))}
     %tr
-      %td.stat Identifiant Jabber/XMPP
+      %td.stat Adresse XMPP
       %td
         .stat.misc(style="width: #{(width_stats * @stats.filled("jabber_id") / maxval).to_i}px;")= @stats.filled("jabber_id")
       %td #{@stats.pctrecent(@stats.filled("jabber_id"))}
@@ -181,14 +181,14 @@
         .stat.misc(style="width: #{(width_stats * @stats.filled("avatar") / maxval).to_i}px;")= @stats.filled("avatar")
       %td #{@stats.pctrecent(@stats.filled("avatar"))}
 
-  %h2#stats_courriel Domaines pour le courriel
+  %h2#stats_courriel Domaines des courriels
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
-      %th Domaines à plus de trois utilisateurs
-      %th Utilisateurs
+      %th Domaines à plus de trois comptes
+      %th Nombre de comptes
       %th Actifs
     - @stats.top_email_domains.each do |domain|
       %tr
@@ -201,45 +201,45 @@
 
   %h2#stats_fonctionnalites Utilisation des fonctionnalités
   %p
-    Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
       %th Fonctionnalité
-      %th Utilisateurs
+      %th Nombre de comptes
       %th Actifs
     %tr
-      %td.stat Dépêches en page d'accueil
+      %td.stat Dépêches en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("News") / maxval).to_i}px;")= @stats.on_home("News")
       %td #{@stats.pctrecent(@stats.on_home("News"))}
     %tr
-      %td.stat Journaux en page d'accueil
+      %td.stat Journaux en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("Diary") / maxval).to_i}px;")= @stats.on_home("Diary")
       %td #{@stats.pctrecent(@stats.on_home("Diary"))}
     %tr
-      %td.stat Entrées de forum en page d'accueil
+      %td.stat Entrées de forum en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("Post") / maxval).to_i}px;")= @stats.on_home("Post")
       %td #{@stats.pctrecent(@stats.on_home("Post"))}
     %tr
-      %td.stat Sondages en page d'accueil
+      %td.stat Sondages en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("Poll") / maxval).to_i}px;")= @stats.on_home("Poll")
       %td #{@stats.pctrecent(@stats.on_home("Poll"))}
     %tr
-      %td.stat Pages wiki en page d'accueil
+      %td.stat Pages wiki en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("WikiPage") / maxval).to_i}px;")= @stats.on_home("WikiPage")
       %td #{@stats.pctrecent(@stats.on_home("WikiPage"))}
     %tr
-      %td.stat Entrées de suivi en page d'accueil
+      %td.stat Entrées de suivi en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.on_home("Tracker") / maxval).to_i}px;")= @stats.on_home("Tracker")
       %td #{@stats.pctrecent(@stats.on_home("Tracker"))}
     %tr
-      %td.stat Tri chronologique en page d'accueil
+      %td.stat Tri chronologique en page d’accueil
       %td
         .stat.misc(style="width: #{(width_stats * @stats.preferences(:sort_by_date_on_home) / maxval).to_i}px;")= @stats.preferences(:sort_by_date_on_home)
       %td #{@stats.pctrecent(@stats.preferences :sort_by_date_on_home)}
@@ -254,18 +254,18 @@
         .stat.misc(style="width: #{(width_stats * @stats.preferences(:hide_avatar) / maxval).to_i}px;")= @stats.preferences(:hide_avatar)
       %td #{@stats.pctrecent(@stats.preferences :hide_avatar)}
   %p
-    Ces fonctionnalités peuvent être modifiées sur #{ link_to("la page des préférences", "/compte/modifier") }.
+    Ces fonctionnalités peuvent être modifiées sur la page des #{ link_to("préférences", "/compte/modifier") }.
 
   %h2#stats_css Style (CSS)
   %p
     = link_to("Changer de style", "/stylesheet/modifier")
   - if @stats.by_style.any?
-    %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+    %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
     %table
       - maxval = @stats.nb_recently_used_accounts
       %tr
         %th Feuille de style
-        %th Utilisateurs
+        %th Nombre de comptes
         %th Actifs
       - @stats.by_style.each do |style|
         %tr
@@ -275,14 +275,14 @@
             .stat.misc(style="width: #{(width_stats * style["cnt"] / maxval).to_i}px;")= style["cnt"]
           %td #{@stats.pctrecent(style["cnt"])}
   - else
-    Aucune CSS autre que celle par défaut
+    Aucune feuille de style CSS autre que celle par défaut
 
-  %h2#stats_karma Karma des utilisateurs
-  %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+  %h2#stats_karma Karmas des utilisatrices et utilisateurs
+  %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     %tr
       %th Karma
-      %th Utilisateurs
+      %th Nombre de comptes
       %th Actifs
     - @stats.by_karma.each do |karma|
       %tr
@@ -297,13 +297,13 @@
           .stat.misc(style="width: #{(width_stats * karma["cnt"] / maxval).to_i}px;")= karma["cnt"]
         %td #{@stats.pctrecent(karma["cnt"])}
 
-  %h2#stats_anciennete Ancienneté des comptes
-  %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte utilisateur valide et utilisé", "comptes utilisateur valides et utilisés"} au cours des 3 derniers mois&nbsp;:
+  %h2#stats_anciennete Anciennetés des comptes
+  %p Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
   %table
     - maxval = @stats.nb_recently_used_accounts
     %tr
       %th Année
-      %th Utilisateurs
+      %th Nombre de comptes
       %th Actifs
     - @stats.by_year.each do |year|
       %tr
@@ -313,13 +313,13 @@
           .stat.misc(style="width: #{(width_stats * year["cnt"] / maxval).to_i}px;")= year["cnt"]
         %td #{@stats.pctrecent(year["cnt"])}
 
-  %h2#stats_state Statut des comptes utilisateurs
-  %p Statut des comptes utilisateurs par tranche de #{@stats.slot_size}
-  - translate_account = {"accountrecent"=>"comptes récemment utilisés", "accountinactive"=>"comptes fermés", "accountrecentinactive"=>"comptes fermés récemment utilisés", "account"=>"autres comptes", "accountpurged"=>"comptes purgés"}
+  %h2#stats_state Statuts des comptes
+  %p Statut des comptes par tranche de #{@stats.slot_size}
+  - translate_account = {"accountrecent"=>"récemment utilisé", "accountinactive"=>"fermé", "accountrecentinactive"=>"fermé récemment utilisé", "account"=>"autre", "accountpurged"=>"purgés"}
   %table
     %tr
       %th Tranche
-      %th Type
+      %th Statut du compte
       %th Nombre de comptes
     - oldslot = ''
     - remaining = @stats.slot_size

--- a/app/views/stylesheets/edit.html.haml
+++ b/app/views/stylesheets/edit.html.haml
@@ -2,16 +2,16 @@
   =h1 "Feuilles de style alternatives"
 
   %p
-    Votre feuille de style actuelle est&nbsp;: #{@current || "celle par défaut"}.
+    Votre feuille de style actuelle est : #{@current || "celle par défaut"}.
 
   %p
-    Vous souhaitez revenir à la CSS fournie par défaut ? Cliquez sur ce bouton :
+    Vous souhaitez revenir à la CSS fournie par défaut ? Cliquez sur ce bouton :
 
   = button_to "CSS par défaut", "/stylesheet", method: :delete, class: "ok_button"
 
   %p
-    Il est possible de choisir une feuille de style (CSS) alternative pour l'affichage du site LinuxFr.org.
-    Ces feuilles de style ont été écrites par des contributeurs externes du site et leur maintenance n'est pas garantie.
+    Il est possible de choisir une feuille de style (CSS) alternative pour l’affichage du site LinuxFr.org.
+    Ces feuilles de style ont été écrites par des contributeurs externes du site et leur maintenance n’est pas garantie.
     Pour en choisir une, cliquer simplement sur son image.
 
   = form_tag "/stylesheet", method: :put do
@@ -26,22 +26,22 @@
 
   %p
     En plus des feuilles de style proposées sur cette page, vous pouvez utiliser une feuille de style de votre choix.
-    Deux méthodes vous sont proposées : utiliser une feuille de style hébergée sur un autre serveur ou uploader un fichier.
+    Deux méthodes vous sont proposées : utiliser une feuille de style hébergée sur un autre serveur ou téléverserer un fichier.
 
   %p
-    Dans les deux cas, la feuille de style peut être une réécriture complète ou juste l'ajout de quelques règles à la feuille de style par défaut.
-    Pour cela, il vous suffit de commencer votre feuille de style par la déclaration suivante :
+    Dans les deux cas, la feuille de style peut être une réécriture complète ou juste l’ajout de quelques règles à la feuille de style par défaut.
+    Pour cela, il vous suffit de commencer votre feuille de style par la déclaration suivante :
 
   %pre
     @import url("//#{MY_DOMAIN}/assets/application.css");
 
   %div.sideforms
     = form_tag "/stylesheet", method: :put do
-      = label_tag :stylesheet, "Pour utiliser une feuille de style externe, veuillez saisir son URL :"
+      = label_tag :stylesheet, "Pour utiliser une feuille de style externe, veuillez saisir son adresse :"
       = text_field_tag :stylesheet
       = submit_tag 'OK'
 
     = form_tag "/stylesheet", multipart: true do
-      = label_tag :uploaded_stylesheet, "Pour utiliser une feuille de style présente sur votre ordinateur, veuillez l'uploader :"
+      = label_tag :uploaded_stylesheet, "Pour utiliser une feuille de style présente sur votre ordinateur, veuillez la téléverser :"
       = file_field_tag :uploaded_stylesheet
       = submit_tag 'OK'

--- a/app/views/tags/_box.html.haml
+++ b/app/views/tags/_box.html.haml
@@ -1,5 +1,5 @@
 #tags_box.box
-  %h1 Mes tags
+  %h1 Mes étiquettes (tags)
   %ul
     = list_of(@tags) do |tag|
       = link_to tag.name, tag_path(tag.name)

--- a/app/views/tags/_form.html.haml
+++ b/app/views/tags/_form.html.haml
@@ -1,3 +1,3 @@
 = form_tag "/nodes/#{@node.id}/tags" do
   = text_field_tag :tags, nil, class: 'autocomplete', 'data-url' => autocomplete_tags_path
-  = submit_tag "Tagger"
+  = submit_tag "Étiqueter"

--- a/app/views/tags/_hide.html.haml
+++ b/app/views/tags/_hide.html.haml
@@ -1,7 +1,7 @@
 - if current_account && current_account.can_update?(@tag)
   - if @tag.public?
-    %p Le tag #{@tag.name} est actuellement visible.
-    = button_to "Cacher ce tag", hide_tag_path(@tag), class: "delete_button"
+    %p L’étiquette « #{@tag.name} » est actuellement visible.
+    = button_to "Cacher cette étiquette", hide_tag_path(@tag), class: "delete_button"
   - else
-    %p Le tag #{@tag.name} est actuellement caché.
-    = button_to "Rendre à nouveau visible ce tag", hide_tag_path(@tag), class: "ok_button"
+    %p L’étiquette « #{@tag.name} » est actuellement cachée.
+    = button_to "Rendre à nouveau visible cette étiquette", hide_tag_path(@tag), class: "ok_button"

--- a/app/views/tags/_link.html.haml
+++ b/app/views/tags/_link.html.haml
@@ -1,2 +1,2 @@
 .tag_in_place{"data-url" => "/nodes/#{@node.id}/tags/nouveau"}
-  = link_to "Tagger", "/nodes/#{@node.id}/tags/nouveau", class: 'action'
+  = link_to "Étiqueter", "/nodes/#{@node.id}/tags/nouveau", class: 'action'

--- a/app/views/tags/_near.html.haml
+++ b/app/views/tags/_near.html.haml
@@ -1,6 +1,6 @@
 - cache "near_tags/#{@tag.name}" do
   #near_tags_box.box
-    %h1 Les tags connexes
+    %h1 Les étiquettes connexes
     %ul
       = list_of(@tag.near_tags) do |tag|
         %span.score{ title: pluralize(tag.cnt, "contenu commun", "contenus communs") }= tag.cnt

--- a/app/views/tags/index.html.haml
+++ b/app/views/tags/index.html.haml
@@ -2,7 +2,7 @@
   = render "tags/box"
 = render "hide"
 
-=h1 "Tous les contenus que j'ai taggés"
+=h1 "Tous les contenus que j’ai étiquetés"
 = paginated_section @nodes do
   %main#contents(role="main")
     = render @nodes.map(&:content)

--- a/app/views/tags/new.html.haml
+++ b/app/views/tags/new.html.haml
@@ -1,7 +1,7 @@
 %main#contents(role="main")
-  =h1 "Tagger un contenu"
+  =h1 "Étiqueter un contenu"
 
-  %p Vous pouvez mettre plusieurs tags séparés par une espace.
-  %p Les caractères autorisés sont les lettres minuscules, les chiffres et le caractère souligné.
+  %p Vous pouvez mettre plusieurs étiquettes en les séparant par des espaces.
+  %p Les caractères autorisés sont les lettres minuscules, les chiffres et le caractère souligné « _ ».
 
   = render partial: 'form'

--- a/app/views/tags/public.atom.builder
+++ b/app/views/tags/public.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => public_tag_url(@tag.name), "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : les contenus taggés avec #{@tag.name}")
+  feed.title("LinuxFr.org : les contenus étiquetés avec « #{@tag.name} »")
   feed.updated(@nodes.first.try :updated_at)
   feed.icon("/favicon.png")
 

--- a/app/views/tags/public.html.haml
+++ b/app/views/tags/public.html.haml
@@ -2,9 +2,9 @@
   = render "tags/near", on_public: true
 = render "hide"
 
-=h1 "Tous les contenus taggés avec #{@tag.name}"
-- feed "Flux Atom du tag #{@tag.name}"
-- link = link_to("Afficher uniquement les contenus que j'ai taggés avec #{@tag.name}", tag_path(@tag.name)) if current_account
+=h1 "Tous les contenus étiquetés avec « #{@tag.name} »"
+- feed "Flux Atom étiqueté « #{@tag.name} »"
+- link = link_to("Afficher uniquement les contenus que j’ai étiquetés avec « #{@tag.name} »", tag_path(@tag.name)) if current_account
 = paginated_section @nodes, link do
   %main#contents(role="main")
     = render @nodes.map(&:content)

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -3,8 +3,8 @@
   = render "tags/box"
 = render "hide"
 
-=h1 "Tous les contenus que j'ai taggés avec #{@tag.name}"
-- link = link_to("Afficher tous les contenus taggés avec #{@tag.name}", public_tag_path(@tag.name))
+=h1 "Tous les contenus que j’ai étiquetés avec « #{@tag.name} »"
+- link = link_to("Afficher tous les contenus étiquetés avec « #{@tag.name} »", public_tag_path(@tag.name))
 = paginated_section @nodes, link do
   %main#contents(role="main")
     = render @nodes.map(&:content)

--- a/app/views/trackers/_tracker.html.haml
+++ b/app/views/trackers/_tracker.html.haml
@@ -1,8 +1,8 @@
 = article_for tracker do |c|
-  - c.title = "#{link_to "Suivi - #{tracker.category_title}", "/suivi?tracker%5Bcategory_id%5D=#{tracker.category_id}", class: "topic"} #{link_to tracker.title, tracker}".html_safe
+  - c.title = "#{link_to "Suivi — #{tracker.category_title}", "/suivi?tracker%5Bcategory_id%5D=#{tracker.category_id}", class: "topic"} #{link_to tracker.title, tracker}".html_safe
   - c.meta = capture do
     %span.tracker_id ##{tracker.id}
     = posted_by(tracker)
-    État de l'entrée&nbsp;: #{tracker.state_name}.
+    État de l’entrée : #{tracker.state_name}.
   - if current_account && current_account.can_update?(tracker)
     - c.actions = link_to("Modifier", "/suivi/#{tracker.to_param}/modifier", class: 'action')

--- a/app/views/trackers/comments.atom.builder
+++ b/app/views/trackers/comments.atom.builder
@@ -1,5 +1,5 @@
 atom_feed(:root_url => trackers_url) do |feed|
-  feed.title("LinuxFr.org : les commentaires du suivi")
+  feed.title("LinuxFr.org : les commentaires du suivi")
   feed.updated(@comments.last.try :created_at)
   feed.icon("/favicon.png")
 
@@ -7,7 +7,7 @@ atom_feed(:root_url => trackers_url) do |feed|
     tracker = comment.node.content
     feed.entry(comment, :url => "#{tracker_url tracker}#comment-#{comment.id}") do |entry|
       entry.title("##{tracker.id} : #{comment.title}")
-      title = content_tag(:h2, "Entrée du suivi : #{tracker.title}")
+      title = content_tag(:h2, "Entrée du suivi « #{tracker.title} »")
       entry.content(title + comment.body, :type => 'html')
       entry.author do |author|
         author.name(comment.user_name)

--- a/app/views/trackers/edit.html.haml
+++ b/app/views/trackers/edit.html.haml
@@ -7,6 +7,6 @@
   = form_for @tracker do |form|
     = render form
 
-  = button_to "Supprimer", @tracker, method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cette entrée du tracker ?" }, class: "delete_button"
+  = button_to "Supprimer", @tracker, method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer cette entrée du suivi ?" }, class: "delete_button"
 
   = render 'shared/wiki_help'

--- a/app/views/trackers/index.atom.builder
+++ b/app/views/trackers/index.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => trackers_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : les entrées du suivi")
+  feed.title("LinuxFr.org : les entrées du suivi")
   feed.updated(@trackers.first.try :created_at)
   feed.icon("/favicon.png")
 

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -1,9 +1,9 @@
-=h1 "Le suivi des suggestions et bugs concernant le site"
+=h1 "Le suivi des suggestions et bogues concernant le site"
 - feed "Flux Atom du suivi"
 - feed "Flux Atom des commentaires", "/suivi/comments.atom"
 
 %nav.toolbox
-  %h2 <strong>#{Tracker.opened.count}</strong> entrées ouvertes sur un total de #{Tracker.count}
+  %h2 <strong>#{pluralize Tracker.opened.count, "entrée ouverte", "entrées ouvertes"}</strong> sur un total de #{Tracker.count}
   .follow_feed
     = link_to "Flux Atom du suivi", "/suivi.atom"
   .new_content
@@ -12,30 +12,30 @@
 = form_for @tracker, url: trackers_path, method: :get do |f|
   %h2 Filtrer les entrées du suivi
   %p
-    = f.label :state, "État&nbsp;: ".html_safe
+    = f.label :state, "État : "
     = f.select :state, Tracker::States.invert, include_blank: true
   %p
-    = f.label :category_id, "Catégorie&nbsp;: ".html_safe
+    = f.label :category_id, "Catégorie : "
     = f.collection_select :category_id, Category.all, :id, :title, include_blank: true
   %p
-    = f.label :assigned_to_user_id, "Assigné à&nbsp;: ".html_safe
+    = f.label :assigned_to_user_id, "Assigné à : "
     = f.collection_select :assigned_to_user_id, Account.admin, :id, :name, include_blank: true
   %p
-    = label_tag :order, "Trier par&nbsp;: ".html_safe
-    = select_tag :order, options_for_select({ "Date d'ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)
+    = label_tag :order, "Trier par : "
+    = select_tag :order, options_for_select({ "Date d’ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)
   %p
     = submit_tag "Filtrer"
 
 %main#contents(role="main")
   - if @trackers.empty?
     %p
-      Pas d'entrées dans le suivi
+      Aucune entrée dans le suivi
   - else
     %table#tracker
       %tr
-        %th N°
+        %th Nᵒ
         %th Titre
-        %th Date d'ouverture
+        %th Date d’ouverture
         %th Assigné à
         %th Envoyé par
         %th Catégorie

--- a/app/views/trackers/new.html.haml
+++ b/app/views/trackers/new.html.haml
@@ -1,18 +1,18 @@
 %main#contents(role="main")
-  =h1 "Signaler un bug ou proposer une suggestion dans le suivi"
+  =h1 "Signaler un bogue ou proposer une suggestion dans le suivi"
 
   - if @preview_mode
     = render "preview", preview: @tracker
   - else
-    = image_tag "/images/dessins/geekscottes_068.png", alt: "Tu coderas pour moi !", title: "Tu coderas pour moi ! - © Johann 'nojhan' Dréo : 2007-11-07 - Licence CC By-Sa 2.5"
+    = image_tag "/images/dessins/geekscottes_068.png", alt: "Tu coderas pour moi !", title: "Tu coderas pour moi ! — © Johann « nojhan » Dréo, 7 novembre 2007 — Licence CC‑By‑SA 2.5"
 
   %p
     Des <a href="/regles_de_moderation">règles de modération</a> sont applicables au suivi (et au reste du site).
 
   .notice
-    %strong Attention :
-    les entrées du suivi sont publiques.
-    Pour les éventuelles failles de sécurité, nous préférerions que vous nous avertissiez au préalable en envoyant un courriel à &lt;moderateurs_@_linuxfr.org&gt;.
+    %strong Attention :<br/>
+    Les entrées du suivi sont publiques.
+    Pour les éventuelles failles de sécurité, nous préférerions que vous nous avertissiez au préalable en envoyant un courriel à &lt;moderateurs_@_linuxfr.org&gt;.
 
   = form_for @tracker do |form|
     = render form

--- a/app/views/users/_recent.html.haml
+++ b/app/views/users/_recent.html.haml
@@ -6,31 +6,31 @@
   - if @user.account && @user.account.viewable_by?(current_account)
     - a = @user.account
     %ul
-      %li Courriel&nbsp;: #{a.email}
-      %li Rôle&nbsp;: #{a.display_role(@user.nodes.where(public: true).count>0)}
-      %li Dernière connexion&nbsp;: #{a.current_sign_in_at ? l(@user.account.current_sign_in_at) : "-"}
-      %li Karma&nbsp;: #{a.karma} (minimum&nbsp;: #{a.min_karma}, maximum&nbsp;: #{a.max_karma})
+      %li Courriel : #{a.email}
+      %li Rôle : #{a.display_role(@user.nodes.where(public: true).count>0)}
+      %li Dernière connexion : #{a.current_sign_in_at ? l(@user.account.current_sign_in_at) : "-"}
+      %li Karma : #{a.karma} (minimum : #{a.min_karma}, maximum : #{a.max_karma})
     - if current_account.admin?
       %p Visibilité
       %ul
-        %li Commentaires &nbsp;: #{ @user.comments.published.count } sur #{ @user.comments.count }
-        %li Contenus &nbsp;: #{ @user.nodes.visible.count } sur #{ @user.nodes.count }
-      %p Tags&nbsp;: #{ @user.taggings.count }
-      = button_to "+50XP", karma_admin_account_path(@user.account.id)
+        %li commentaires : #{ @user.comments.published.count } sur #{ @user.comments.count } ;
+        %li contenus : #{ @user.nodes.visible.count } sur #{ @user.nodes.count }.
+      %p Étiquettes : #{ @user.taggings.count }
+      = button_to "+50 XP", karma_admin_account_path(@user.account.id)
     - if current_account.can_block?
       %button.more.block Interdire de commenter
       .more_actions.block(style="display: none;")
         %ul
-          %li= button_to "24h", moderation_block_index_path(nb_days: 1, account_id: @user.account.id), remote: true, class: "block"
-          %li= button_to "2 jours", moderation_block_index_path(nb_days: 2, account_id: @user.account.id), remote: true, class: "block"
+          %li= button_to "24 h", moderation_block_index_path(nb_days: 1, account_id: @user.account.id), remote: true, class: "block"
+          %li= button_to "48 h", moderation_block_index_path(nb_days: 2, account_id: @user.account.id), remote: true, class: "block"
           %li= button_to "une semaine", moderation_block_index_path(nb_days: 7, account_id: @user.account.id), remote: true, class: "block"
           %li= button_to "un mois", moderation_block_index_path(nb_days: 30, account_id: @user.account.id), remote: true, class: "block"
     - if current_account.can_plonk?
       %button.more.plonk Interdire de tribune
       .more_actions.plonk(style="display: none;")
         %ul
-          %li= button_to "24h", moderation_plonk_index_path(nb_days: 1, account_id: @user.account.id), remote: true, class: "plonk"
-          %li= button_to "2 jours", moderation_plonk_index_path(nb_days: 2, account_id: @user.account.id), remote: true, class: "plonk"
+          %li= button_to "24 heures", moderation_plonk_index_path(nb_days: 1, account_id: @user.account.id), remote: true, class: "plonk"
+          %li= button_to "48 heures", moderation_plonk_index_path(nb_days: 2, account_id: @user.account.id), remote: true, class: "plonk"
           %li= button_to "une semaine", moderation_plonk_index_path(nb_days: 7, account_id: @user.account.id), remote: true, class: "plonk"
           %li= button_to "un mois", moderation_plonk_index_path(nb_days: 30, account_id: @user.account.id), remote: true, class: "plonk"
       - if @user.account.logs.any?

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -8,7 +8,7 @@
       Compte fermé
   - if user.homesite
     %p
-      Site personnel&nbsp;: #{link_to user.homesite, user.homesite, class: 'url me'}
+      Site Web personnel : #{link_to user.homesite, user.homesite, class: 'url me'}
   - if current_account && user.jabber_id
     %p
-      Jabber ID&nbsp;: #{link_to 'xmpp:' + user.jabber_id, 'xmpp:' + user.jabber_id, class: 'url'}
+      Adresse XMPP : #{link_to 'xmpp:' + user.jabber_id, 'xmpp:' + user.jabber_id, class: 'url'}

--- a/app/views/users/journaux.html.haml
+++ b/app/views/users/journaux.html.haml
@@ -2,6 +2,6 @@
   = render 'recent'
   = render 'nodes'
 
-=h1 "#{@user.name} a écrit #{pluralize @nodes.total_count, "journal"}"
+=h1 "#{@user.name} a écrit #{pluralize @nodes.total_count, "journal", "journaux"}"
 - feed "Flux Atom des journaux de #{@user.name}"
 = paginated_nodes @nodes

--- a/app/views/users/not_enough_karma.html.haml
+++ b/app/views/users/not_enough_karma.html.haml
@@ -1,5 +1,5 @@
 =h1 "Karma insuffisant"
 %p
-  En raison d'un #{link_to "karma trop faible", "/aide#aide-karma"},
-  ce compte n'est pas actuellement autorisé à écrire des #{@content_type} sur le site.
-%img(src="/images/403.png" alt="")
+  En raison d’un #{link_to "karma trop faible", "/aide#aide-karma"},
+  ce compte n’est actuellement pas autorisé à écrire des #{@content_type} sur le site.
+%img(src="/images/403.png" alt="Image d’interdiction")

--- a/app/views/users/posts.html.haml
+++ b/app/views/users/posts.html.haml
@@ -3,5 +3,5 @@
   = render 'nodes'
 
 =h1 "#{@user.name} a écrit #{pluralize @nodes.total_count, "message"} dans les forums"
-- feed "Flux Atom des messages dans les forums de #{@user.name}"
+- feed "Flux Atom des messages de #{@user.name} dans les forums"
 = paginated_nodes @nodes

--- a/app/views/users/show.atom.builder
+++ b/app/views/users/show.atom.builder
@@ -1,6 +1,6 @@
 # encoding: utf-8
 atom_feed(:root_url => user_url(@user), "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : les contenus de #{@user.name}")
+  feed.title("LinuxFr.org : les contenus de #{@user.name}")
   feed.updated(@nodes.first.try :updated_at)
   feed.icon("/favicon.png")
 

--- a/app/views/users/too_old_for_edition.html.haml
+++ b/app/views/users/too_old_for_edition.html.haml
@@ -1,4 +1,4 @@
-=h1 "Édition impossible : #{@content_type} trop ancien"
+=h1 "Édition impossible : #{@content_type} ayant dépassé le délai de modification"
 %p
-  Un #{@content_type} ne peut plus être modifié après #{@period_in_minutes} minutes.
-%img(src="/images/403.png" alt="")
+  Un contenu de type #{@content_type} ne peut plus être modifié passées #{@period_in_minutes} minutes.
+%img(src="/images/403.png" alt="Image d’interdiction")

--- a/app/views/users/wiki.html.haml
+++ b/app/views/users/wiki.html.haml
@@ -9,5 +9,5 @@
     = list_of(@versions) do |v|
       #{l v.created_at.to_date} -
       = link_to v.wiki_page.title, v.wiki_page
-      = link_to "(révision #{v.version} par #{v.user.try :name})", revision_wiki_page_path(v.wiki_page.cached_slug, v.version)
+      = link_to "(révision #{v.version}, par #{v.user.try :name})", revision_wiki_page_path(v.wiki_page.cached_slug, v.version)
   = paginate @versions

--- a/app/views/wiki_pages/_edition.html.haml
+++ b/app/views/wiki_pages/_edition.html.haml
@@ -7,7 +7,7 @@
     Modifié le
     = l edition.versions.first.created_at.to_date
   %p
-    Les dernières modifications&nbsp;:
+    Les dernières modifications :
   %ul
     = list_of(edition.versions) do |v|
-      = link_to "#{v.author_name}&nbsp;: #{v.message}".html_safe, "/wiki/#{edition.to_param}/revisions/#{v.version}"
+      = link_to "#{v.author_name} : #{v.message}".html_safe, "/wiki/#{edition.to_param}/revisions/#{v.version}"

--- a/app/views/wiki_pages/_form.html.haml
+++ b/app/views/wiki_pages/_form.html.haml
@@ -2,7 +2,7 @@
   = form.label :wiki_body, "Contenu"
   = form.text_area :wiki_body, required: 'required', spellcheck: 'true', class: 'markItUp'
 %p
-  = form.label :message, "Log des modifications"
+  = form.label :message, "Journal des modifications"
   = form.text_field :message, autocomplete: 'off', spellcheck: 'true', maxlength: 250, size: 80
 %p
   = form.submit "Prévisualiser", id: "wiki_preview"

--- a/app/views/wiki_pages/_form.html.haml
+++ b/app/views/wiki_pages/_form.html.haml
@@ -2,7 +2,7 @@
   = form.label :wiki_body, "Contenu"
   = form.text_area :wiki_body, required: 'required', spellcheck: 'true', class: 'markItUp'
 %p
-  = form.label :message, "Journal des modifications"
+  = form.label :message, "Description de la modification"
   = form.text_field :message, autocomplete: 'off', spellcheck: 'true', maxlength: 250, size: 80
 %p
   = form.submit "Prévisualiser", id: "wiki_preview"

--- a/app/views/wiki_pages/_wiki_page.atom.builder
+++ b/app/views/wiki_pages/_wiki_page.atom.builder
@@ -1,7 +1,7 @@
 feed.entry(wiki_page) do |entry|
   entry.title(wiki_page.title)
   url = wiki_page_url wiki_page
-  epub = content_tag(:div, link_to("Télécharger ce contenu au format Epub", "#{url}.epub"))
+  epub = content_tag(:div, link_to("Télécharger ce contenu au format EPUB", "#{url}.epub"))
   entry.content(wiki_page.body + epub + atom_comments_link(wiki_page, url), :type => 'html')
   entry.author do |author|
     author.name(wiki_page.node.user.try :name)

--- a/app/views/wiki_pages/changes.atom.builder
+++ b/app/views/wiki_pages/changes.atom.builder
@@ -1,13 +1,13 @@
 atom_feed(:root_url => wiki_pages_url) do |feed|
-  feed.title("LinuxFr.org : les derniers changements dans le wiki")
+  feed.title("LinuxFr.org : les derniers changements dans le wiki")
   feed.updated(@versions.first.created_at)
   feed.icon("/favicon.png")
-  feed.rights("Licence CC by-sa http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
+  feed.rights("Licence CC By‑SA http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
 
   @versions.each do |v|
     feed.entry(v, :url => polymorphic_url(v.wiki_page)) do |entry|
       entry.title("#{v.wiki_page.title} (révision #{v.version})")
-      entry.content(link_to("Afficher le diff", "/wiki/#{v.wiki_page.to_param}/revisions/#{v.version}"), :type => 'html')
+      entry.content(link_to("Afficher les différences", "/wiki/#{v.wiki_page.to_param}/revisions/#{v.version}"), :type => 'html')
       entry.author do |author|
         author.name(v.user.try :name)
       end

--- a/app/views/wiki_pages/edit.html.haml
+++ b/app/views/wiki_pages/edit.html.haml
@@ -8,6 +8,6 @@
     = render form
 
   - if current_account && current_account.can_destroy?(@wiki_page)
-    = button_to "Supprimer", [@wiki_page], method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cette page de wiki ?" }, class: "delete_button"
+    = button_to "Supprimer", [@wiki_page], method: :delete, data: { confirm: "Confirmez‑vous vouloir supprimer cette page de wiki ?" }, class: "delete_button"
 
   = render 'shared/wiki_help'

--- a/app/views/wiki_pages/index.atom.builder
+++ b/app/views/wiki_pages/index.atom.builder
@@ -1,8 +1,8 @@
 atom_feed(:root_url => wiki_pages_url, "xmlns:wfw" => "http://wellformedweb.org/CommentAPI/") do |feed|
-  feed.title("LinuxFr.org : le wiki")
+  feed.title("LinuxFr.org : le wiki")
   feed.updated(@wiki_pages.first.try :updated_at)
   feed.icon("/favicon.png")
-  feed.rights("Licence CC by-sa http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
+  feed.rights("Licence CC By‑SA http://creativecommons.org/licenses/by-sa/4.0/deed.fr")
 
   render :partial => @wiki_pages, :locals => { :feed => feed }
 end

--- a/app/views/wiki_pages/new.html.haml
+++ b/app/views/wiki_pages/new.html.haml
@@ -2,7 +2,7 @@
   =h1 "Créer une page de wiki"
 
   %p
-    Des <a href="/regles_de_moderation">règles de modération</a> sont applicables aux pages wiki (et au reste du site).
+    Des <a href="/regles_de_moderation">règles de modération</a> sont applicables aux pages du wiki (et au reste du site).
 
   = render "preview", preview: @wiki_page if @preview_mode
 

--- a/app/views/wiki_pages/not_found.html.haml
+++ b/app/views/wiki_pages/not_found.html.haml
@@ -2,4 +2,4 @@
   =h1 "Page de wiki absente"
 
   %p
-    Cette page de wiki n'existe pas. Si vous souhaitez la créer, vous devez d'abord vous identifier.
+    Cette page de wiki n’existe pas. Si vous souhaitez la créer, vous devez d’abord vous identifier.

--- a/app/views/wiki_pages/revision.html.haml
+++ b/app/views/wiki_pages/revision.html.haml
@@ -16,7 +16,7 @@
   %h2
     = link_to @wiki_page.title, @wiki_page
   %h3
-    #{@version.author_name}&nbsp;: #{@version.message} (#{l @version.created_at})
+    #{@version.author_name} : #{@version.message} (#{l @version.created_at})
   %pre
     = htmldiff @was, @version.body
 

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -5,7 +5,7 @@ fr:
       send_instructions: "Vous allez recevoir un courriel avec les instruction pour confirmer votre compte dans quelques minutes."
     failure:
       already_authenticated: "Vous êtes déjà connecté(e)."
-      inactive: "Votre compte n'a pas encore été activé."
+      inactive: "Votre compte n’a pas encore été activé."
       invalid: "Identifiant ou mot de passe invalide."
       locked: "Votre compte a été verrouillé."
       last_attempt: "Ceci est votre dernier essai avant que votre compte ne soit verrouillé."
@@ -22,14 +22,14 @@ fr:
       unlock_instructions:
         subject: "Instructions pour le déverrouillage"
     passwords:
-      no_token: "Vous ne pouvez accéder à cette page qu'à partir d'un courriel de réinitialisation du mot de passe."
+      no_token: "Vous ne pouvez accéder à cette page qu’à partir d’un courriel de réinitialisation du mot de passe."
       send_instructions: "Vous allez recevoir un courriel avec les instructions pour réinitialiser votre mot de passe dans quelques minutes."
       updated: "Votre mot de passe a été modifié avec succès. Vous êtes maintenant connecté."
       updated_not_active: "Votre mot de passe a été modifié avec succès."
     registrations:
       destroyed: "Au revoir. Votre compte a été fermé avec succès. Nous espérons vous revoir bientôt."
       signed_up: "Vous vous êtes inscrit avec succès. Vous allez recevoir les instructions de confirmation par courriel."
-      signed_up_but_inactive: "Vous vous êtes identifié correctement. Pourtant, nous ne pouvons pas ouvrir votre session tant que votre compte n'aura pas été activé."
+      signed_up_but_inactive: "Vous vous êtes identifié correctement. Pourtant, nous ne pouvons pas ouvrir votre session tant que votre compte n’aura pas été activé."
       signed_up_but_locked: "Vous vous êtes identifié correctement. Pourtant, nous ne pouvons pas ouvrir votre session car votre compte est bloqué."
       signed_up_but_unconfirmed: "Un message avec un lien de confirmation a été envoyé à votre adresse de courriel. Veuillez ouvrir le lien pour activer votre compte."
       update_needs_confirmation: "Vous avez mis à jour votre compte avec succès, mais nous devons vérifier votre nouvelle adresse de courriel."
@@ -45,9 +45,9 @@ fr:
       expired: "a expiré, veuillez en demander un nouveau"
       not_found: "pas trouvé"
       already_confirmed: "était déjà confirmé, veuillez essayer de vous connecter"
-      not_locked: "n'était pas verrouillé"
+      not_locked: "n’était pas verrouillé"
       not_saved:
-        one: "Ce %{resource} n'a pu être enregistré à cause d'une erreur :"
-        other: "Ce %{resource} n'a pu être enregistré à cause de %{count} erreurs :"
+        one: "Ce %{resource} n’a pu être enregistré à cause d’une erreur :"
+        other: "Ce %{resource} n’a pu être enregistré à cause de %{count} erreurs :"
       confirmation_period_expired: "doit être confirmé avant %{period}, veuillez refaire une demande"
 

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -3,7 +3,7 @@ fr:
     attributes:
       doorkeeper/application:
         name: "Nom"
-        redirect_uri: "L’URL de redirection"
+        redirect_uri: "L’adresse de redirection"
         scopes: "Portées"
     errors:
       models:

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -11,7 +11,7 @@ fr:
           attributes:
             redirect_uri:
               fragment_present: "ne peut contenir un fragment."
-              invalid_uri: "doit être une URL valide."
+              invalid_uri: "doit être une adresse valide."
               relative_uri: "doit être une URL absolue."
               secured_uri: "doit être une URL HTTP/SSL."
               forbidden_uri: 'est interdite par le serveur.'

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -13,7 +13,7 @@ fr:
               fragment_present: "ne peut contenir un fragment."
               invalid_uri: "doit être une adresse valide."
               relative_uri: "doit être une adresse absolue."
-              secured_uri: "doit être une URL HTTP/SSL."
+              secured_uri: "doit être une adresse HTTPS."
               forbidden_uri: 'est interdite par le serveur.'
 
   doorkeeper:

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -3,7 +3,7 @@ fr:
     attributes:
       doorkeeper/application:
         name: "Nom"
-        redirect_uri: "L'URL de redirection"
+        redirect_uri: "L’URL de redirection"
         scopes: "Portées"
     errors:
       models:
@@ -14,52 +14,52 @@ fr:
               invalid_uri: "doit être une URL valide."
               relative_uri: "doit être une URL absolue."
               secured_uri: "doit être une URL HTTP/SSL."
-              forbidden_uri: 'est interdit par le serveur.'
+              forbidden_uri: 'est interdite par le serveur.'
 
   doorkeeper:
     scopes:
-      account: "Accéder à votre adresse de courriel, votre identifiant et la date de création de votre compte"
+      account: "Accéder à votre adresse de courriel, votre identifiant et à la date de création de votre compte"
       board: "Poster sur les tribunes"
 
     errors:
       messages:
         # Common error messages
-        invalid_request: 'Il manque un paramètre obligatoire dans la requête, elle comporte une valeur non prise en charge pour un paramètre, ou elle est mal-formée.'
-        invalid_redirect_uri: "L'URI de redirection incluse n'est pas valide."
-        unauthorized_client: "Le client n'est pas autorisé à effectuer cette requête en utilisant cette méthode."
-        access_denied: "Le propriétaire de la ressource ou le serveur d'autorisation a refusé la requête."
-        invalid_scope: "Les droits demandés sont invalides, inconnues ou mal-formés."
-        server_error: "Le serveur d'autorisation a rencontré une erreur."
-        temporarily_unavailable: "Le serveur d'autorisation est momentannément indisponible."
+        invalid_request: 'Il manque un paramètre obligatoire dans la requête, elle comporte une valeur non prise en charge pour un paramètre, ou elle est malformée.'
+        invalid_redirect_uri: "L’URI de redirection indiquée n’est pas valide."
+        unauthorized_client: "Le client n’est pas autorisé à effectuer cette requête en utilisant cette méthode."
+        access_denied: "Le propriétaire de la ressource ou le serveur d’autorisation a refusé la requête."
+        invalid_scope: "Les droits demandés sont invalides, inconnus ou malformés."
+        server_error: "Le serveur d’autorisation a rencontré une erreur."
+        temporarily_unavailable: "Le serveur d’autorisation est momentanément indisponible."
 
         #configuration error messages
-        credential_flow_not_configured: "Le flux des identifiants du mot de passe du propriétaire de la ressource a échoué en raison de Doorkeeper.configure.resource_owner_from_credentials n'est pas configuré."
-        resource_owner_authenticator_not_configured: "La recherche du propriétaire de la ressource a échoué en raison de Doorkeeper.configure.resource_owner_authenticator n'est pas configuré."
+        credential_flow_not_configured: "Le flux des informations d’identification du mot de passe du propriétaire de la ressource a échoué car Doorkeeper.configure.resource_owner_from_credentials n’est pas configuré."
+        resource_owner_authenticator_not_configured: "La recherche du propriétaire de la ressource a échoué car Doorkeeper.configure.resource_owner_authenticator n’est pas configuré."
 
         # Access grant errors
-        unsupported_response_type: "Le serveur d'autorisation ne prend pas en charge ce type de réponse."
+        unsupported_response_type: "Le serveur d’autorisation ne prend pas en charge ce type de réponse."
 
         # Access token errors
-        invalid_client: "L'authentification du client a échoué en raison d'un client inconnu, de l'absence d'authentification pour le client ou d'une méthode d'authentification inconnue."
-        invalid_grant: "La délégation d'autorisation fournie est invalide, a expiré, a été révoquée, ne correspond pas à l'URI de redirection utilisée pour la requête d'autorisation ou a été émise pour un autre client."
-        unsupported_grant_type: "Le type de la délégation d'autorisation n'est pas pris en charge pour le serveur d'autorisation."
+        invalid_client: "L’authentification du client a échoué en raison d’un client inconnu, de l’absence d’authentification pour le client ou d’une méthode d’authentification inconnue."
+        invalid_grant: "La délégation d’autorisation fournie est invalide, a expiré, a été révoquée, ne correspond pas à l’URI de redirection utilisée pour la requête d’autorisation ou a été émise pour un autre client."
+        unsupported_grant_type: "Le type de la délégation d’autorisation n’est pas pris en charge par le serveur d’autorisation."
 
         # Password Access token errors
-        invalid_resource_owner: "Les identifiants fournis pour le propriétaire de la ressource ne sont pas valides, ou le propriétaire de la ressource ne peut pas être trouvé."
+        invalid_resource_owner: "Les identifiants fournis pour le propriétaire de la ressource ne sont pas valides, ou le propriétaire de la ressource est introuvable."
 
         invalid_token:
-          revoked: "Le jeton d'accès a été révoqué"
-          expired: "Le jeton d'accès a expiré"
-          unknown: "Le jeton d'accès est invalide"
+          revoked: "Le jeton d’accès a été révoqué"
+          expired: "Le jeton d’accès a expiré"
+          unknown: "Le jeton d’accès est invalide"
 
     flash:
       applications:
         create:
-          notice: "L'application a été enregistrée."
+          notice: "L’application a été enregistrée."
         destroy:
-          notice: "L'application a été supprimée."
+          notice: "L’application a été supprimée."
         update:
-          notice: "L'application a été mise à jour."
+          notice: "L’application a été mise à jour."
       authorized_applications:
         destroy:
-          notice: "L'application a été révoquée."
+          notice: "L’application a été révoquée."

--- a/config/locales/doorkeeper.fr.yml
+++ b/config/locales/doorkeeper.fr.yml
@@ -12,7 +12,7 @@ fr:
             redirect_uri:
               fragment_present: "ne peut contenir un fragment."
               invalid_uri: "doit être une adresse valide."
-              relative_uri: "doit être une URL absolue."
+              relative_uri: "doit être une adresse absolue."
               secured_uri: "doit être une URL HTTP/SSL."
               forbidden_uri: 'est interdite par le serveur.'
 

--- a/config/locales/kaminari.fr.yml
+++ b/config/locales/kaminari.fr.yml
@@ -1,8 +1,8 @@
 fr:
   views:
     pagination:
-      first: "&laquo; Premier"
-      last: "Dernier &raquo;"
-      previous: "&lsaquo; Précédent"
-      next: "Suivant &rsaquo;"
+      first: "‹ Premier"
+      last: "Dernier ›"
+      previous: "‹ Précédent"
+      next: "Suivant ›"
       truncate: "…"

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -44,15 +44,15 @@ fr:
       post: "au message"
       response: "à la réponse"
       section: "à la section"
-      tracker: "à l'entrée du suivi"
-      user: "à l'utilisateur"
+      tracker: "à l’entrée du suivi"
+      user: "à l’utilisateur"
       wikipage: "à la page de wiki"
       wikiversion: "à la version"
     attributes:
       account:
-        reset_password_token: "token de réinitialisation"
+        reset_password_token: "jeton de réinitialisation"
 
   errors:
     messages:
-      carrierwave_processing_error: "n'a pu être traité"
-      carrierwave_integrity_error: "n'est pas un type de fichier autorisé"
+      carrierwave_processing_error: "n’a pu être traité"
+      carrierwave_integrity_error: "n’est pas un type de fichier autorisé"

--- a/config/templates/maintenance.rhtml
+++ b/config/templates/maintenance.rhtml
@@ -37,11 +37,12 @@
     </pre>
     <div class="inner">
       <h1>Maintenance</h1>
-      <p>Le site est actuellement en maintenance depuis <%= Time.now.strftime("%H:%M") %> et n'est donc pas accessible.</p>
+      <p>Le site est actuellement en maintenance depuis <%= Time.now.strftime("%H:%M") %> et n’est donc pas accessible.</p>
       <% if reason %>
-      <p>Raison : <%= reason %>.</p>
+      <p>Raison : <%= reason %>.</p>
       <% end %>
       <p>Il devrait revenir <%= deadline || "très rapidement" %>.</p>
     </div>
   </div>
 </body>
+</html>

--- a/db/pages/a-propos.html
+++ b/db/pages/a-propos.html
@@ -1,69 +1,69 @@
 <div class="static-about">
 <div class="about-welcome">
   <h2>Bienvenue sur LinuxFr.org</h2>
-  <p>LinuxFr.org est la référence francophone sur le Logiciel Libre, la culture libre et Linux, évidemment !</p>
+  <p><em>LinuxFr.org</em> est la référence francophone sur le logiciel libre, la culture libre et Linux, évidemment !</p>
 </div>
 <img src="/images/a-propos/yvan-musy-369832-unsplash.jpg" alt="Wildebeast, gnu, horns and africa, HD photo de Yvan Musy" title="Wildebeast, gnu, horns and africa, HD photo de Yvan Musy" />
 
 <div class="about-plurality">
   <h3>Une pluralité de points de vue</h3>
   <p>
-    LinuxFr.org rassemble des populations diverses vivant à travers le monde :
-    artisans du Logiciel Libre ou utilisateurs néophytes, artistes de la culture
-    libre ou amateurs éclairés, ils partagent l'usage de la langue française et
-    des centres d'intérêts communs. Simples curieux et véritables passionnés
+    <em>LinuxFr.org</em> rassemble des populations diverses vivant à travers le monde :
+    artisans du logiciel libre ou utilisateurs néophytes, artistes de la culture
+    libre ou amateurs éclairés, ils partagent l’usage de la langue française et
+    des centres d’intérêts communs. Simples curieux et véritables passionnés
     peuvent venir aussi bien pour présenter leurs travaux et parler de leur
-    expérience, que pour inviter à réfléchir sur les enjeux de société liés aux
-    mouvements du libre.
+    expérience, que pour inviter à réfléchir aux enjeux de société liés aux
+    mouvements du Libre.
   </p>
 </div>
 
 <div class="about-navigation">
   <h3>Ajustez la navigation à vos envies</h3>
   <p>
-    Votre compte LinuxFr.org facilite le suivi des commentaires qui viennent
+    Votre compte <em>LinuxFr.org</em> facilite le suivi des commentaires qui viennent
     enrichir les articles. Ignorez les impertinents et ne perdez plus une miette
     des discussions qui vous intéressent. Trouvez aisément les contenus que vous
-    cherchez, en ajustant la densité d'information présente à l'écran, et en
+    cherchez, en ajustant la densité d’information présente à l'écran, et en
     gardant vos articles favoris à portée de main.
   </p>
 </div>
-<img src="/images/a-propos/aaron-burden-523450-unsplash.jpg" alt="Compass, wooden table, direction and old fashioned, HD photo de Aaron Burden" title="Compass, wooden table, direction and old fashioned, HD photo de Aaron Burden" />
+<img src="/images/a-propos/aaron-burden-523450-unsplash.jpg" alt="Compass, wooden table, direction and old fashioned, HD photo d’Aaron Burden" title="Compass, wooden table, direction and old fashioned, HD photo d’Aaron Burden" />
 
 <div class="about-writing">
-  <h3>Rédigez, publiez !</h3>
+  <h3>Rédigez, publiez !</h3>
   <p>
     Nous vous encourageons à participer aux articles que nous publions sur le
-    site. Dans l'espace de rédaction collaborative, même les petites
-    contributions sont les bienvenues, et peuvent mener à de beaux articles.
+    site. Dans l’espace de rédaction coopérative, même les petites
+    contributions sont les bienvenues et peuvent mener à de beaux articles.
     Envie de vous exprimer sur un sujet plus personnel ou éloigné des
-    thématiques de LinuxFr.org ? Nous avons aménagé un blog, rien que pour
-    vous.
+    thématiques de <em>LinuxFr.org</em> ? Nous avons aménagé un blog, rien que
+    pour vous.
   </p>
 </div>
-<img src="/images/a-propos/aaron-burden-64849-unsplash.jpg" alt="Writing with a fountain pen, photo de Aaron Burden" title="Writing with a fountain pen, photo de Aaron Burden" />
+<img src="/images/a-propos/aaron-burden-64849-unsplash.jpg" alt="Writing with a fountain pen, photo d’Aaron Burden" title="Writing with a fountain pen, photo d’Aaron Burden" />
 
 <div class="about-contributors">
   <h3>Ils participent à LinuxFr.org</h3>
   <ul class="people-list">
     <li><img src="https://img.linuxfr.org/avatars/687474703a2f2f666f72756d2d696d616765732e68617264776172652e66722f696d616765732f6d657364697363757373696f6e732d3237373130352e706e67/mesdiscussions-277105.png" class="avatar" />
       <a href="/users/edhelas">edhelas</a>
-      <p>Timothée nous tient régulièrement informé des nouveautés de <a href="https://movim.eu">Movim</a>, la plate-forme de communication basée sur le protocole XMPP.</p>
+      <p>Timothée nous tient régulièrement informé des nouveautés de <a href="https://movim.eu">Movim</a>, la plate‑forme de communication basée sur le protocole XMPP.</p>
     </li>
     <li><img src="https://img.linuxfr.org/avatars/687474703a2f2f7777772e67726176617461722e636f6d2f6176617461722f31363137396435613161333963613131353135373237666161633866376364643f73697a653d353132/16179d5a1a39ca11515727faac8f7cdd" class="avatar" />
       <a href="/users/bookynette">Bookynette</a>
-      <p>Bookynette est une personne très active dans les communautés du libre, que ce soit <a href="https://april.org/">l'April</a>, <a href="https://parinux.org/">Parinux</a>, <a href="https://www.agendadulibre.org/">l'Agenda du Libre</a> ou <a href="https://enventelibre.org/">En Vente Libre</a>. Elle vient régulièrement faire la publicité d'événements du Libre.</p>
+      <p>Bookynette est une personne très active dans les communautés du Libre, que ce soit <a href="https://april.org/">l’April</a>, <a href="https://parinux.org/">Parinux</a>, <a href="https://www.agendadulibre.org/">l'Agenda du Libre</a> ou <a href="https://enventelibre.org/">En Vente Libre</a>. Elle vient régulièrement faire la publicité d’événements du Libre.</p>
     </li>
     <li><img src="https://img.linuxfr.org/avatars/621/031/000/avatar.jpg" class="avatar" />
       <a href="/users/jehan">Jehan</a>
-      <p>Il travaille en ce moment à un film d'animation libre : <a href="https://film.zemarmot.net">ZeMarmot</a>. Aux côtés de Aryeom Han, il fait évoluer le logiciel <a href="https://www.gimp.org/fr/">GIMP</a> pour faciliter le travail de la réalisatrice et dessinatrice !</p>
+      <p>Il travaille en ce moment à un film d’animation libre : <em><a href="https://film.zemarmot.net">ZeMarmot</a></em>. Aux côtés de Aryeom Han, il fait évoluer le logiciel <a href="https://www.gimp.org/fr/">GIMP</a> pour faciliter le travail de la réalisatrice et dessinatrice !</p>
     </li>
   </ul>
 </div>
 
 <div class="about-signup">
-  <h3>N'attendez plus et rejoignez la communauté</h3>
-  <p>Ça vous tente ? Nous vous promettons de ne faire aucun usage publicitaire
+  <h3>N’attendez plus et rejoignez la communauté</h3>
+  <p>Ça vous tente ? Nous vous promettons de ne faire aucun usage publicitaire
     ou commercial de vos données personnelles. Lorsque vous créerez votre
     compte, vous nous promettez de respecter les règles du site.
   </p>
@@ -85,12 +85,12 @@
 
 <div class="about-credits">
 <h3>Crédits photos</h3>
-<p>Les photos proviennent du site Unsplash (<a href="https://unsplash.com/license">licence</a>).</p>
+  <p>Les photos proviennent du site <em>Unsplash</em> (<a href="https://unsplash.com/license">licence</a>).</p>
 <ul class="people-list">
-  <li><a href="https://unsplash.com/photos/1Z-vzN0WmVg"><em>Wildebeast, gnu, horns and africa HD</em>, photo de Yvan Musy (@navyysum)</a></li>
-  <li><a href="https://unsplash.com/photos/NXt5PrOb_7U"><em>Compass, wooden table, direction and old fashioned</em>, HD photo de Aaron Burden (@aaronburden)</a></li>
-  <li><a href="https://unsplash.com/photos/y02jEX_B0O0"><em>Writing with a fountain pen</em>, photo de Aaron Burden (@aaronburden)</a></li>
-  <li><a href="https://unsplash.com/photos/UjpEGHu8uNU"><em>Penguins at Boulders Beach</em>, photo de Casey Allen (@westbeach013)</a></li>
+  <li><a href="https://unsplash.com/photos/1Z-vzN0WmVg"><em>Wildebeast, gnu, horns and africa HD</em>, photo d’Yvan Musy (<em>@navyysum)</em></a></li>
+  <li><a href="https://unsplash.com/photos/NXt5PrOb_7U"><em>Compass, wooden table, direction and old fashioned</em>, HD photo d’Aaron Burden (<em>@aaronburden</em>)</a></li>
+  <li><a href="https://unsplash.com/photos/y02jEX_B0O0"><em>Writing with a fountain pen</em>, photo d’Aaron Burden (<em>@aaronburden</em>)</a></li>
+  <li><a href="https://unsplash.com/photos/UjpEGHu8uNU"><em>Penguins at Boulders Beach</em>, photo de Casey Allen (<em>@westbeach013</em>)</a></li>
 </ul>
 </div>
 </div>

--- a/db/pages/aide.html
+++ b/db/pages/aide.html
@@ -3,401 +3,410 @@
 <ul>
 <li><a href="#aide-sections" class="anchor">Les différentes sections du site</a></li>
 <li><a href="#aide-gagnants" class="anchor">Gagnants et prix</a></li>
-<li><a href="#aide-authentification" class="anchor">Visiteur (non) authentifié, ou pourquoi ouvrir un compte&nbsp;?</a></li>
-<li><a href="#aide-toolbar" class="anchor">Barre d'outils</a></li>
-<li><a href="#aide-boiteperso" class="anchor">Boîte d'identification personnelle</a></li>
+<li><a href="#aide-authentification" class="anchor">Visiteur (non) authentifié, ou pourquoi ouvrir un compte ?</a></li>
+<li><a href="#aide-toolbar" class="anchor">Barre d’outils</a></li>
+<li><a href="#aide-boiteperso" class="anchor">Boîte d’identification personnelle</a></li>
 <li><a href="#aide-note" class="anchor">Notes sur les contenus</a></li>
 <li><a href="#aide-compteferme" class="anchor">Compte fermé et adresse de courriel déjà utilisée</a></li>
 <li><a href="#aide-fermercompte" class="anchor">Fermer son compte</a></li>
 <li><a href="#aide-certificatssl" class="anchor">HTTPS, certificat X.509/SSL/TLS et alertes dans les navigateurs</a></li>
-<li><a href="#aide-autrecertificatssl" class="anchor">Pourquoi ne prenez-vous pas un certificat X.509/SSL/TLS gratuit ou payant de chez Machin qui est par défaut dans un navigateur&nbsp;?</a></li>
-<li><a href="#aide-imgcertificatssl" class="anchor">Pourquoi les avatars et images ne s'affichent pas chez moi en HTTPS ?</a></li>
+<li><a href="#aide-autrecertificatssl" class="anchor">Pourquoi ne prenez‑vous pas un certificat X.509/SSL/TLS gratuit ou payant de chez Machin qui est par défaut dans un navigateur ?</a></li>
+<li><a href="#aide-imgcertificatssl" class="anchor">Pourquoi les avatars et images ne s’affichent pas chez moi en HTTPS ?</a></li>
 <li><a href="#aide-karma" class="anchor">Système de karma</a></li>
-<li><a href="#aide-role" class="anchor">À quoi correspond le rôle sur la page d'un utilisateur&nbsp;?</a></li>
-<li><a href="#aide-cookies" class="anchor">Quels sont les cookies utilisés par le site&nbsp;?</a></li>
-<li><a href="#aide-sondage" class="anchor">Sondage&nbsp;: qui peut voter et pour quoi&nbsp;?</a></li>
-<li><a href="#aide-ancienscontenus" class="anchor">Pourquoi est-il impossible de commenter un contenu vieux de plus de 3 mois&nbsp;?</a></li>
-<li><a href="#aide-nouveautes" class="anchor">Comment être notifié(e) des nouveaux commentaires sur un contenu déjà visité&nbsp;?</a></li>
-<li><a href="#aide-dlfp" class="anchor">DLFP&nbsp;? Da Linux French page&nbsp;?</a></li>
-<li><a href="#aide-multis" class="anchor">Comptes multiples ou «&nbsp;multis&nbsp;»</a></li>
-<li><a href="#aide-offresemploi" class="anchor">Peut-on proposer des offres d'emploi sur le site&nbsp;?</a></li>
+<li><a href="#aide-role" class="anchor">À quoi correspond le rôle sur la page d’un utilisateur ?</a></li>
+<li><a href="#aide-cookies" class="anchor">Quels sont les cookies utilisés par le site ?</a></li>
+<li><a href="#aide-sondage" class="anchor">Sondage : qui peut voter et pour quoi ?</a></li>
+<li><a href="#aide-ancienscontenus" class="anchor">Pourquoi est‑il impossible de commenter un contenu vieux de plus de trois mois ?</a></li>
+<li><a href="#aide-nouveautes" class="anchor">Comment recevoir des notifications de nouveaux commentaires sur un contenu déjà visité ?</a></li>
+<li><a href="#aide-dlfp" class="anchor">DLFP ? <em>Da Linux French Page</em> ?</a></li>
+<li><a href="#aide-multis" class="anchor">Comptes multiples ou « multis »</a></li>
+<li><a href="#aide-offresemploi" class="anchor">Peut‑on proposer des offres d’emploi sur le site ?</a></li>
+<li><a href="#aide-fairemonexercice" class="anchor">Forums : je n’arrive pas à faire mon exercice (ou j’ai la flemme de le faire), voici l’énoncé. Merci.</a></li>
 </ul>
 
-<h2 id="aide-sections">Les différentes sections du site<a class="anchor" href="#aide-sections">¶</a></h2>
+<h2 id="aide-sections">Les différentes sections du site <a class="anchor" href="#aide-sections">¶</a></h2>
 
-<p>Le site LinuxFr.org accueille sept types de contenus (tous ces contenus étant écrits par nos visiteurs)&nbsp;:</p>
+<p>Le site <em>LinuxFr.org</em> accueille sept types de contenus (tous ces contenus étant écrits par nos visiteurs) :</p>
 
 <ul>
-<li>les <a href="//linuxfr.org/news">dépêches</a>&nbsp;: des actualités, des synthèses, des événements, etc. sur des sujets liés au logiciel libre, à la culture libre, etc. Elles sont modérées, vérifiées, amendées ou étoffées a priori&nbsp;;</li>
-<li>les <a href="//linuxfr.org/journaux">journaux</a>&nbsp;: les blogs personnels des visiteurs authentifiés&nbsp;;</li>
-<li>les <a href="//linuxfr.org/forums">forums</a>&nbsp;: des questions classées par thème, l'endroit pour chercher ou trouver de l'aide&nbsp;;</li>
-<li>les <a href="//linuxfr.org/sondages">sondages</a>&nbsp;: des questions posées de temps à temps à aux lecteurs du site&nbsp;;</li>
-<li>les <a href="//linuxfr.org/wiki">pages wiki</a>&nbsp;: un espace documentaire de type <a href="https://fr.wikipedia.org/wiki/wiki">wiki</a> pour des contenus en préparation ou pour consolider de l'information&nbsp;;</li>
-<li>les <a href="//linuxfr.org/liens">liens</a>&nbsp;: des liens hypertextes avec une description courte&nbsp;;</li>
-<li>le <a href="//linuxfr.org/suivi">système de suivi</a> des suggestions et des bugs du site&nbsp;: pour proposer des améliorations à l'équipe de développement.</li>
+<li>les <a href="//linuxfr.org/news">dépêches</a> : des actualités, des synthèses, des événements, etc., sur des sujets liés au logiciel libre, à la culture libre, etc. ; elles sont modérées, vérifiées, amendées ou étoffées <em>a priori</em> ;</li>
+<li>les <a href="//linuxfr.org/journaux">journaux</a> : les blogs personnels des visiteurs authentifiés ;</li>
+<li>les <a href="//linuxfr.org/forums">forums</a> : des questions classées par thème, l’endroit pour chercher ou trouver de l’aide ;</li>
+<li>les <a href="//linuxfr.org/sondages">sondages</a> : des questions posées de temps en temps aux lecteurs du site ;</li>
+<li>les <a href="//linuxfr.org/wiki">pages wiki</a> : un espace documentaire de type <a href="https://fr.wikipedia.org/wiki/wiki">wiki</a> pour des contenus en préparation ou pour consolider de l’information ;</li>
+<li>les <a href="//linuxfr.org/liens">liens</a> : des liens hypertextes avec une description courte ;</li>
+<li>le <a href="//linuxfr.org/suivi">système de suivi</a> des suggestions et des bogues du site : pour proposer des améliorations à l’équipe de développement.</li>
 </ul>
 
-<p>Sur la page d'accueil du site sont affichés par défaut (notamment pour les visiteurs non authentifiés) les dépêches et les sondages. Les visiteurs <a href="/compte/inscription">ayant un compte</a> sur le site peuvent utiliser les préférences du compte pour <a href="//linuxfr.org/compte/modifier">personnaliser les contenus affichés</a> sur la page d'accueil.</p>
+<p>Sur la page d’accueil du site sont affichés par défaut (notamment pour les visiteurs non authentifiés) les dépêches et les sondages. Les visiteurs ayant <a href="/compte/inscription">un compte</a> sur le site peuvent utiliser les préférences du compte pour <a href="//linuxfr.org/compte/modifier">personnaliser les contenus affichés</a> sur la page d’accueil.</p>
 
-<h2 id="aide-gagnants">Gagnants et prix <a class="anchor" href="#aide-gagnants">¶</a></h2>
-
+<h2 id="aide-gagnants">Gagnants et prix <a class="anchor" href="#aide-gagnants">¶</a></h2>
 <p>
-	Vous pouvez gagner des livres des éditions <a href="https://www.editions-eyrolles.com/Recherche/?q=linux">Eyrolles</a>,
-	<a href="https://www.editions-eni.fr/livres/open-source/.12659ab71294b44082200c97a40710bc.html">ENI</a>
-	ou encore des abonnements <a href="https://boutique.ed-diamond.com/">Linux Mag France (éditions Diamond)</a> en contribuant au site :
-	<a href="/news/nouveau">soumission de dépêche</a>, journaux, amélioration du code du site, logos, feuilles de style, etc.
+Vous pouvez gagner des livres des éditions <a href="https://www.editions-eyrolles.com/Recherche/?q=linux">Eyrolles</a> et
+<a href="https://www.editions-eni.fr/livres/open-source/.12659ab71294b44082200c97a40710bc.html">ENI</a>,
+ou encore des abonnements <a href="https://boutique.ed-diamond.com/"><em>GNU/Linux Magazine France</em> (éditions Diamond)</a> en contribuant au site :
+<a href="/news/nouveau">soumission de dépêche</a>, journaux, amélioration du code du site, logos, feuilles de style, etc.
 </p>
 
-
-<h2 id="aide-authentification">Visiteur (non) authentifié, ou pourquoi ouvrir un compte&nbsp;? <a href="#aide-authentification" class="anchor">¶</a></h2>
-
+<h2 id="aide-authentification">Visiteur (non) authentifié, ou pourquoi ouvrir un compte ? <a href="#aide-authentification" class="anchor">¶</a></h2>
 <p>
-	Pour passer du statut de visiteur non authentifié à celui de visiteur authentifié,
-	il suffit de se <a href="/compte/inscription">créer un compte</a> sur le site et de se connecter avec.
+Pour passer du statut de visiteur non authentifié à celui de visiteur authentifié,
+il suffit de se <a href="/compte/inscription">créer un compte</a> sur le site et de se connecter avec.
 </p>
 
-<p>Un visiteur non authentifié sur le site peut&nbsp;:</p>
+<p>Un visiteur non authentifié sur le site peut :</p>
 
 <ul>
-<li>lire le site (dépêches, journaux, forums, sondages, liens, tâches du système de suivi, les commentaires associés, flux RSS/Atom)&nbsp;;</li>
-<li><a href="//linuxfr.org/news/nouveau">proposer une dépêche</a> pour envoi direct en modération&nbsp;;</li>
-<li>signaler un bogue ou faire une proposition d'évolution via le <a href="//linuxfr.org/suivi">système de suivi</a>&nbsp;;</li>
-<li>demander à être abonné(e) à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/redacteurs">redaction@</a>&nbsp;;</li>
-<li>accéder à l'<a href="//linuxfr.org/redaction">espace de rédaction</a> et à la liste des contenus en rédaction&nbsp;;</li>
+<li>lire le site (dépêches, journaux, forums, sondages, liens, tâches du système de suivi, les commentaires associés, flux RSS/Atom) ;</li>
+<li><a href="//linuxfr.org/news/nouveau">proposer une dépêche</a> pour envoi direct en modération ;</li>
+<li>signaler un bogue ou faire une proposition d’évolution via le <a href="//linuxfr.org/suivi">système de suivi</a> ;</li>
+<li>demander un abonnement à la liste de discussion <em><a href="https://lists.linuxfr.org/wws/arc/redacteurs">redaction@</a></em> ;</li>
+<li>accéder à l’<a href="//linuxfr.org/redaction">espace de rédaction</a> et à la liste des contenus en rédaction.</li>
 </ul>
 
-<p>Un visiteur authentifié (rôle <i>visitor</i>, affiché comme <i>visiteur</i> si le visiteur n'a pas encore de contenus ou <i>contributeur</i> sinon) peut en plus&nbsp;:</p>
+<p>Un visiteur authentifié (rôle <em>visitor</em>, affiché comme <em>visiteur</em> s’il n’a pas encore de contenus ou <em>contributeur</em> sinon) peut en plus :</p>
 <ul>
-<li><a href="//linuxfr.org/redaction">écrire collaborativement</a> une dépêche dans l'espace de rédaction&nbsp;;</li>
-<li>réorganiser n'importe quelle dépêche en rédaction&nbsp;;</li>
-<li>utiliser l'<a href="//linuxfr.org/redaction">espace de rédaction</a> et participer à la rédaction des contenus&nbsp;;</li>
-<li>écrire des commentaires sur les différentes ressources du site (dépêches, journaux, forums, sondages, tâches du système de suivi, tribunes) et les rééditer pendant quelques minutes&nbsp;;</li>
-<li>ajouter des tags sur les différentes ressources du site&nbsp;;</li>
-<li>publier dans les forums, les journaux, les liens ou le wiki (sous condition de <a href="#aide-karma">karma</a>)&nbsp;;</li>
-<li>noter les commentaires des autres visiteurs&nbsp;;</li>
-<li>modifier ses propres entrées dans le <a href="//linuxfr.org/suivi">système de suivi</a> ou dans les forums&nbsp;;</li>
-<li>voter pour le bogue/la suggestion la plus prioritaire dans le système de suivi&nbsp;;</li>
-<li>utiliser la <a href="#aide-toolbar">barre d'outils</a> du site&nbsp;;</li>
-<li>choisir l'<a href="//linuxfr.org/stylesheet/modifier">apparence du site</a> (choix de la CSS)&nbsp;;</li>
-<li><a href="//linuxfr.org/compte/modifier">publier ou non</a> son adresse de courriel et/ou de messagerie instantanée pour être contacté(e)&nbsp;;</li>
-<li>voir les commentaires ajoutés depuis sa dernière visite&nbsp;;</li>
-<li>voir ses dernières contributions regroupées dans sa page personnelle&nbsp;;</li>
-<li>accéder à ses dépêches en modération ou en rédaction dans son <a href="//linuxfr.org/tableau-de-bord">tableau de bord</a>&nbsp;;</li>
-<li>choisir un avatar&nbsp;;</li>
-<li>publier l'adresse de son site personnel associée à son compte (sous condition de <a href="#aide-karma">karma</a>)&nbsp;;</li>
-<li>afficher ou non les signatures ou les avatars, ou afficher par défaut les journaux notés négativement&nbsp;;</li> 
-<li>être remarqué pour la qualité de ses contributions et devenir animateur de l'espace de rédaction ou modérateur.</li>
+<li><a href="//linuxfr.org/redaction">écrire en coopération</a> une dépêche dans l’espace de rédaction ;</li>
+<li>réorganiser n’importe quelle dépêche en rédaction ;</li>
+<li>utiliser l’<a href="//linuxfr.org/redaction">espace de rédaction</a> et participer à la rédaction des contenus ;</li>
+<li>écrire des commentaires sur les différentes ressources du site (dépêches, journaux, forums, sondages, tâches du système de suivi, tribunes) et les rééditer pendant quelques minutes ;</li>
+<li>ajouter des étiquettes (<em>tags</em>) sur les différentes ressources du site ;</li>
+<li>publier dans les forums, les journaux, les liens ou le wiki (sous condition de <a href="#aide-karma">karma</a>) ;</li>
+<li>noter les commentaires des autres visiteurs ;</li>
+<li>modifier ses propres entrées dans le <a href="//linuxfr.org/suivi">système de suivi</a> ou dans les forums ;</li>
+<li>voter pour les bogues ou suggestions les plus prioritaires dans le système de suivi ;</li>
+<li>utiliser la <a href="#aide-toolbar">barre d’outils</a> du site ;</li>
+<li>choisir l’<a href="//linuxfr.org/stylesheet/modifier">apparence du site</a> (choix de la CSS) ;</li>
+<li><a href="//linuxfr.org/compte/modifier">publier ou non</a> son adresse de courriel ou de messagerie instantanée pour être contacté ;</li>
+<li>voir les commentaires ajoutés depuis sa dernière visite ;</li>
+<li>voir ses dernières contributions regroupées dans sa page personnelle ;</li>
+<li>accéder à ses dépêches en modération ou en rédaction dans son <a href="//linuxfr.org/tableau-de-bord">tableau de bord</a> ;</li>
+<li>choisir un avatar ;</li>
+<li>publier l’adresse de son site personnel associée à son compte (sous condition de <a href="#aide-karma">karma</a>) ;</li>
+<li>afficher ou non les signatures ou les avatars, ou afficher par défaut les journaux notés négativement ;</li>
+<li>être remarqué pour la qualité de ses contributions et devenir animateur de l’espace de rédaction ou modérateur.</li>
 </ul>
 
-<p>Par rapport à un visiteur, un animateur de l'espace de rédaction (rôle <i>editor</i>) peut&nbsp;:</p>
+<p>Par rapport à un visiteur, un animateur de l’espace de rédaction (rôle <i>editor</i>) peut :</p>
 <ul>
-<li>envoyer n'importe quelle dépêche en rédaction vers la modération&nbsp;;</li>
-<li>réattribuer n'importe quelle dépêche en rédaction à un autre compte&nbsp;;</li>
-<li>étigueter (tag) n'importe quelle dépêche en rédaction&nbsp;;</li>
-<li>relancer les contributeurs de n'importe quelle dépêche en rédaction&nbsp;;</li>
-<li>supprimer une dépêche en rédaction&nbsp;;</li>
-<li>modifier l'indicateur d'urgence sur une dépêche en rédaction.</li>
+<li>envoyer n’importe quelle dépêche en rédaction vers la modération ;</li>
+<li>réattribuer n’importe quelle dépêche en rédaction à un autre compte ;</li>
+<li>étiqueter n’importe quelle dépêche en rédaction ;</li>
+<li>relancer les contributeurs de n’importe quelle dépêche en rédaction ;</li>
+<li>supprimer une dépêche en rédaction ;</li>
+<li>modifier l’indicateur d’urgence sur une dépêche en rédaction.</li>
 </ul>
 
-<p>L'animateur de l'espace de rédaction est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta">meta@</a> de coordination des équipes du site ainsi qu'à la liste <a href="https://lists.linuxfr.org/wws/arc/redacteurs">redacteurs@</a>.</p>
+<p>L’animateur de l’espace de rédaction est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta"><em>meta@</em></a> de coordination des équipes du site, ainsi qu’à la liste <a href="https://lists.linuxfr.org/wws/arc/redacteurs"><em>redacteurs@</em></a>.</p>
 
-<p>Par rapport à un visiteur, un modérateur (rôle <i>moderator</i>) peut&nbsp;:</p>
+<p>Par rapport à un visiteur, un modérateur (rôle <i>moderator</i>) peut :</p>
 <ul>
-<li>accéder à la tribune de modération générale et celles liées à chaque dépêche en modération&nbsp;;</li>
-<li>modérer a priori les dépêches (voter pour un rejet ou une publication ou un renvoi en rédaction, et si le seuil de décision est atteint, l'appliquer)&nbsp;;</li>
-<li>modérer a priori les sondages (édition, rejet ou publication)&nbsp;;</li>
-<li>modérer a posteriori les contenus et les commentaires (édition, suppression, déplacement)&nbsp;;</li>
-<li>modérer a posteriori les images externes&nbsp;;</li>
-<li>modérer a posteriori les tags&nbsp;;</li>
-<li>interdire temporairement à un compte utilisateur de pouvoir écrire des commentaires&nbsp;;</li>
-<li>interdire temporairement à un compte utilisateur d'écrire sur la tribune&nbsp;;</li>
+<li>accéder à la tribune de modération générale et celles liées à chaque dépêche en modération ;</li>
+<li>modérer <em>a priori</em> les dépêches (voter pour un rejet, une publication ou un renvoi en rédaction, et si le seuil de décision est atteint, l’appliquer) ;</li>
+<li>modérer <em>a priori</em> les sondages (édition, rejet ou publication) ;</li>
+<li>modérer <em>a posteriori</em> les contenus et les commentaires (édition, suppression et déplacement) ;</li>
+<li>modérer <em>a posteriori</em> les images externes ;</li>
+<li>modérer <em>a posteriori</em> les étiquetages ;</li>
+<li>interdire temporairement à un utilisateur ou une utilisatrice de pouvoir écrire des commentaires ;</li>
+<li>interdire temporairement à un utilisateur ou une utilisatrice d’écrire sur la tribune ;</li>
 <li>proposer un journal comme dépêche.</li>
 </ul>
 
-<p>Le modérateur est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta">meta@</a> de coordination des équipes du site ainsi qu'à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/moderateurs">moderateurs@</a>.</p>
+<p>Le modérateur est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta"><em>meta@</em></a> de coordination des équipes du site ainsi qu’à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/moderateurs"><em>moderateurs@</em></a>.</p>
 
-<p>Un admin (rôle <i>admin</i>) cumule toutes les possibilités précédentes, et peut en plus&nbsp;:</p>
+<p>Un admin (rôle <i>admin</i>) cumule toutes les possibilités précédentes, et peut en plus :</p>
 <ul>
-<li>créditer le karma d'un compte de 50 points
-<li>changer le rôle d'un compte utilisateur, le fermer ou le rouvrir&nbsp;;</li>
-<li>changer les réponses de refus pour les dépêches&nbsp;;</li>
-<li>forcer la publication, le rejet ou le renvoi en rédaction d'une dépêche sans tenir compte des votes actuels, ou annuler les votes actuels&nbsp;;</li>
-<li>gérer les sections pour les dépêches&nbsp;;</li>
-<li>gérer les forums&nbsp;;</li>
-<li>gérer les catégories pour le suivi&nbsp;;</li>
-<li>gérer les bannières&nbsp;;</li>
-<li>gérer le logo&nbsp;;</li>
-<li>gérer les feuilles de style&nbsp;;</li>
-<li>gérer la liste des sites ami&nbsp;;</li>
-<li>éditer les pages statiques du site&nbsp;;</li>
-<li>lister les applications utilisant l'API du site&nbsp;;</li>
+<li>créditer le karma d’un compte de 50 points ;</li>
+<li>changer le rôle d’un compte utilisateur, le fermer ou le rouvrir ;</li>
+<li>changer les réponses de refus pour les dépêches ;</li>
+<li>forcer la publication, le rejet ou le renvoi en rédaction d’une dépêche sans tenir compte des votes actuels, ou annuler les votes actuels ;</li>
+<li>gérer les sections pour les dépêches ;</li>
+<li>gérer les forums ;</li>
+<li>gérer les catégories pour le suivi ;</li>
+<li>gérer les bannières ;</li>
+<li>gérer le logo ;</li>
+<li>gérer les feuilles de style ;</li>
+<li>gérer la liste des sites amis ;</li>
+<li>éditer les pages statiques du site ;</li>
+<li>lister les applications utilisant l’API du site ;</li>
 <li>voir les utilisations du site détectées comme abusives.</li>
 </ul>
 
-<p>L'admin est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta">meta@</a> de coordination des équipes du site ainsi qu'aux listes de discussion <a href="https://lists.linuxfr.org/wws/arc/moderateurs">moderateurs@</a> et <a href="https://lists.linuxfr.org/wws/arc/team">team@</a>.</p>
+<p>L’admin est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta"><em>meta@</em></a> de coordination des équipes du site ainsi qu’aux listes de discussion <a href="https://lists.linuxfr.org/wws/arc/moderateurs"><em>moderateurs@</em></a> et <a href="https://lists.linuxfr.org/wws/arc/team"><em>team@</em></a>.</p>
 
 
-<h2 id="aide-toolbar">Barre d'outils <a href="#aide-toolbar" class="anchor">¶</a></h2>
+<h2 id="aide-toolbar">Barre d’outils <a href="#aide-toolbar" class="anchor">¶</a></h2>
 
-<p>La barre d'outils (<i>toolbar</i>) du site n'est que pour les visiteurs authentifiés.</p>
-<p>Elle permet&nbsp;:</p>
+<p>La barre d’outils (<i>toolbar</i>) du site n’est disponible que pour les visiteurs authentifiés.</p>
+<p>Elle permet :</p>
 <ul>
-	<li>d'adapter le seuil de visualisation des commentaires (à -42 vous aurez tout, même les commentaires les plus mal notés)</li>
-	<li>d'enrouler / dérouler un commentaire avec une élégante petite case [-] ou [+]. C'est notamment utile pour les commentaires masqués à cause du seuil de visualisation, pour éviter d'avoir à ouvrir un nouvel onglet/une nouvelle page pour tout de même lire le commentaire</li>
-	<li>de bénéficier d'une navigation rapide à la souris, en cliquant sur &lt; # &gt;, de nouveau commentaire en nouveau commentaire, pour ne pas user la molette de votre souris</li>
-	<li>de bénéficier d'une navigation rapide au clavier, avec les touches &lt; et &gt; (j et k fonctionnent aussi), de nouveau commentaire en nouveau commentaire, et pour les nouveaux commentaires sur les contenus [ et ] (h et l fonctionnent aussi), pour ne pas lâcher votre clavier des mains pour utiliser une souris</li>
-        <li>de retourner en haut de la page en appuyant sur g ou en bas de la page avec G</li> 
+<li>d’adapter le seuil de visualisation des commentaires (à -42 vous aurez tout, même les commentaires les plus mal notés) ;</li>
+<li>d’enrouler ou dérouler un commentaire avec les élégantes petites cases <code>[-]</code> et <code>[+]</code> ; c’est notamment utile pour les commentaires masqués à cause du seuil de visualisation, pour éviter d’avoir à ouvrir un nouvel onglet ou une nouvelle page pour tout de même lire le commentaire ;</li>
+<li>de bénéficier d’une navigation rapide à la souris, en cliquant sur #, de nouveau commentaire en nouveau commentaire, pour ne pas user la molette de votre souris ;</li>
+<li>de bénéficier d’une navigation rapide au clavier, avec les touches <code>&lt;</code> et <code>&gt;</code> (<code>j</code> et <code>k</code> fonctionnent aussi), de nouveau commentaire en nouveau commentaire, et pour les nouveaux commentaires sur les contenus <code>[</code> et <code>]</code> (<code>h</code> et <code>l</code> fonctionnent aussi), pour ne pas lâcher votre clavier des mains pour utiliser une souris ;</li>
+        <li>de retourner en haut de la page en appuyant sur <code>g</code> ou en bas de la page avec <code>G</code>.</li>
 </ul>
-<p>L'aide mémoire des raccourcis clavier est disponible en appuyant sur la touche ?.
+<p>L’aide mémoire des raccourcis clavier est disponible en appuyant sur la touche <code>?</code>.
+
+<h2 id="aide-boiteperso">Boîte d’identification personnelle <a href="#aide-boiteperso" class="anchor">¶</a></h2>
 
 
-<h2 id="aide-boiteperso">Boîte d'identification personnelle <a href="#aide-boiteperso" class="anchor">¶</a></h2>
-
-<p>Une boîte d'identification personnelle apparaît sur chaque page sous le logo. Elle contient différentes informations :</p>
+<p>Une boîte d’identification personnelle apparaît sur chaque page sous le logo, elle contient différentes informations :</p>
 <ul>
-	<li>Votre login qui pointe vers l'adresse de votre page personnelle LinuxFr.org&nbsp;;</li>
-	<li>Une ligne qui vous donne le nombre de fois où vous pouvez encore donner votre avis sur un commentaire aujourd'hui ainsi que le total quotidien. Si vous n'avez pas cette ligne c'est que vous n'avez pas la possibilité de le faire&nbsp;;</li>
-	<li>Différents liens pour la gestion de votre compte&nbsp;;</li>
+<li>votre nom d’utilisateur qui pointe vers l’adresse de votre page personnelle <em>LinuxFr.org</em> ;</li>
+<li>une ligne qui vous donne le nombre de fois où vous pouvez encore donner votre avis sur un commentaire aujourd’hui, ainsi que le total quotidien ; si vous n’avez pas cette ligne, c’est que vous n’avez pas la possibilité de le faire ;</li>
+<li>différents liens pour la gestion de votre compte/</li>
 </ul>
-<p><i>Note</i> : Le nombre d'avis auquel vous avez droit peut évoluer.</p>
+<p><em>Note : le nombre d’avis auquel vous avez droit peut évoluer.</em></p>
 
 
-<h2 id="aide-note">Notes sur les contenus <a href="#aide-note" class="anchor">¶</a></h2>
+<h2 id="aide-note">Notes sur les contenus <a href="#aide-note" class="anchor">¶</a></h2>
 
 <p>
-	Les contenus du site (dépêches, journaux, forums, sondages, système de suivi, liens, etc.)
-	peuvent être notés pertinent (+1) ou inutile (-1).
+Chaque contenu du site (dépêche, journal, forum, sondage, entrée de suivi, lien, etc.)
+peut être noté pertinent (+1) ou inutile (-1).
 </p>
 <p>
-	Il n'est pas possible de noter ses propres contenus, de noter un même contenu plusieurs fois
-	ou de noter les contenus anciens. Il faut être authentifié pour pouvoir noter un
-	contenu. L'affichage de la nouvelle note peut être légèrement différée pour des raisons techniques
-	(systèmes de cache en place sur le site).
+Il n’est pas possible de noter ses propres contenus, de noter un même contenu plusieurs fois
+ou de noter les contenus anciens. Il faut être authentifié pour pouvoir noter un contenu.
+L’affichage de la nouvelle note peut être légèrement différé pour des raisons techniques
+(systèmes de cache en place sur le site).
 </p>
 <p>
-	La <b>note</b> globale d'un contenu est la somme des notes pertinent (+1) et inutile (-1)
-	mises par les visiteurs. Elle peut être positive, négative ou nulle.
+La <b>note</b> globale d’un contenu est la somme des notes pertinent (+1) et inutile (-1)
+données par les visiteurs. Elle peut être positive, négative ou nulle.
 </p>
 <p>
-	L'<b>intérêt</b> d'un contenu est un indicateur calculé à partir de la date de création
-	et de la note globale du contenu. Il sert à trier les contenus récents et bien notés (donc soit
-	les plus récents, soit les suffisamment bien notés et pas trop anciens).
+L’<b>intérêt</b> d’un contenu est un indicateur calculé à partir de la date de création
+et de la note globale du contenu. Il sert à trier les contenus récents et bien notés (donc,
+soit les plus récents, soit les suffisamment bien notés et pas trop anciens).
 </p>
-<p>intérêt = date de création + note * coefficient de contenu * coefficient de fréquence</p>
+<p>intérêt = date + note × coef. de contenu × coef. de fréquence</p>
 <ul>
-	<li>date de création en secondes depuis Epoch</li>
-	<li>coefficient de contenu =
-	<ul>
-		<li>dépêches&nbsp;: 2</li>
-		<li>forums&nbsp;: 1</li>
-		<li>journaux&nbsp;: 2</li>
-		<li>liens&nbsp;: 2</li>
-		<li>pages wiki&nbsp;: 4</li>
-		<li>sondages&nbsp;: 12</li>
-		<li>système de suivi&nbsp;: 2</li>
+<li>date : date de création en secondes depuis Epoch ;</li>
+<li>coefficient de contenu :
+<ul>
+<li>dépêches : 2,</li>
+<li>forums : 1,</li>
+<li>journaux : 2,</li>
+<li>liens : 2,</li>
+<li>pages wiki : 4,</li>
+<li>sondages : 12,</li>
+<li>système de suivi : 2 ;</li>
 </ul></li>
-	<li>coefficient de fréquence&nbsp;: 864 (~ nombre de secondes par jour / nombre de votes par jour)</li>
+<li>coefficient de fréquence : 864 (≃ nombre de secondes par jour divisé par le nombre de votes par jour).</li>
 </ul>
 
-<h2 id="aide-compteferme">Compte fermé et adresse de courriel déjà utilisée<a href="#aide-compteferme" class="anchor">¶</a></h2>
+<h2 id="aide-compteferme">Compte fermé et adresse de courriel déjà utilisée <a href="#aide-compteferme" class="anchor">¶</a></h2>
 
-<p>Une adresse de courriel ne peut être associée qu'à un seul compte. Si, à la création d'un nouveau compte, vous voyez l'erreur « Cette adresse de courriel est déjà utilisée », c'est donc qu'elle est déjà associée à un compte.</p>
-
+<p>Une adresse de courriel ne peut être associée qu’à un seul compte. Si, à la création d’un nouveau compte, vous voyez l’erreur « Cette adresse de courriel est déjà utilisée », c’est donc qu’elle est déjà associée à un compte.</p>
 <ul>
-<li>Soit il s'agit d'un compte ouvert, auquel cas il suffit de se connecter ou de redemander le renvoi de mot de passe sur l'adresse de courriel.</li>
-
-<li>Soit il s'agit d'un compte fermé, auquel cas il faut <a href="mailto:team@linuxfr.org">envoyez une demande aux administrateurs</a> pour réouverture du compte. Un compte peut avoir été fermé par l'<a href="#aide-fermercompte">utilisateur lui-même</a>, par un administrateur ou un modérateur sur demande de l'utilisateur ou pour non-respect des <a href="/regles_de_moderation">règles de modération en vigueur sur le site</a>, ou pour inactivité&nbsp;; afin de mieux
-sécuriser les mots de passe de nos utilisateurs (voir cette <a href="https://linuxfr.org/news/un-an-apres-la-mise-a-jour-majeure-du-site-grand-nettoyage-dans-les-comptes-utilisateur">dépêche <i>Un an après la mise à jour majeure du site, grand nettoyage dans les comptes utilisateur</i></a>), nous avons fermé le 31 mars 2012 les environ 35000 comptes de nos utilisateurs qui n'ont pas été utilisés entre le 20 février 2011 et le 31 mars 2012, après plusieurs relances par courriel sur les adresses de comptes concernés.</li>
+<li>soit il s’agit d’un compte ouvert, auquel cas il suffit de se connecter ou de redemander la réinitialistation du mot de passe sur l’adresse de courriel ;</li>
+<li>soit il s’agit d’un compte fermé, auquel cas il faut <a href="mailto:team@linuxfr.org">envoyez une demande aux administrateurs</a> pour réouverture du compte ; un compte peut avoir été <a href="#aide-fermercompte">fermé par l’utilisateur ou l’utilisatrice</a>, par un administrateur ou un modérateur sur demande de l’utilisateur, ou pour non‑respect des <a href="/regles_de_moderation">règles de modération en vigueur sur le site</a>, ou pour cause d’inactivité ;
+afin de mieux sécuriser les mots de passe des comptes (voir la dépêche « <a href="https://linuxfr.org/news/un-an-apres-la-mise-a-jour-majeure-du-site-grand-nettoyage-dans-les-comptes-utilisateur">Un an après la mise à jour majeure du site, grand nettoyage dans les comptes utilisateur</a> »), nous avons fermé le 31 mars 2012 les environ 35 000 comptes de nos utilisateurs qui n’ont pas été utilisés entre le 20 février 2011 et le 31 mars 2012, après plusieurs relances par courriel sur les adresses de comptes concernés.</li>
 </ul>
 
-<h2 id="aide-fermercompte">Fermer son compte <a href="#aide-fermercompte" class="anchor">¶</a></h2>
+<h2 id="aide-fermercompte">Fermer son compte <a href="#aide-fermercompte" class="anchor">¶</a></h2>
 
 <p>
-	La «&nbsp;fermeture du compte&nbsp;» consiste en une invalidation du compte, qui devient inutilisable.
-	Pour cela, après avoir lu ce qui suit, rendez-vous sur la page <a href="/compte/modifier">modifier mes préférences</a> partie <i>Fermer son compte</i>.
-	Les contenus et commentaires associés au compte restent inchangés.
-	Si vous ne souhaitez pas que les éventuels nom et prénom renseignés dans les <a href="/compte/modifier">préférences</a> ne continuent d'apparaître en ligne
-	(et soient donc indexés par les moteurs de recherche),
-	pensez à les supprimer avant de fermer le compte (le changement sera effectif à la prochaine suppression du cache temporaire LinuxFr.org).
+La « fermeture du compte » consiste en une invalidation du compte, qui devient inutilisable.
+Pour cela, après avoir lu ce qui suit, rendez‑vous sur la page <em><a href="/compte/modifier">modifier mes préférences</a></em> à la partie <i>Fermer son compte</i>.
+Les contenus et commentaires associés au compte restent inchangés.
+Si vous ne souhaitez pas que les éventuels nom et prénom renseignés dans les <a href="/compte/modifier">préférences</a> ne continuent d’apparaître en ligne
+(et soient donc indexés par les moteurs de recherche),
+pensez à les supprimer avant de fermer le compte (le changement sera effectif à la prochaine suppression du cache temporaire de <em>LinuxFr.org</em>).
 </p>
 <p>
-	Si vous souhaitez ne plus faire apparaître votre pseudo/login pour les mêmes raisons,
-	<a href="mailto:team@linuxfr.org">envoyez une demande aux administrateurs</a> de fermeture d'un compte avec anonymisation
-	(tous les contenus et commentaires associés seront affectés à Anonyme).
-	Cette dernière opération est définitive.
+Si vous souhaitez ne plus faire apparaître votre pseudo/nom d’utilisateur pour les mêmes raisons,
+<a href="mailto:team@linuxfr.org">envoyez une demande aux administrateurs</a> pour la fermeture d’un compte avec anonymisation
+(tous les contenus et commentaires associés seront affectés à « Anonyme »).
+Cette dernière opération est définitive.
 </p>
-<p>Il n'est pas possible d'utiliser à nouveau le pseudo/login ou l'adresse de courriel associés à un compte fermé&nbsp;:</p>
+<p>Il n’est pas possible d’utiliser à nouveau le pseudo, le nom d’utilisateur ou l’adresse de courriel associés à un compte fermé :</p>
 <ul>
-	<li>supprimer l'adresse de courriel d'un compte fermé nécessite de faire une demande aux administrateurs</li>
-	<li>libérer un pseudo/login nécessite une purge du compte et donc une demande aux administrateurs</li>
+<li>supprimer l’adresse de courriel d’un compte fermé nécessite de faire une demande aux administrateurs ;</li>
+<li>libérer un pseudo/nom d’utilisateur nécessite une purge du compte, et donc une demande aux administrateurs.</li>
 </ul>
 <p>
-	La «&nbsp;purge du compte&nbsp;» consiste à totalement supprimer le compte et à anonymiser ou supprimer tous les contenus associés.
-	Seuls les administrateurs peuvent réaliser cette opération, définitive par nature.
+La « purge du compte » consiste à totalement supprimer le compte et à anonymiser ou supprimer tous les contenus associés.
+Seuls les administrateurs peuvent réaliser cette opération, définitive par nature.
 </p>
 
 
-<h2 id="aide-certificatssl">HTTPS, certificat X.509/TLS/SSL et alertes dans les navigateurs <a href="#aide-certificatssl" class="anchor">¶</a></h2>
+<h2 id="aide-certificatssl">HTTPS, certificat X.509/TLS/SSL et alertes dans les navigateurs <a href="#aide-certificatssl" class="anchor">¶</a></h2>
 
-<p><a href="https://fr.wikipedia.org/wiki/Transport_Layer_Security">SSL/TLS</a> est un protocole de sécurisation des échanges sur le web. Lorsque vous accédez à une page du site dont l'adresse commence par https://linuxfr.org (la partie importante est le <b>s</b> de http<b>s</b>), votre navigateur web utilise le protocole SSL/TLS pour discuter avec le site LinuxFr.org. SSL/TLS repose sur l'utilisation de certificat <a href="https://fr.wikipedia.org/wiki/X.509">X.509</a>, pour qu'un site prouve, autant que possible, qu'il est bien celui qu'il prétend être et pour éviter que l'utilisateur ne soit leurré.</p>
+<p><a href="https://fr.wikipedia.org/wiki/Transport_Layer_Security">SSL/TLS</a> est un protocole de sécurisation des échanges sur le Web. Lorsque vous accédez à une page du site dont l’adresse commence par https://linuxfr.org (la partie importante est le <b>s</b> de http<b>s</b>), votre navigateur Web utilise le protocole SSL/TLS pour discuter avec le site <em>LinuxFr.org</em>. SSL/TLS repose sur l’utilisation de certificat <a href="https://fr.wikipedia.org/wiki/X.509">X.509</a>, pour qu’un site prouve, autant que possible, qu’il est bien celui qu’il prétend être et pour éviter que l’utilisateur ne soit leurré.</p>
 
-<p>LinuxFr.org utilise un certificat X.509 fourni par <a href="https://fr.wikipedia.org/wiki/Let%27s_Encrypt">Let's Encrypt</a>. Par défaut, les navigateurs embarquent les certificats racine des autorités de confiance (à savoir DST Root CA X3 et Let's Encrypt Authority X3, pour <em>Digital Signature Trust Co.</em>).</p>
+<p><em>LinuxFr.org</em> utilise un certificat X.509 fourni par <a href="https://fr.wikipedia.org/wiki/Let%27s_Encrypt">Let’s Encrypt</a>. Par défaut, les navigateurs embarquent les certificats racine des autorités de confiance (à savoir DST Root CA X3 et Let’s Encrypt Authority X3, pour <em>Digital Signature Trust Co.</em>).</p>
 
-<p>Si vous n'avez pas ou plus ces certificats racine dans votre navigateur et que vous n'avez pas rajouté le certificat racine de Digital Signature Trust Co dans votre navigateur manuellement, il est possible que votre navigateur affiche une alerte de sécurité lors de la visite d'une page https.</p>
+<p>Si vous n’avez pas ou plus ces certificats racine dans votre navigateur et que vous n’avez pas rajouté le certificat racine de Digital Signature Trust Co dans votre navigateur manuellement, il est possible que votre navigateur affiche une alerte de sécurité lors de la visite d’une page HTTPS.</p>
 
-<img alt="Capture avec Firefox 3.5 sans certificat racine" src="/images/https_firefox_3_5_sans_root_cert.png" />
+<img alt="Capture avec Firefox 3.5 sans certificat racine" src="/images/https_firefox_3_5_sans_root_cert.png" />
 
-<p>Avant le 5 juin 2015, LinuxFr.org utilisait l'autorité de certification communautaire CAcert. Entre le 5 juin 2015 et le 3 juin 2018, LinuxFr.org utilisait un certificat offert (merci à eux) par la <a href="https://www.gandi.net/fr">société Gandi</a> (un bureau d’enregistrement de noms de domaines (registrar).</p>
+<p>Avant le 5 juin 2015, <em>LinuxFr.org</em> utilisait l’autorité de certification communautaire CAcert. Entre le 5 juin 2015 et le 3 juin 2018, <em>LinuxFr.org</em> utilisait un certificat offert (merci à eux) par la <a href="https://www.gandi.net/fr">société Gandi</a>,un bureau d’enregistrement de noms de domaines (<em>registrar</em>).</p>
 
-<h2 id="aide-autrecertificatssl">Pourquoi ne prenez-vous pas un certificat X.509/SSL/TLS gratuit ou payant de chez Machin qui est par défaut dans un navigateur&nbsp;? <a href="#aide-autrecertificatssl" class="anchor">¶</a></h2>
 
-<p>La question date de l'époque de l'utilisation de CAcert, soit avant juin 2015. Depuis les certificats en provenance de <a href="https://www.gandi.net/fr">Gandi</a> ou de <a href="https://letsencrypt.org/">Let's Encrypt</a> sont reconnus par défaut par les navigateurs. La réponse ci-dessous est conservée pour des raisons historiques et pour les liens et arguments fournis.</p>
+<h2 id="aide-autrecertificatssl">Pourquoi ne prenez‑vous pas un certificat X.509/SSL/TLS gratuit ou payant de chez Machin qui est par défaut dans un navigateur ? <a href="#aide-autrecertificatssl" class="anchor">¶</a></h2>
 
-<p>Lors de l'assemblée générale de l'association LinuxFr du 6 mai 2015 (précédant la période de renouvellement des certificats du site du 5 juin 2015) a eu lieu un vote pour choisir entre continuer avec CAcert et opter une autre autorité de certification&nbsp;: il a été décidé d'opter pour une autre autorité de certification, notamment suite aux retraits des certificats racine CAcert des distributions libres.</p>
+<p>La question date de l’époque de l’utilisation de CAcert, soit avant juin 2015. Depuis, les certificats en provenance de <a href="https://www.gandi.net/fr">Gandi</a> ou de <a href="https://letsencrypt.org/">Let’s Encrypt</a> sont reconnus par défaut par les navigateurs. La réponse ci‑dessous est conservée pour des raisons historiques et pour les liens et arguments fournis.</p>
 
-<p>La gratuité n'était pas le critère principal dans le choix de CAcert. CAcert est une autorité de certification basée sur une communauté (community driven non-Profit Certificate Authority), qui propose à la fois du centralisé et du décentralisé (réseau de confiance), qui <a href="https://www.cacert.org/src-lic.php">publie son code sous licence libre</a>. De plus nous avions eu des échos positifs sur CAcert et nous avions déjà discuté avec certains de leurs admins.</p>
+<p>Lors de l’assemblée générale de l’association LinuxFr du 6 mai 2015 (précédant la période de renouvellement des certificats du site du 5 juin 2015) a eu lieu un vote pour choisir entre continuer avec CAcert et opter une autre autorité de certification : il a été décidé d’opter pour une autre autorité de certification, notamment suite aux retraits des certificats racine CAcert des distributions libres.</p>
 
-<p>Être reconnue par défaut par les navigateurs est un plus, mais si on se limite à ce seul critère, on encourage un oligopole d'autorités de confiance, dont certaines ont déjà fait montre de pratiques plus que discutables (liste non exhaustive)&nbsp;:</p>
+<p>La gratuité n’était pas le critère principal dans le choix de CAcert. CAcert est une autorité de certification basée sur une communauté (<i>community driven non‑Profit Certificate Authority</i>), qui propose à la fois du centralisé et du décentralisé (réseau de confiance), qui <a href="https://www.cacert.org/src-lic.php">publie son code sous licence libre</a>. De plus, nous avions eu des échos positifs sur CAcert et nous avions déjà discuté avec certains de leurs administrateurs.</p>
 
+<p>Être reconnue par défaut par les navigateurs est un plus, mais si l’on se limite à ce seul critère, on encourage un oligopole d’autorités de confiance, dont certaines ont déjà fait montre de pratiques plus que discutables (liste non exhaustive) :</p>
 <ul>
-    <li><a href="https://blog.mozilla.org/security/2015/04/02/distrusting-new-cnnic-certificates/">Distrusting New CNNIC Certificates</a> [CNNIC] (2015)</li>
-    <li><a href="https://www.zdnet.com/indian-government-agency-issues-fake-google-certificates-7000031396/">Indian government agency issues fake Google certificates</a> [NIC India, India CCA] (2014)</li>
-    <li><a href="https://blog.mozilla.com/security/2011/08/29/fraudulent-google-com-certificate/">Mozilla Security&nbsp;: Fraudulent *.google.com Certificate [DigiNotar, Iran]</a> (2011)</li>
-    <li><a href="https://www.zdnet.fr/actualites/des-certificats-ssl-frauduleux-de-comodo-autorisent-des-attaques-contre-les-webmails-39759360.htm">ZdNet&nbsp;: «&nbsp;Des certificats SSL frauduleux de Comodo autorisent des attaques contre les Webmails&nbsp;»</a> (2011)</li>
-    <li><a href="https://www.rue89.com/2011/03/18/tunisie-microsoft-complice-de-la-censure-numerique-par-ben-ali-195693">Rue89&nbsp;: «&nbsp;Tunisie&nbsp;: Microsoft complice de la censure numérique par Ben Ali&nbsp;»</a> (2011)</li>
-    <li>les résultats de l'<a href="https://www.eff.org/observatory">observatoire SSL de l'Electronic Frontier Foundation</a> présentés à Defcon 2010 et au CCC 2010</li>
-    <li><a href="https://en.wikipedia.org/wiki/VeriSign#Controversies">Page wikipédia Controverses autour de Verisign</a></li>
-    <li><a href="/2004/02/27/15556.html">DLFP&nbsp;: «&nbsp;Verisign attaque l'ICANN&nbsp;»</a> (2004)</li>
-    <li><a href="/2003/10/04/14186.html">DLFP&nbsp;: «&nbsp;ICANN vs. Verisign&nbsp;?&nbsp;»</a> (2003)</li>
-    <li><a href="/2003/09/23/14033.html">DLFP&nbsp;: «&nbsp;VeriSign refuse d'obtempérer&nbsp;»</a> (2003)</li>
-    <li><a href="/2003/09/21/14008.html">DLFP&nbsp;: «&nbsp;L'ICANN et l'IAB somment Verisign de suspendre leur service de redirection&nbsp;»</a> (2003)</li>
-    <li><a href="/2003/09/17/13947.html">DLFP&nbsp;: «&nbsp;VeriSign détruit l'un des fondements d'Internet&nbsp;»</a> (2003)</li>
+    <li><a href="https://blog.mozilla.org/security/2015/04/02/distrusting-new-cnnic-certificates/"><i>Distrusting New CNNIC Certificates</i></a> [CNNIC] (2015) ;</li>
+    <li><a href="https://www.zdnet.com/indian-government-agency-issues-fake-google-certificates-7000031396/"><i>Indian government agency issues fake Google certificates</i></a> [NIC India, India CCA] (2014) ;</li>
+    <li><a href="https://blog.mozilla.com/security/2011/08/29/fraudulent-google-com-certificate/"><i>Mozilla Security : Fraudulent *.google.com Certificate</i> [DigiNotar, Iran]</a> (2011) ;</li>
+    <li><a href="https://www.zdnet.fr/actualites/des-certificats-ssl-frauduleux-de-comodo-autorisent-des-attaques-contre-les-webmails-39759360.htm"><em>ZDNet</em> : « Des certificats SSL frauduleux de Comodo autorisent des attaques contre les Webmails »</a> (2011) ;</li>
+    <li><a href="https://www.rue89.com/2011/03/18/tunisie-microsoft-complice-de-la-censure-numerique-par-ben-ali-195693"><em>Rue89</em> : « Tunisie : Microsoft complice de la censure numérique par Ben Ali »</a> (2011) ;</li>
+    <li>les résultats de l’<a href="https://www.eff.org/observatory">observatoire SSL de l’Electronic Frontier Foundation</a> présentés à la Defcon 2010 et au CCC 2010 ;</li>
+    <li><a href="https://en.wikipedia.org/wiki/VeriSign#Controversies">Page wikipédia « Controverses autour de Verisign »</a> ;</li>
+    <li><a href="/2004/02/27/15556.html"><em>DLFP</em> : « Verisign attaque l’ICANN »</a> (2004) ;</li>
+    <li><a href="/2003/10/04/14186.html"><em>DLFP</em> : « ICANN vs. Verisign ? »</a> (2003) ;</li>
+    <li><a href="/2003/09/23/14033.html"><em>DLFP</em> : « VeriSign refuse d’obtempérer »</a> (2003) ;</li>
+    <li><a href="/2003/09/21/14008.html"><em>DLFP</em> : « L’ICANN et l’IAB somment Verisign de suspendre leur service de redirection »</a> (2003) ;</li>
+    <li><a href="/2003/09/17/13947.html"><em>DLFP</em> : « VeriSign détruit l’un des fondements d’Internet »</a> (2003).</li>
 </ul>
 
 
-<h2 id="aide-imgcertificatssl">Pourquoi les avatars et images ne s'affichent pas chez moi en HTTPS ?<a href="#aide-imgcertificatssl" class="anchor">¶</a></h2>
+<h2 id="aide-imgcertificatssl">Pourquoi les avatars et images ne s’affichent pas chez moi en HTTPS ? <a href="#aide-imgcertificatssl" class="anchor">¶</a></h2>
 
-<p>Comme expliqué <a href="#aide-certificatssl">précédemment</a>, il peut arriver que les certificats racine requis pour le site LinuxFr.org ne soient pas présents dans votre navigateur. Les avatars et images du site sont servis depuis un sous-domaine (img.linuxfr.org en l'occurrence). Si vous n'avez ni les certificats racine dans votre navigateur, ni une exception pour le certificat utilisé sur img.linuxfr.org, votre navigateur refusera de charger les images depuis ce sous-domaine.</p>
+<p>Comme expliqué <a href="#aide-certificatssl">précédemment</a>, il peut arriver que les certificats racines requis pour le site <em>LinuxFr.org</em> ne soient pas présents dans votre navigateur. Les avatars et images du site sont servis depuis un sous‑domaine (<em>img.linuxfr.org</em>, en l’occurrence). Si vous n’avez ni les certificats racines dans votre navigateur, ni une exception pour le certificat utilisé sur <em>img.linuxfr.org</em>, votre navigateur refusera de charger les images depuis ce sous‑domaine.</p>
 
-<p>Pour corriger ce problème, le plus simple est de <a href="#aide-certificatssl">rajouter le certificat racine</a>. Une autre méthode serait de rajouter une exception pour le certificat utilisé sur les domaines linuxfr.org et img.linuxfr.org.</p>
+<p>Pour corriger ce problème, le plus simple est de <a href="#aide-certificatssl">rajouter le certificat racine</a>. Une autre méthode serait de rajouter une exception pour le certificat utilisé sur les domaines <em>linuxfr.org</em> et <em>img.linuxfr.org</em>.</p>
 
-<p>À noter qu'il est aussi possible pour les visiteurs authentifiés de cocher/décocher la case «&nbsp;Ne pas afficher les avatars sur le site&nbsp;» dans les préférences du <a href="//linuxfr.org/compte/modifier">compte utilisateur</a>.</p>
+<p>À noter qu’il est aussi possible pour les visiteurs authentifiés de cocher/décocher la case « Ne pas afficher les avatars sur le site » dans les préférences du <a href="//linuxfr.org/compte/modifier">compte utilisateur</a>.</p>
 
 
 <h2 id="aide-karma">Système de karma <a href="#aide-karma" class="anchor">¶</a></h2>
 
-<p>Le karma est une note interne qui détermine le nombre d'avis journaliers et la possibilité d'écrire sur le site.</p>
+<p>Le karma est une note interne qui détermine le nombre d’avis quotidiens et la possibilité d’écrire sur le site.</p>
 
-<p>L'influence de différentes actions sur le karma&nbsp;:</p>
+<p>L’influence de différentes actions sur le karma :</p>
 <ul>
-<li>Karma par défaut&nbsp;: 20</li>
-<li>Note «&nbsp;pertinent&nbsp;»&nbsp;: +1</li>
-<li>Note «&nbsp;inutile&nbsp;»&nbsp;: -1</li>
-<li>Dépêche publiée&nbsp;: +50 (pour l'auteur)</li>
+<li>karma par défaut : 20 ;</li>
+<li>note « pertinent » : +1 ;</li>
+<li>note « inutile » : -1 ;</li>
+<li>dépêche publiée : +50 (pour l’auteur).</li>
 </ul>
 
-<p>Le karma augmente donc lorsque l'on reçoit des notes «&nbsp;pertinent&nbsp;» (quel que soit le type de contenu ou le commentaire noté) ou que l'on publie des dépêches.</p>
+<p>Le karma augmente donc lorsque l’on reçoit des notes « pertinent » (quel que soit le type de contenu ou le commentaire noté) ou que l’on publie des dépêches.</p>
 
-<p>Le nombre d'avis quotidiens est déterminé à partir du karma. La formule est <em>max(0, min(3 + karma / 10, 100))</em> (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/account.rb">source</a>).</p>
+<p>Le nombre d’avis quotidiens est déterminé à partir du karma. La formule est <code>max(0, min(3 + karma/10, 100))</code> (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/account.rb">source</a>).</p>
 
-<p>Le score de base des commentaires dépend du karma. La formule est E( log10( karma ) ) - 1, où E() est la partie entière inférieure si le karma est strictement positif. Et c'est max(-10, -2 + E(karma/30)) pour un karma négatif ou nul. Avec un karma à 0, ça donne un score de -2 (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/comment.rb">source</a>).</p>
+<p>Le score de base des commentaires dépend du karma. La formule est <code>E(log10(karma)) - 1</code>, où <code>E()</code> est la partie entière inférieure si le karma est strictement positif. Et c’est <code>max(-10, -2 + E(karma/30))</code> pour un karma négatif ou nul. Avec un karma à 0, ça donne un score de -2 (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/comment.rb">source</a>).</p>
 
-<p>Pour pouvoir écrire un journal ou sur la tribune, il faut avoir un karma supérieur strictement à 0, et pour éditer une page de wiki, il faut un karma strictement supérieur à 20 (sources <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/diary.rb">journal</a>, <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/wiki_page.rb">wiki</a>, <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/account.rb">tribune</a>).</p>
+<p>Pour pouvoir écrire un journal ou sur la tribune, il faut avoir un karma supérieur strictement à 0, et pour éditer une page de wiki, il faut un karma strictement supérieur à 20 (sources <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/diary.rb">journal</a>, <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/wiki_page.rb">wiki</a> et <a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/models/account.rb">tribune</a>).</p>
 
-<p>Pour pouvoir afficher l'adresse de son site personnel, il faut avoir un karma supérieur strictement à 0 (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/helpers/users_helper.rb">source</a>).</p>
+<p>Pour pouvoir afficher l’adresse de son site personnel, il faut avoir un karma strictement supérieur à 0 (<a href="https://github.com/linuxfrorg/linuxfr.org/blob/master/app/helpers/users_helper.rb">source</a>).</p>
 
-<h2 id="aide-role">À quoi correspond le rôle sur la page d'un utilisateur&nbsp;? <a href="#aide-role" class="anchor">¶</a></h2>
+<h2 id="aide-role">À quoi correspond le rôle sur la page d’un utilisateur ? <a href="#aide-role" class="anchor">¶</a></h2>
 
-<p>Les différents rôles sont&nbsp;:</p>
-
+<p>Les différents rôles sont :</p>
 <ul>
-<li>admin&nbsp;: les <a href="/team">admins</a></li>
-<li>compte fermé (<i>inactive</i>)&nbsp;: les comptes fermés</li>
-<li>modérateur (<i>moderator</i>)&nbsp;: les <a href="/team">modérateurs</a></li>
-<li>animateur (<i>editor</i>)&nbsp;: les <a href="/team">animateurs de l'espace de rédaction</a></li>
-<li>visiteur ou contributeur (<i>visitor</i>)&nbsp;: les visiteurs, tous ceux qui ne sont pas dans une catégorie précédente, suivant s'ils sont déjà écrits des contenus ou non.</li>
+<li>admin : les <a href="/team">admins</a> ;</li>
+<li>compte fermé (<i>inactive</i>) : les comptes fermés ;</li>
+<li>modérateur (<i>moderator</i>) : les <a href="/team">modérateurs</a> ;</li>
+<li>animateur (<i>editor</i>) : les <a href="/team">animateurs de l’espace de rédaction</a> ;</li>
+<li>visiteur ou contributeur (<i>visitor</i>) : les visiteurs, tous ceux qui ne sont pas dans une catégorie précédente, suivant s’ils sont déjà écrits des contenus ou non.</li>
 </ul>
 
 
-<h2 id="aide-cookies">Quels sont les cookies utilisés par le site&nbsp;? <a href="#aide-cookies" class="anchor">¶</a></h2>
+<h2 id="aide-cookies">Quels sont les cookies utilisés par le site ? <a href="#aide-cookies" class="anchor">¶</a></h2>
 
-<p>Le site utilise actuellement les cookies suivant&nbsp;:</p>
-
+<p>Le site utilise actuellement les cookies suivants :</p>
 <ul>
-  <li>remember_account_token
+  <li><em>remember_account_token</em> :
   <ul>
-    <li>durée&nbsp;: courte (deux semaines)</li>
-    <li>usage&nbsp;: cookie de session sur le site</li>
-    <li>concerne&nbsp;: les utilisateurs authentifiés</li>
+    <li>durée : courte (deux semaines),</li>
+    <li>usage : cookie de session sur le site,</li>
+    <li>concerne : les utilisateurs authentifiés ;</li>
   </ul>
-  </li><li>https
+  </li><li><em>https</em> :
   <ul>
-    <li>durée&nbsp;: permanent (jusqu'en 2031)</li>
-    <li>usage&nbsp;: sa présence indiquant que l'ensemble des accès au site doivent se faire en HTTPS</li>
-    <li>concerne&nbsp;: les utilisateurs authentifiés en HTTPS</li>
+    <li>durée : permanente (jusqu’en 2031),</li>
+    <li>usage : sa présence indiquant que l’ensemble des accès au site doivent se faire en HTTPS,</li>
+    <li>concerne : les utilisateurs authentifiés en HTTPS ;</li>
   </ul>
-  </li><li>linuxfr.org_session
+  </li><li><em>linuxfr.org_session</em> :
   <ul>
-    <li>durée&nbsp;: temporaire pour la durée de la session de navigation</li>
-    <li>usage&nbsp;: cookie de session sur le site (utilisable uniquement sur les accès HTTPS si le cookie https précédent existe)</li>
-    <li>concerne&nbsp;: les utilisateurs authentifiés</li>
+    <li>durée : temporaire pour la durée de la session de navigation,</li>
+    <li>usage : cookie de session sur le site (utilisable uniquement sur les accès HTTPS si le cookie https précédent existe),</li>
+    <li>concerne : les utilisateurs authentifiés ;</li>
   </ul>
-  </li><li>stylesheet
+  </li><li><em>stylesheet</em> :
   <ul>
-    <li>durée&nbsp;: temporaire pour la durée de la session de navigation</li>
-    <li>usage&nbsp;: permet d'utiliser une feuille de style particulière uniquement pour la session en cours</li>
-    <li>concerne&nbsp;: les utilisateurs authentifiés</li>
+    <li>durée : temporaire pour la durée de la session de navigation,</li>
+    <li>usage : permet d’utiliser une feuille de style particulière uniquement pour la session en cours,</li>
+    <li>concerne : les utilisateurs authentifiés ;</li>
   </ul>
-  </li><li>totoz-type
+  </li><li><em>totoz-type</em> :
   <ul>
-    <li>durée&nbsp;: cookie permanent (jusqu'en 2042)</li>
-    <li>usage&nbsp;: choisir le type d'affichage des images dans la tribune (en surimpression, insérées dans le texte, et sans images en l'absence du cookie)</li>
-    <li>concerne&nbsp;: les visiteurs de la tribune</li>
+    <li>durée : cookie permanent (jusqu’en 2042),</li>
+    <li>usage : choisir le type d’affichage des images dans la tribune (en surimpression, insérées dans le texte, et sans images en l’absence du cookie)</li>
+    <li>concerne : les visiteurs de la tribune.</li>
   </ul>
   </li>
 </ul>
 
 
-<h2 id="aide-sondage">Sondage&nbsp;: qui peut voter et pour quoi&nbsp;? <a class="anchor" href="#aide-sondage">¶</a></h2>
+<h2 id="aide-sondage">Sondage : qui peut voter et pour quoi ? <a class="anchor" href="#aide-sondage">¶</a></h2>
 
-<p>Un sondage est une question sur un thème donné&nbsp;; les visiteurs du site LinuxFr.org peuvent choisir parmi un ensemble de réponses proposées.</p>
+<p>Un sondage est une question sur un thème donné ; les visiteurs du site <em>LinuxFr.org</em> peuvent choisir parmi un ensemble de réponses proposées.</p>
 
-<p>La liste des options proposées est volontairement limitée&nbsp;: tout l'intérêt (ou son absence) de ce type de sondage réside dans le fait de forcer les participants à faire un choix. Les réponses multiples sont interdites pour les mêmes raisons. Il est donc inutile de se plaindre au sujet du faible nombre de réponses proposées, ou de l'impossibilité de choisir plusieurs réponses. 76,78% des sondés estiment que ces sondages sont ineptes.</p>
+<p>La liste des options proposées est volontairement limitée : tout l’intérêt (ou son absence) de ce type de sondage réside dans le fait de forcer les participants à faire un choix. Les réponses multiples sont interdites pour les mêmes raisons. Il est donc inutile de se plaindre au sujet du faible nombre de réponses proposées, ou de l’impossibilité de choisir plusieurs réponses. 76,78 % des sondés estiment que ces sondages sont ineptes.</p>
 
-<p>Les utilisateurs, identifiés ou non, peuvent voter. Le système se base sur l'adresse IP du votant, limitant ainsi le vote multiple sans léser les utilisateurs qui accéderaient au site depuis une même adresse IP (<a href="https://fr.wikipedia.org/wiki/Proxy" title="Définition Wikipédia">proxy</a>, <a href="https://fr.wikipedia.org/wiki/NAT" title="Définition Wikipédia">NAT</a>, adresse IP dynamique, etc.). Il est possible, pour une même IP, de voter une fois chaque jour.</p>
+<p>Les utilisateurs, identifiés ou non, peuvent voter. Le système se base sur l’adresse IP du votant, limitant ainsi le vote multiple sans léser les utilisateurs qui accéderaient au site depuis une même adresse IP (<a href="https://fr.wikipedia.org/wiki/Proxy" title="Définition Wikipédia">proxy</a>, <a href="https://fr.wikipedia.org/wiki/NAT" title="Définition Wikipédia">NAT</a>, adresse IP dynamique, etc.). Il est possible, pour une même adresse IP, de voter une fois chaque jour.</p>
 
-<h2 id="aide-ancienscontenus">Pourquoi est-il impossible de commenter un contenu vieux de plus de 3 mois&nbsp;? <a class="anchor" href="#aide-sondage">¶</a></h2>
 
-<p>Dans un monde idéal, LinuxFr.org laisserait tout le monde aller écrire des commentaires partout. Mais en réalité il y a des spammeurs, des monomaniaques égocentriques, des hallucinés, des prosélytes politiques/religieux/etc., bref des gens qui profiteront du fait que quasi personne d'humain n'ira lire les vieux contenus (donc pas de système d'auto-modération effectif) alors que les moteurs de recherche les indexeront. Sans parler des personnes qui attendront désespérément une réponse à leur question formulée sur un contenu ancien.</p>
+<h2 id="aide-ancienscontenus">Pourquoi est‑il impossible de commenter un contenu vieux de plus de trois mois ? <a class="anchor" href="#aide-sondage">¶</a></h2>
 
-<p>Un autre aspect légal est à prendre en compte : <a href="https://fr.wikipedia.org/wiki/Diffamation_en_droit_fran%C3%A7ais">au bout de 3 mois de parution</a> d'un contenu, la prescription standard en matière de diffamation publique est atteinte. Au bout de 6 mois, elle concerne donc aussi tous les commentaires dudit contenu. Cela limite le risque aux commentaires sur les contenus récents, au lieu de la centaine de milliers de contenus et de plus d'un million et demi de commentaires (attention il y a une prescription d'un an en cas de discrimination spécialement interdite par exemple).</p>
+<p>Dans un monde idéal, <em>LinuxFr.org</em> laisserait tout le monde aller écrire des commentaires partout. Mais en réalité, il y a des spammeurs, des monomaniaques égocentriques, des hallucinés, des prosélytes politiques ou religieux, etc. Bref, des gens qui profiteront du fait que quasi personne d’humain n’ira lire les vieux contenus (donc pas de système d’auto‐modération effectif) alors que les moteurs de recherche les indexeront. Sans parler des personnes qui attendront désespérément une réponse à leur question formulée sur un contenu ancien.</p>
 
-<h2 id="aide-nouveautes">Comment être notifié(e) des nouveaux commentaires sur un contenu déjà visité&nbsp;? <a class="anchor" href="#aide-nouveautes">¶</a></h2>
+<p>Un autre aspect légal est à prendre en compte : <a href="https://fr.wikipedia.org/wiki/Diffamation_en_droit_fran%C3%A7ais">au bout de trois mois de parution</a> d’un contenu, la prescription standard en matière de diffamation publique est atteinte. Au bout de six mois, elle concerne donc aussi tous les commentaires dudit contenu. Cela limite le risque aux commentaires sur les contenus récents, au lieu de la centaine de milliers de contenus et de plus d’un million et demi de commentaires (attention, il y a une prescription d’un an en cas de discrimination spécialement interdite par exemple).</p>
 
-<p>Il faut utiliser le lien <a href="//linuxfr.org/readings">Les contenus que j'ai lus</a> (dans la partie sous le logo, disponible pour les utilisateurs authentifiés seulement) : il permet de n'afficher que les contenus que l'on a déjà visités ; ils sont triés par défaut par « dernier commentaire », donc il faut parcourir les pages jusqu'à ce qu'il n'y ait plus de nouveaux commentaires.
 
-<p>Si un contenu ne m'intéresse plus ou s'il ne m'intéresse pas à la première lecture, il est possible de cliquer sur «&nbsp;Oublier&nbsp;», il sort alors de la liste disponible dans <a href="//linuxfr.org/readings">Les contenus que j'ai lus</a>.</p>
+<h2 id="aide-nouveautes">Comment recevoir des notifications de nouveaux commentaires sur un contenu déjà visité ? <a class="anchor" href="#aide-nouveautes">¶</a></h2>
 
-<p>Sur la page <a href="//linuxfr.org/readings">Les contenus que j'ai lus</a>, la barre d'outils remplit déjà ce rôle en indiquant par exemple «&nbsp;<em>Contenus jamais visités&nbsp;: 0&nbsp;/&nbsp;0 &lt;&nbsp;|&nbsp;&gt; Contenus lus avec + de commentaires&nbsp;: 0&nbsp;/&nbsp;3 [&nbsp;|&nbsp;]</em>&nbsp;» et en permettant de se déplacer avec les raccourcis clavier indiqués (inférieur/supérieur et crochets).</p>
+<p>Il faut utiliser le lien <a href="//linuxfr.org/readings">Les contenus que j’ai lus</a> (dans la partie sous le logo, disponible pour les utilisateurs authentifiés seulement) : il permet de n’afficher que les contenus que l’on a déjà visités ; ils sont triés par défaut par « dernier commentaire ». Donc, il faut parcourir les pages jusqu’à ce qu’il n’y ait plus de nouveaux commentaires.
 
-<p>Sur les autres pages, on est actuellement notifié des réponses non-lues à ses commentaires via l'icône suivante <img src="//linuxfr.org/images/icones/chat.png" alt="notification" /> qui apparaît à côté du lien <a href="//linuxfr.org/tableau-de-bord">Mon tableau de bord</a>, mais pas de commentaires non lus sur les contenus déjà visités à côté du lien <a href="//linuxfr.org/readings">Les contenus que j'ai lus</a>.</p>
+<p>Si un contenu ne m’intéresse plus ou s’il ne m’intéresse pas à la première lecture, il est possible de cliquer sur « Oublier ». Il sort alors de la liste disponible dans <a href="//linuxfr.org/readings">les contenus que j’ai lus</a>.</p>
 
-<h2 id="aide-dlfp">DLFP&nbsp;? Da Linux French Page&nbsp;?<a class="anchor" href="#aide-dlfp">¶</a></h2>
+<p>Sur la page « <a href="//linuxfr.org/readings">Les contenus que j’ai lus</a> », la barre d’outils remplit déjà ce rôle en indiquant par exemple « <em>Contenus jamais visités : 0 / 0 &lt; | &gt; Contenus lus avec + de commentaires : 0 / 3 [ | ]</em> » et en permettant de se déplacer avec les raccourcis clavier indiqués (inférieur, supérieur et crochets).</p>
 
-<p>Le site LinuxFr.org a été et est encore parfois appelé Da Linux French Page ou simplement DLFP. On peut retrouver cette appellation sur d'<a href="//linuxfr.org/images/logos/">anciens logos</a> par exemple.
+<p>Sur les autres pages, on est actuellement notifié des réponses non lues à ses commentaires via l’icône <img src="//linuxfr.org/images/icones/chat.png" alt="notification" /> qui apparaît à côté du lien « <a href="//linuxfr.org/tableau-de-bord">Mon tableau de bord</a> », mais pas de commentaires non lus sur les contenus déjà visités à côté du lien « <a href="//linuxfr.org/readings">Les contenus que j’ai lus</a> ».</p>
 
-<h2 id="aide-multis">Comptes multiples ou «&nbsp;multis&nbsp;»<a class="anchor" href="#aide-multis">¶</a></h2>
 
-<p>Toute création de comptes multiples par une même personne, qu'elle qu'en soit la raison, <em>pour une utilisation simultanée</em> de ces comptes, est considérée comme un abus de ressources. Cette pratique est souvent utilisée avec une volonté de manipulation du système de karma (notes en masse). Elle est donc interdite et les comptes sont fermés en cas de détection par l'équipe du site.</p>
+<h2 id="aide-dlfp">DLFP ? <em>Da Linux French Page</em> ? <a class="anchor" href="#aide-dlfp">¶</a></h2>
 
-<p>Il est bien ici question de comptes actifs simultanément&nbsp;: cette interdiction ne concerne pas les personnes ayant fermé leur compte et souhaitant en rouvrir un autre plus tard par exemple.</p>
+<p>Le site <em>LinuxFr.org</em> a été et est encore parfois appelé <em>Da Linux French Page<em> ou simplement DLFP. On peut retrouver cette appellation sur d’<a href="//linuxfr.org/images/logos/">anciens logos</a>, par exemple.
 
-<p>Le souci habituel posé par les comptes multiples <em>actifs</em> concerne les diverses manipulations possibles, comme encenser son propre contenu ou commentaire en utilisant des commentaires d'autres comptes à soi, voter massivement pour soi, ou pour ou contre quelqu'un, etc.</p>
 
-<h2 id="aide-offresemploi">Peut-on proposer des offres d'emploi sur le site&nbsp;?<a class="anchor" href="#aide-offresemploi">¶</a></h2>
+<h2 id="aide-multis">Comptes multiples ou « multis » <a class="anchor" href="#aide-multis">¶</a></h2>
 
-<p>Vous pouvez <a href="//linuxfr.org/posts/nouveau?forum_id=45">poster votre offre</a> dans le <a href="//linuxfr.org/forums/general-petites-annonces">forum général.petites-annonces</a> qui peut être utilisé pour les offres d'emploi.</p>
+<p>Toute création de comptes multiples par une même personne, qu’elle qu’en soit la raison, <em>pour une utilisation simultanée</em> de ces comptes, est considérée comme un abus de ressources. Cette pratique est souvent utilisée avec une volonté de manipulation du système de karma (notes en masse). Elle est donc interdite et les comptes sont fermés en cas de détection par l’équipe du site.</p>
 
-<p>Nos visiteurs vous demanderont les informations suivantes de toute façon, donc nous vous recommandons de les donner initialement dans votre offre: localisation, type de contrat (durée déterminée ou indéterminée, etc.), fourchette de salaire, niveau demandé, avantages possibles, etc.</p>
+<p>Il est bien ici question de comptes actifs simultanément : cette interdiction ne concerne pas les personnes ayant fermé leur compte et souhaitant en rouvrir un autre plus tard, par exemple.</p>
 
-<p>Si ce n'est pas déjà fait, vous avez probablement aussi intérêt à publier votre offre sur <a href="http://fr.lolix.org/">Lolix</a> et <a href="https://www.linuxjobs.fr/">LinuxJobs</a> qui publient des offres/demandes autour du logiciel libre.</p>
+<p>Le souci habituel posé par les comptes multiples <em>actifs</em> concerne les diverses manipulations possibles, comme encenser son propre contenu ou commentaire en utilisant des commentaires d’autres comptes à soi, voter massivement pour soi, ou pour ou contre quelqu’un, etc.</p>
+
+
+<h2 id="aide-offresemploi">Peut‑on proposer des offres d’emploi sur le site ? <a class="anchor" href="#aide-offresemploi">¶</a></h2>
+
+<p>Vous pouvez <a href="//linuxfr.org/posts/nouveau?forum_id=45">poster votre offre</a> dans le <a href="//linuxfr.org/forums/general-petites-annonces">forum <em>général.petites-annonces</em></a> qui peut être utilisé pour les offres d’emploi.</p>
+
+<p>Nos visiteurs vous demanderont les informations suivantes de toute façon ; donc, nous vous recommandons de les donner initialement dans votre offre : localisation, type de contrat (durée déterminée ou indéterminée, etc.), fourchette de salaire, niveau demandé, avantages possibles, etc.</p>
+
+<p>Si ce n’est pas déjà fait, vous avez probablement aussi intérêt à publier votre offre sur <a href="http://fr.lolix.org/">Lolix</a> et <a href="https://www.linuxjobs.fr/">LinuxJobs</a> qui publient des offres et demandes autour du logiciel libre.</p>
+
+<h2 id="aide-fairemonexercice">Forums : je n’arrive pas à faire mon exercice (ou j’ai la flemme de le faire), voici l’énoncé. Merci. <a class="anchor" href="#aide-dlfp">¶</a></h2>
+
+<p>Si vous vous attendez à ce que quelqu’un le fasse à votre place, il n’y aura pas de problème, mais ça ne sera pas gratuit. Sinon, postez ce que vous avez commencé à faire et nous vous aiderons.</p>
+ 
+<p>En effet, il arrive régulièrement que des gens qui ont un problème avec leur exercice viennent ici pour demander que quelqu’un le fasse à leur place (ou alors ils formulent leur demande maladroitement). En général il y a toujours une réponse favorable à cette demande, mais contre rémunération. Certains trouvent ça malhonnête, ou les tarifs prohibitifs, mais ce n’est pas le point de vue de tout le monde.</p>
+ 
+<p>Dans la vie, lorsqu’on ne sait pas faire quelque chose, soit on apprend à le faire, soit on le fait faire par quelqu’un. Et quand on le fait faire par quelqu’un, souvent ce n’est pas gratuit. Alors certes les tarifs demandés peuvent paraître élevés, mais en général ils sont conformes à ce qui se fait dans le milieu de la prestation informatique. Parce que oui, demander à quelqu’un d’écrire du code pour résoudre un problème, c’est une prestation informatique. Et oui, c’est un métier qui aujourd’hui est plutôt bien rémunéré.</p>
+
+<p>Alors si vous aussi vous voulez gagner plein de thunes, et facturer plus de 75 euros de l’heure un bête hello world ou un truc un peu plus compliqué, commencez par essayer de faire votre travail. Relisez l’énoncé. En posant votre question, essaiez de le reformuler comme vous l’avez compris. Si vous n’avez rien compris, dites-le «·j’ai pas compris ce que je dois faire. Quelqu’un peut-il me l’expliquer?·» (si possible en indiquant le chapitre du cours que vous examinez, ça peut aider à resituer le contexte). Si vous avez compris l’énoncé, mais que vous n’arrivez pas à coder, relisez vos cours. Écrivez quelque chose même si c’est faux, et postez votre code. Vous trouverez alors quelqu’un qui sera en mesure de vous expliquer ce que vous avez bien fait et ce qui ne va pas. En agissant comme ça vous pourrez comprendre, et avec le temps, vous pourrez à votre tour demander à une bonne rémunération pour écrire du code.</p>

--- a/db/pages/code_source_du_site.html
+++ b/db/pages/code_source_du_site.html
@@ -1,20 +1,20 @@
 <p>
-  Le code source du site web LinuxFr.org est placé sous licence <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public License</a>.
-  Il est versionné avec git.
-  Le dépôt principal se trouve sur le serveur LinuxFr.org. Vous pouvez en trouver une copie sur <a href="https://github.com/linuxfrorg/linuxfr.org" rel="source">github</a>. Les contributions (par exemple les <i>pull requests</i>) sont les bienvenues.
+  Le code source du site Web <em>LinuxFr.org</em> est placé sous licence <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public License</a>.
+  Il est versionné avec Git.
+  Le dépôt principal se trouve sur le serveur <em>LinuxFr.org</em>. Vous pouvez en trouver une copie sur <a href="https://github.com/linuxfrorg/linuxfr.org" rel="source">github</a>. Les contributions (par exemple, les demandes d’intégration Git — <i>pull requests</i>) sont les bienvenues.
 </p>
-<p>Le site est principalement codé en Ruby (ainsi que du Go, de l'HTML, CSS, JS, etc.) en utilisant le framework web Ruby On Rails.</p>
+<p>Le site est principalement codé en Ruby (ainsi que du Go, du HTML, des feuilles de style CSS, du JavaScript, etc.) en utilisant le cadriciel Web <a href="https://fr.wikipedia.org/wiki/Ruby_on_Rails">Ruby on Rails</a>.</p>
 <p>
-  L'avatar par défaut est une version modifiée de <a href="https://fr.wikipedia.org/wiki/Tux">Tux</a>.
-</p>
-<p>
-  Certaines icônes utilisées sur le site proviennent du jeu d'icônes <a href="https://somerandomdude.com/projects/iconic/">Iconic Set</a>, sous <a href="https://creativecommons.org/licenses/by-sa/3.0/us/">licence CC by-sa 3.0</a>.
+  L’avatar par défaut est une version modifiée de <a href="https://fr.wikipedia.org/wiki/Tux">Tux</a>.
 </p>
 <p>
-  Le logo Android provient de la page <a href="https://www.android.com/branding.html">https://www.android.com/branding.html</a> (licence CC by-sa).
-<p>
-  Si vous souhaitez remonter un bug, proposer une évolution ou fournir un patch, vous pouvez le faire dans <a href="/suivi">le suivi.</a>
+  Certaines icônes utilisées sur le site proviennent du jeu d’icônes <a href="https://somerandomdude.com/projects/iconic/">Iconic Set</a>, sous <a href="https://creativecommons.org/licenses/by-sa/3.0/us/">licence CC By‑SA 3.0</a>.
 </p>
 <p>
-  Le <a href="/changelog">Changelog</a> affiche la liste des dernières modifications apportées au site.
+  Le logo Android provient de la page <a href="https://www.android.com/branding.html">https://www.android.com/branding.html</a> (licence CC By‑SA).
+<p>
+  Si vous souhaitez remonter un bogue, proposer une évolution ou fournir un correctif, vous pouvez le faire dans <a href="/suivi">le suivi.</a>
+</p>
+<p>
+  Le <a href="/changelog">journal des modifications</a> affiche la liste des dernières modifications apportées au site.
 </p>

--- a/db/pages/developer.html
+++ b/db/pages/developer.html
@@ -1,59 +1,58 @@
 <h2>Principes généraux</h2>
 
 <p>
-  LinuxFr.org expose une API Rest au format JSON dont l'authentification repose
-  sur OAuth2. Celle-ci est en cours de développement et ne propose pour le
-  moment que peu de méthodes. Si vous avez des besoins particuliers pour cette
-  API qui ne sont pas encore implémentés, n'hésitez pas à
+  <em>LinuxFr.org</em> expose une API <a href="https://fr.wikipedia.org/wiki/Representational_state_transfer">REST</a>
+  au format JSON dont l’authentification repose sur OAuth2.
+  Celle‑ci est en cours de développement et ne propose pour le
+  moment que peu de méthodes. Si vous avez des besoins particuliers pour
+  cette API qui ne sont pas encore implémentés, n’hésitez pas à
   <a href="/suivi/nouveau">créer une entrée dans le suivi</a>.
 </p>
-
-
 
 <h2>OAuth2</h2>
 
 <p>
   <a href="https://oauth.net/2/">OAuth2</a> est un protocole qui permet à des
-  applications externes de demander l'autorisation d'accéder à des informations
-  privées d'un utilisateur avec un compte LinuxFr.org et de faire des actions
-  en son nom. L'utilisateur n'a pas besoin de fournir son mot de passe au site
-  externe et reste maître des autorisations qu'il a fournies.
+  applications externes de demander l’autorisation d’accéder à des informations
+  privées d’un utilisateur avec un compte <em>LinuxFr.org</em> et de faire des actions
+  en son nom. L’utilisateur n’a pas besoin de fournir son mot de passe au site
+  externe et reste maître des autorisations qu’il a fournies.
 </p>
 
 <p>
-  Si vous êtes un développeur d'applications web et que vous souhaitez utiliser
-  l'API de LinuxFr.org, la première chose à faire est d'
-  <a href="/api/applications">enregistrer votre application</a>. Vous
-  obtiendrez ainsi un identifiant et un secret qui vous serviront lors des
-  échanges OAuth. Le secret doit, comme son nom l'indique, rester secret.
+  Si vous êtes un développeur d’applications Web et que vous souhaitez utiliser
+  l’API de <em>LinuxFr.org</em>, la première chose à faire est
+  d’<a href="/api/applications">enregistrer votre application</a>.
+  Vous obtiendrez ainsi un identifiant et un secret qui vous serviront lors des
+  échanges OAuth. Le secret doit, comme son nom l’indique, rester secret.
 </p>
 
 <p>
-  OAuth fonctionne avec un principe de jetons. Quand une application web
+  OAuth fonctionne avec un principe de jetons. Quand une application Web
   souhaite accéder aux données confidentielles de l'utilisateur, il va demander
-  à l'utilisateur un jeton d'autorisation qui sera délivré par LinuxFr.org,
+  à l’utilisateur un jeton d’autorisation qui sera délivré par <em>LinuxFr.org</em>,
   puis il pourra utiliser ce jeton pour accéder aux informations.
 </p>
 
 <p>
-  LinuxFr.org utilise la bibliothèque Ruby
+  <em>LinuxFr.org</em> utilise la bibliothèque Ruby
   <a href="https://github.com/doorkeeper-gem/doorkeeper">Doorkeeper</a>
   pour gérer la partie OAuth2. Aussi, nous vous conseillons ces deux liens si
-  vous souhaitez utiliser l'API de LinuxFr.org :
+  vous souhaitez utiliser l’API de <em>LinuxFr.org</em> :
+  <ol>
+    <li><a href="https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples"><i>API endpoint descriptions and examples</i></a> ;</li>
+    <li><a href="https://github.com/doorkeeper-gem/doorkeeper/wiki/Interacting-as-an-OAuth-client-with-Doorkeeper"><i>Interacting as an OAuth client with Doorkeeper</a><i>.</li>
+  </ol>
 </p>
-<ol>
-  <li><a href="https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples">API endpoint descriptions and examples</a></li>
-  <li><a href="https://github.com/doorkeeper-gem/doorkeeper/wiki/Interacting-as-an-OAuth-client-with-Doorkeeper">Interacting as an OAuth client with Doorkeeper</a></li>
-</ol>
 
 
-<h2>Obtention d'un jeton d'autorisation</h2>
+<h2>Obtention d’un jeton d’autorisation</h2>
 
-<h3>Redirection de l'utilisateur vers LinuxFr.org</h3>
+<h3>Redirection de l’utilisateur vers LinuxFr.org</h3>
 
 <p>
-  La première étape consiste à envoyer l'utilisateur sur LinuxFr.org pour
-  qu'il puisse accepter ou refuser de donner l'autorisation.
+  La première étape consiste à envoyer l’utilisateur sur <em>LinuxFr.org</em>
+  pour qu’il puisse accepter ou refuser de donner l’autorisation.
 </p>
 <pre>
 GET https://linuxfr.org/api/oauth/authorize
@@ -63,37 +62,37 @@ GET https://linuxfr.org/api/oauth/authorize
 <dl>
   <dt><var>client_id</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - L'identifiant de l'application lors
-    de l'inscription sur LinuxFr.org.
+    Chaîne de caractères obligatoire — l’identifiant de l’application lors
+    de l’inscription sur <em>LinuxFr.org</em>.
   </dd>
   <dt>redirect_uri</dt>
   <dd>
-    Chaîne de caractères obligatoire - L'URL vers laquelle sera redirigé
-    l'utilisateur après l'autorisation.
+    Chaîne de caractères obligatoire — l’URL vers laquelle sera redirigé
+    l’utilisateur ou l’utilisatrice après l’autorisation.
   </dd>
   <dt>response_type</dt>
   <dd>
-    Chaîne de caractères obligatoire - <var>code</var> dans le flux d'OAuth2 le
+    Chaîne de caractères obligatoire — <var>code</var> dans le flux d’OAuth2 le
     plus courant.
   </dd>
   <dt>scope</dt>
   <dd>
-    Chaîne de caractères facultative - la liste des scopes demandées, séparés
-    par des espaces (URL encodés en +). Cela indique les actions que
-    l'application pourra faire au nom de l'utilisateur. Exemple :
+    Chaîne de caractères facultative — la liste des scopes demandées, séparés
+    par des espaces (URL encodés en +). Cela indique les actions que
+    l’application pourra faire au nom de l’utilisateur. Exemple :
     <var>scope=account+board</var>. Par défaut, seul le scope
     <var>account</var> sera fourni.
   </dd>
 </dl>
 
 
-<h3>L'utilisateur revient sur le site</h3>
+<h3>L’utilisateur revient sur le site</h3>
 
 <p>
-  Si l'utilisateur accepte l'autorisation, il est renvoyé sur le site d'origine
-  avec un <var>code</var> temporaire. Le code sera passé dans la <i>query
-  string</i> sur l'URL de redirection. Le site peut alors échanger ce code
-  contre le jeton d'autorisation.
+  Si l’utilisateur accepte l’autorisation, il est renvoyé sur le site d’origine
+  avec un <var>code</var> temporaire. Le code sera passé dans la <i>query string</i>
+  sur l’URL de redirection. Le site peut alors échanger ce code contre le jeton
+  d’autorisation.
 </p>
 <pre>
 POST https://linuxfr.org/api/oauth/token
@@ -103,28 +102,28 @@ POST https://linuxfr.org/api/oauth/token
 <dl>
   <dt><var>client_id</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - L'identifiant de l'application lors
-    de l'inscription sur LinuxFr.org.
+    Chaîne de caractères obligatoire — l’identifiant de l’application lors
+    de l’inscription sur <em>LinuxFr.org</em>.
   </dd>
   <dt><var>client_secret</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - Le secret de l'application lors
-    de l'inscription sur LinuxFr.org.
+    Chaîne de caractères obligatoire — le secret de l’application lors
+    de l’inscription sur <em>LinuxFr.org</em>.
   </dd>
   <dt><var>code</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - Le code reçu à l'étape 1.
+    Chaîne de caractères obligatoire — le code reçu à l’étape 1.
   </dd>
   <dt><var>grant_type</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - Le format d'authentification utilisé,
-    "authorization_code" pour une application web.
+    Chaîne de caractères obligatoire — le format d’authentification utilisé,
+    "authorization_code" pour une application Web.
   </dd>
   <dt><var>redirect_uri</var></dt>
   <dd>
-    Chaîne de caractères obligatoire - L'URI vers laquelle l'utilisateur
-    sera redirigé après obtention du token (doit être la même que celle
-    indiquée lors de l'enregistrement de l'application).
+    Chaîne de caractères obligatoire — l’URI vers laquelle l’utilisateur
+    sera redirigé après obtention du jeton (doit être la même que celle
+    indiquée lors de l’enregistrement de l’application).
   </dd>
 </dl>
 
@@ -132,7 +131,7 @@ POST https://linuxfr.org/api/oauth/token
 <dl>
   <dt><var>access_token</var></dt>
   <dd>
-    Chaîne de caractères - Le jeton d'autorisation, également appelé
+    Chaîne de caractères — le jeton d’autorisation, également appelé
     <var>bearer_token</var>.
   </dd>
   <dt><var>refresh_token</var></dt>
@@ -141,26 +140,26 @@ POST https://linuxfr.org/api/oauth/token
   </dd>
   <dt><var>expires_in</var></dt>
   <dd>
-    Entier - Nombre de secondes avant expiration de l'<var>access_token</var>.
+    Entier — Nombre de secondes avant expiration du jeton d’accès <var>access_token</var>.
   </dd>
 </dl>
 
 
 
-<h2>Méthodes d'API</h2>
+<h2>Méthodes d’API</h2>
 
 <p>
-  Lors de l'appel des méthodes d'API, le <var>bearer_token</var> peut être
+  Lors de l’appel des méthodes d’API, le <var>bearer_token</var> peut être
   envoyé soit en paramètre GET ou POST (suivant la méthode requise pour la
-  requête) soit dans les headers HTTP :
-
+  requête) soit dans les en‑têtes HTTP :
+</p>
 <pre>
 Authorization: Bearer cf075a5c84bbb9489bdca8d18c51937cc69af6b23e06cfc5f0a52e2eef3f6339
 </pre>
 
 <h3>Authentification</h3>
 
-<p>Scope nécessaire : <var>account</var></p>
+<p>Scope nécessaire : <var>account</var></p>
 
 <pre>
 GET https://linuxfr.org/api/v1/me
@@ -169,25 +168,25 @@ GET https://linuxfr.org/api/v1/me
 <h4>Paramètres</h4>
 <dl>
   <dt><var>bearer_token</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le jeton d'autorisation.</dd>
+  <dd>Chaîne de caractères obligatoire — le jeton d’autorisation.</dd>
 </dl>
 
 <h4>Réponse</h4>
 <dl>
   <dt><var>login</var></dt>
   <dd>
-    Chaîne de caractères - L'identifiant du compte utilisateur sur
-    LinuxFr.org.
+    Chaîne de caractères — l’identifiant du compte utilisateur sur
+    <em>LinuxFr.org</em>.
   </dd>
   <dt><var>email</var></dt>
   <dd>
-    Chaîne de caractères - L'adresse de courriel de l'utilisateur (note :
-    elle a déjà été validée à l'inscription sur LinuxFr.org et il n'est
-    donc pas souhaitable de revalider cette adresse de courriel).
+    Chaîne de caractères — l’adresse de courriel de l’utilisateur ou 
+    l’utilisatrice (note : elle a déjà été validée à l’inscription sur <em>LinuxFr.org</em>
+    et il n’est donc pas souhaitable de revalider cette adresse de courriel).
   </dd>
   <dt><var>created_at</var></dt>
   <dd>
-    Chaîne de caractères - La date de création du compte, format ISO.
+    Chaîne de caractères — la date de création du compte au format ISO.
   </dd>
 </dl>
 
@@ -199,7 +198,7 @@ GET https://linuxfr.org/api/v1/me
 
 <h3>Proposer une dépêche</h3>
 
-<p>Scope nécessaire : <var>news</var></p>
+<p>Scope nécessaire : <var>news</var></p>
 
 <pre>
 POST https://linuxfr.org/api/v1/news
@@ -208,46 +207,47 @@ POST https://linuxfr.org/api/v1/news
 <h4>Paramètres</h4>
 <dl>
   <dt><var>bearer_token</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le jeton d'autorisation.</dd>
+  <dd>Chaîne de caractères obligatoire — le jeton d’autorisation.</dd>
   <dt><var>title</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le titre de la dépêche</dd>
+  <dd>Chaîne de caractères obligatoire — le titre de la dépêche</dd>
   <dt><var>section_id</var></dt>
   <dd>
-    Entier - L'identifiant de la section
-    (le code source de <a href="/news/nouveau">la page de soumission d'une dépêche</a> permet de trouver la liste des sections)
+    Entier — l’identifiant de la section
+    (le code source de <a href="/news/nouveau">la page de soumission d’une dépêche</a>
+    permet de trouver la liste des sections).
   </dd>
   <dt><var>wiki_body</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le contenu en markdown de la première partie de la dépêche</dd>
+  <dd>Chaîne de caractères obligatoire — le contenu en Markdown de la première partie de la dépêche</dd>
   <dt><var>wiki_second_part</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le contenu en markdown de la seconde partie de la dépêche</dd>
+  <dd>Chaîne de caractères obligatoire — le contenu en Markdown de la seconde partie de la dépêche</dd>
 </dl>
 
 <h4>Réponse</h4>
 <dl>
   <dt><var>id</var></dt>
-  <dd>Entier - Id de la dépêche qui vient d'être créée.</dd>
+  <dd>Entier — identifiant de la dépêche qui vient d’être créée.</dd>
   <dt><var>section_id</var></dt>
-  <dd>Entier - Id de la section.</dd>
+  <dd>Entier — identifiant de la section.</dd>
   <dt><var>cached_slug</var></dt>
-  <dd>Chaîne de caractères - Le slug de la dépeche.</dd>
+  <dd>Chaîne de caractères — le « <em><a href="https://fr.wikipedia.org/wiki/Slug_(journalisme)">slug</a></em> » de la dépeche.</dd>
   <dt><var>title</var></dt>
-  <dd>Chaîne de caractères - Le titre de la dépêche.</dd>
+  <dd>Chaîne de caractères — le titre de la dépêche.</dd>
   <dt><var>body</var></dt>
-  <dd>Chaîne de caractères - Le contenu de la première partie de la dépêche en HTML.</dd>
+  <dd>Chaîne de caractères — le contenu de la première partie de la dépêche en HTML.</dd>
   <dt><var>body</var></dt>
-  <dd>Chaîne de caractères - Le contenu de la seconde partie de la dépêche en HTML.</dd>
+  <dd>Chaîne de caractères — le contenu de la seconde partie de la dépêche en HTML.</dd>
   <dt><var>created_at</var></dt>
-  <dd>Chaîne de caractères - Les date et heure de création.</dd>
+  <dd>Chaîne de caractères — les date et heure de création.</dd>
   <dt><var>updated_at</var></dt>
-  <dd>Chaîne de caractères - Les date et heure de dernière modification.</dd>
+  <dd>Chaîne de caractères — les date et heure de dernière modification.</dd>
   <dt><var>submitted_at</var></dt>
-  <dd>Chaîne de caractères - Les date et heure de soumission en modération.</dd>
+  <dd>Chaîne de caractères — les date et heure de soumission en modération.</dd>
 </dl>
 
 
 <h3>Poster un journal</h3>
 
-<p>Scope nécessaire : <var>diary</var></p>
+<p>Scope nécessaire : <var>diary</var></p>
 
 <pre>
 POST https://linuxfr.org/api/v1/journaux
@@ -256,39 +256,39 @@ POST https://linuxfr.org/api/v1/journaux
 <h4>Paramètres</h4>
 <dl>
   <dt><var>bearer_token</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le jeton d'autorisation.</dd>
+  <dd>Chaîne de caractères obligatoire — le jeton d’autorisation.</dd>
   <dt><var>title</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le titre du journal</dd>
+  <dd>Chaîne de caractères obligatoire — le titre du journal</dd>
   <dt><var>wiki_body</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le contenu en markdown du journal</dd>
+  <dd>Chaîne de caractères obligatoire — le contenu en Markdown du journal</dd>
 </dl>
 
 <h4>Réponse</h4>
 <dl>
   <dt><var>id</var></dt>
-  <dd>Entier - Id du journal qui vient d'être créé.</dd>
+  <dd>Entier - identifiant du journal qui vient d’être créé.</dd>
   <dt><var>owner_id</var></dt>
-  <dd>Entier - Id de l'utilisateur qui vient de créer le journal.</dd>
+  <dd>Entier - identifiant de l’utilisateur qui vient de créer le journal.</dd>
   <dt><var>cached_slug</var></dt>
-  <dd>Chaîne de caractères - Le slug du journal.</dd>
+  <dd>Chaîne de caractères — le « <em><a href="https://fr.wikipedia.org/wiki/Slug_(journalisme)">slug</a></em> » du journal.</dd>
   <dt><var>title</var></dt>
-  <dd>Chaîne de caractères - Le titre du journal.</dd>
+  <dd>Chaîne de caractères — le titre du journal.</dd>
   <dt><var>body</var></dt>
-  <dd>Chaîne de caractères - Le contenu du journal en HTML.</dd>
+  <dd>Chaîne de caractères — le contenu du journal en HTML.</dd>
   <dt><var>wiki_body</var></dt>
-  <dd>Chaîne de caractères - Le contenu du journal en Markdown.</dd>
+  <dd>Chaîne de caractères — le contenu du journal en Markdown.</dd>
   <dt><var>truncated_body</var></dt>
-  <dd>Chaîne de caractères - La version courte du contenu du journal en HTML.</dd>
+  <dd>Chaîne de caractères — la version courte du contenu du journal en HTML.</dd>
   <dt><var>created_at</var></dt>
-  <dd>Chaîne de caractères - Les date et heure de création.</dd>
+  <dd>Chaîne de caractères — les date et heure de création.</dd>
   <dt><var>updated_at</var></dt>
-  <dd>Chaîne de caractères - Les date et heure de dernière modification.</dd>
+  <dd>Chaîne de caractères — les date et heure de dernière modification.</dd>
 </dl>
 
 
 <h3>Poster sur la tribune</h3>
 
-<p>Scope nécessaire : <var>board</var></p>
+<p>Scope nécessaire : <var>board</var></p>
 
 <pre>
 POST https://linuxfr.org/api/v1/board
@@ -297,12 +297,12 @@ POST https://linuxfr.org/api/v1/board
 <h4>Paramètres</h4>
 <dl>
   <dt><var>bearer_token</var></dt>
-  <dd>Chaîne de caractères obligatoire - Le jeton d'autorisation.</dd>
+  <dd>Chaîne de caractères obligatoire — le jeton d’autorisation.</dd>
   <dt><var>message</var></dt>
-  <dd>Chaîne de caractères obligatoire - Message à poster sur la tribune</dd>
+  <dd>Chaîne de caractères obligatoire — message à poster sur la tribune</dd>
   <dt><var>object_type</var></dt>
   <dd>
-    Chaîne de caractères facultative - Par défaut, le message est posté sur la
+    Chaîne de caractères facultative — par défaut, le message est posté sur la
     tribune de test, mais en passant <var>writing</var>, il sera posté sur la
     tribune de rédaction.
   </dd>
@@ -311,7 +311,7 @@ POST https://linuxfr.org/api/v1/board
 <h4>Réponse</h4>
 <dl>
   <dt><var>id</var></dt>
-  <dd>Entier - Id du message qui vient d'être créé, le cas échéant.</dd>
+  <dd>Entier — identifiant du message qui vient d’être créé, le cas échéant.</dd>
 </dl>
 
 <h4>Exemple de réponse</h4>
@@ -320,12 +320,11 @@ POST https://linuxfr.org/api/v1/board
 </pre>
 
 
-
 <h2>Bibliothèques</h2>
 
 <p>
-  <a href="https://github.com/intridea/omniauth">Omniauth</a> est une gem Ruby
-  qui permet d'authentifier des utilisateurs à partir d'applications web
-  distantes. Il possède une stratégie d'authentification pour LinuxFr.org :
-  <a href="https://github.com/linuxfrorg/omniauth-linuxfr.org">omniauth-linuxfr.org</a>.
+  <a href="https://github.com/intridea/omniauth">OmniAuth</a> est une <i>gem</i> Ruby
+  qui permet d’authentifier des utilisateurs à partir d’applications Web
+  distantes. Il possède une stratégie d’authentification pour <em>LinuxFr.org</em> :
+  <em><a href="https://github.com/linuxfrorg/omniauth-linuxfr.org">omniauth-linuxfr.org</a></em>.
 </p>

--- a/db/pages/faire_un_don.html
+++ b/db/pages/faire_un_don.html
@@ -1,82 +1,82 @@
 <p>
-	En 1998, LinuxFr.org c'était avant tout un site monté par des potes, pour des potes.
-         Aujourd'hui le nombre de visites quotidiennes font que le cercle des proches s'est un peu élargi. C'est un site par et pour les communautés du libre (au sens large). LinuxFr.org a
-	toujours été financé par des personnes physiques ou morales, proches de LinuxFr.org et soutenant son
-	concept et son autonomie. De la machine à l'hébergement en passant par le
-	travail d'administration ou de développement, LinuxFr.org a toujours été géré par
-	un groupe restreint de personnes bénévoles motivées.
+En 1998, <em>LinuxFr.org</em> c’était avant tout un site monté par des potes, pour des potes.
+Aujourd’hui, le nombre de visites quotidiennes fait que le cercle des proches s’est un peu élargi.
+C’est un site par et pour les communautés du libre (au sens large). <em>LinuxFr.org</em> a
+toujours été financé par des personnes physiques ou morales, proches de <em>LinuxFr.org</em>
+et soutenant son concept et son autonomie. De la machine à l’hébergement en passant par le
+travail d’administration ou de développement, <em>LinuxFr.org</em> a toujours été géré par
+un groupe restreint de personnes bénévoles motivées.
 </p>
 
 <p>
-	Grâce à de nombreux contributeurs les frais financiers restent
-	relativement faibles. Cependant comme le site ne génère aucun revenu, les frais 
-	engendrés sont quasi-exclusivement financés par les donateurs.
+Grâce à de nombreux contributeurs, les frais financiers restent relativement faibles.
+Cependant, comme le site ne génère aucun revenu, les frais engendrés sont quasi‐exclusivement
+financés par les donateurs.
 </p>
 
-<p>Pour aider l'association, vous pouvez faire un don via l'un des moyens suivants&nbsp;:</p>
+<p>Pour aider l’association, vous pouvez faire un don via l’un des moyens suivants :</p>
 
 <ul>
-<li><a href="https://enventelibre.org/57-linuxfr">via le site En Vente Libre</a>, par carte bancaire notamment&nbsp;;</li>
-<li>par virement bancaire (vous pouvez <a href="mailto:webmaster_&#64;_linuxfr.org">nous contacter par courriel</a>, nous vous ferons parvenir les informations nécessaires (IBAN))&nbsp;;</li>
-<li>par chèque à l'ordre de l'association LinuxFr à l'adresse suivante:
-
+<li><a href="https://enventelibre.org/57-linuxfr">via le site <em>En Vente Libre</em></a>, par carte bancaire notamment ;</li>
+<li>par virement bancaire (vous pouvez <a href="mailto:webmaster_&#64;_linuxfr.org">nous contacter par courriel</a>, nous vous ferons parvenir les informations nécessaires (IBAN)) ;</li>
+<li>par chèque à l’ordre de l’association LinuxFr à l’adresse suivante :
 
 <pre>
 Association LinuxFr
-BL 6-113
-154 rue de Picpus
-75012 Paris
+BL 6-113
+154 rue de Picpus
+75012 Paris
 </pre>
 </li>
 </ul>
 
 <p>
-	Chaque don est mentionné sur cette page lorsque le donateur ne
-	souhaite pas rester anonyme. Les dons envoyés ne vous permettent pas
-	d'avoir une réduction d'impôts, il faudrait que l'on soit déclaré
-	d'intérêt public pour ça (mais <a href="https://fsffrance.org/donations/howto.fr.html">ce serait possible</a>,
-	si quelqu'un souhaite s'en occuper, qu'il nous contacte). Nous pouvons
-	vous faire parvenir un reçu si vous le désirez.
+Chaque don est mentionné sur cette page lorsque le donateur nesouhaite pas rester anonyme.
+Les dons envoyés ne vous permettent pas d’avoir une réduction d’impôts, il faudrait que 
+nous soyons déclarés d’intérêt public pour cela
+(mais <a href="https://fsffrance.org/donations/howto.fr.html">ce serait possible</a>,
+si quelqu’un souhaite s’en occuper, qu’il nous contacte). Nous pouvonsvous faire parvenir
+un reçu si vous le désirez.
 </p>
-<p>Voici donc la liste des donateurs, par ordre plus ou moins chronologique, sauf erreur ou oubli, hors anonymes, certains pouvant être présents plusieurs fois&nbsp;:</p>
+<p>Voici donc la liste des donateurs, par ordre plus ou moins chronologique, sauf erreur ou oubli, hors anonymes, certains pouvant être présents plusieurs fois :</p>
 
 <h3>Particuliers</h3>
 <ul>
-<li>De multiples anonymes</li>
-<li>Jocelyn JOVENE</li>
+<li>de multiples anonymes</li>
+<li>Jocelyn JOVÈNE</li>
 <li>Charles VIDAL</li>
 <li>Thomas PEDAUSSAUT</li>
 <li>Franck YVONNET</li>
-<li>Stephane Lee Chip HING</li>
+<li>Stéphane Lee Chip HING</li>
 <li>Mathieu DESSUS</li>
-<li>Jean Yves BOISIAUD</li>
+<li>Jean‑Yves BOISIAUD</li>
 <li>Philipe ESPI</li>
 <li>Bernard MAYET</li>
-<li>Jerome FLEURANCEAU</li>
+<li>Jérôme FLEURANCEAU</li>
 <li>Olivier RIPOLL</li>
-<li>Dr Eric BARONET</li>
-<li>Frederic CORNE</li>
-<li>Jerome DUMONTEIL</li>
+<li>Dʳ Éric BARONET</li>
+<li>Frédéric CORNE</li>
+<li>Jérôme DUMONTEIL</li>
 <li>Didier CLAVERIE</li>
-<li>Gerald TOUSSAINT</li>
+<li>Gérald TOUSSAINT</li>
 <li>Pascale LEVRIER</li>
 <li>Olivier LOESS</li>
 <li>Lionel BOUCHPAN</li>
-<li>Regis RAMPNOUX</li>
+<li>Régis RAMPNOUX</li>
 <li>Franck DANIEL</li>
 <li>Laurent KESTEMONT</li>
 <li>Emmanuel SEYMAN</li>
 <li>Philippe LONGONE</li>
-<li>Gael PEGLIASCO</li>
+<li>Gaël PEGLIASCO</li>
 <li>Lol ZIMMERLI</li>
 <li>Guillaume MORIN</li>
 <li>François GUILLIER</li>
-<li>Romain TOUZE</li>
+<li>Romain TOUZÉ</li>
 <li>Antoine LEDOUX</li>
 <li>Patrick DEROUBAIX</li>
 <li>Mohamed KALAI</li>
 <li>Lionel ALLORGE</li>
-<li>Sebastien LETHIELLEUX</li>
+<li>Sébastien LETHIELLEUX</li>
 <li>Julien POMMIER</li>
 <li>Thomas WALRAET</li>
 <li>Guillaume ROUSSE</li>
@@ -84,19 +84,19 @@ BL 6-113
 <li>Charles JOUBERT</li>
 <li>Olivier RIPOLL</li>
 <li>Frédéric MULLIER</li>
-<li>Marc-Aurèle DARCHE</li>
+<li>Marc‑Aurèle DARCHE</li>
 <li>Lol ZIMMERLI</li>
 <li>Bruno MICHEL</li>
-<li>Jean François VIDAL</li>
+<li>Jean‑François VIDAL</li>
 <li>Pierre TARDY</li>
-<li>Joel PROAL</li>
+<li>Joël PROAL</li>
 <li>Jérôme WYLLEMAN</li>
 <li>Nicolas DEVEAUD</li>
 <li>Thomas BIGOT</li>
 <li>Pierre MOUREN</li>
 <li>Yann NEVEU</li>
 <li>Mathieu GEOFFRE</li>
-<li>Bruno ADELE</li>
+<li>Bruno ADÈLE</li>
 <li>Yann PAPIN</li>
 <li>Matthieu DUBUGET</li>
 <li>Ludovic BELLIER</li>
@@ -105,7 +105,7 @@ BL 6-113
 <li>Olivier NICOLAS</li>
 <li>Christophe LAURE</li>
 <li>Julien SERGE</li>
-<li>Cornet BENOIT</li>
+<li>Benoît Cornet</li>
 <li>Anthony MAHE</li>
 <li>Marc BOUSSARD</li>
 <li>Isabelle HURBAIN</li>
@@ -113,11 +113,11 @@ BL 6-113
 <li>Étienne BAGNOUD</li>
 <li>Cyrille HENRY</li>
 <li>Julien BALAS</li>
-<li>Arnaud LE BLANC</li>
-<li>Jean-François B.</li>
+<li>Arnaud LE BLANC</li>
+<li>Jean‑François B.</li>
 <li>Hervé LARDIN</li>
 <li>Michel PETIT</li>
-<li>Romain LE DISEZ</li>
+<li>Romain LE DISEZ</li>
 <li>Olivier LAMBERT</li>
 <li>Pierre BETTENS</li>
 <li>Lol ZIMMERLI</li>
@@ -129,14 +129,14 @@ BL 6-113
 <li>Thierry PINON</li>
 <li>Fabien PENSO</li>
 <li>Benjamin CAMA</li>
-<li>Sebastien CHEMINEL</li>
+<li>Sébastien CHEMINEL</li>
 <li>Mickael CORDON</li>
-<li>Pierre Alain BANDINELLI</li>
-<li>JP ROAL</li>
+<li>Pierre‑Alain BANDINELLI</li>
+<li>J.‑P. ROAL</li>
 <li>Florent ZARA</li>
 <li>Christophe LAURENCE</li>
 <li>Guillaume GOMMARD</li>
-<li>Etienne BERSAC</li>
+<li>Étienne BERSAC</li>
 <li>Christophe GUILLOUX</li>
 <li>Benoit BALON</li>
 <li>Xavier BELANGER</li>
@@ -151,12 +151,12 @@ BL 6-113
 <li>Marc QUINTON</li>
 <li>Emmanuel PROCHASSON</li>
 <li>Luc SANTERAMO</li>
-<li>Etienne ANDRE</li>
+<li>Étienne ANDRÉ</li>
 <li>Raphael PASQUIER</li>
 <li>Jean MONNARD</li>
-<li>Jean-Yves CADIC</li>
+<li>Jean‑Yves CADIC</li>
 <li>Guiral LACOTTE</li>
-<li>François-Xavier POSTEL</li>
+<li>François‑Xavier POSTEL</li>
 <li>Philippe FREMY</li>
 <li>Yannick PALANQUE</li>
 <li>Bruno VASTA</li>
@@ -165,11 +165,11 @@ BL 6-113
 <li>Albert PERRIOL</li>
 <li>? WITTE</li>
 <li>Vincent MERLET</li>
-<li>Jean-Louis BARROIS</li>
+<li>Jean‑Louis BARROIS</li>
 <li>Philippe LATREYTE</li>
 <li>? MAZAIN</li>
 <li>Jacques SALMON</li>
-<li>Baptiste DURAND BRET</li>
+<li>Baptiste DURAND-BRET</li>
 <li>Mickael KURMANN</li>
 <li>Sylvain BLANDEL</li>
 <li>Julien MARDAS</li>
@@ -177,6 +177,7 @@ BL 6-113
 <li>Laurent Breton</li>
 <li>Martin Serge</li>
 <li>Mathieu Roche</li>
+<li>Satan</li>
 </ul>
 
 <h3>Associations</h3>
@@ -185,22 +186,22 @@ BL 6-113
 <li><a href="https://www.april.org">April</a></li>
 <li><a href="https://www.culte.org">CULTE</a></li>
 <li><a href="https://www.framasoft.org">Framasoft</a></li>
-<li><a href="https://www.linux-azur.org/">Linux Azur</a></li>
+<li><a href="https://www.linux-azur.org/">Linux Azur</a></li>
 <li><a href="https://www.aful.org">AFUL</a></li>
-<li><a href="https://www.lolica.org/">LoLiCA</a> (Logiciels Libres en Champagne-Ardenne)</li>
-<li><a href="http://asso.lanpower.free.fr/"> LanPower</a></li>
-<li><a href="http://xulfr.org/">Xulfr</a></li>
+<li><a href="https://www.lolica.org/">LoLiCA</a> (Logiciels Libres en Champagne‑Ardenne)</li>
+<li><a href="http://asso.lanpower.free.fr/">LanPower</a></li>
+<li><a href="http://xulfr.org/">XulFr</a></li>
 </ul>
 
 
 <h3>Sociétés</h3>
 <ul>
-<li>S.A.R.L Numlog</li>
+<li>S. A. R. L. Numlog</li>
 <li>CSTB</li>
-<li>Mosaique</li>
+<li>Mosaïque</li>
 <li><a href="https://www.alcove.fr">Alcove</a></li>
 <li>Firewall-Services</li>
-<li>SARL AESIS Conseil</li>
+<li>S. A. R. L. AESIS Conseil</li>
 <li><a href="https://www.besttech.fr/">BestTech</a></li>
 </ul>
 Un grand merci à eux.

--- a/db/pages/informations.html
+++ b/db/pages/informations.html
@@ -1,41 +1,42 @@
-<h2>L'association LinuxFr</h2>
+<h2>L’association LinuxFr</h2>
 <p>
-	LinuxFr est une association régie par la loi de 1901, créée fin octobre 1998.</p>
+	LinuxFr est une association régie par la loi de 1901, créée fin octobre 1998.</p>
 
-<p>	Elle a pour objectif de promouvoir les Logiciels Libres, en particulier Linux (voir les <a href="/association/statuts.html">statuts</a> (<a href="/association/statuts.old.html">statuts originaux</a>) ainsi que le <a href="/association/reglement.html">règlement intérieur</a>).
+<p>	Elle a pour objectif de promouvoir les Logiciels libres, en particulier GNU/Linux (voir les <a href="/association/statuts.html">statuts</a> (<a href="/association/statuts.old.html">statuts originaux</a>) ainsi que le <a href="/association/reglement.html">règlement intérieur</a>).
 </p>
 
 <p>
-<a href="//www.april.org/" title="Membre de l'association April"><img alt="Membre de l'association April" src="https://www.april.org/sites/default/files/association/documents/bannieres/membre-de-april.png " /></a>
+<a href="//www.april.org/" title="Membre de l’association April"><img alt="Membre de l’association April" src="https://www.april.org/sites/default/files/association/documents/bannieres/membre-de-april.png " /></a>
 </p>
 <ul>
-	<li>Président : Nicolas Vérité</li>
-	<li>Secrétaire/trésorier : Florent Zara</li>
+	<li>président : Benoît Sibaud ;</li>
+	<li>vice-président : Nicolas Vérité ;</li>
+	<li>secrétaire et trésorier : Florent Zara.</li>
 </ul>
 
-<h2>Le site web LinuxFr.org</h2>
+<h2>Le site Web LinuxFr.org</h2>
 <p>
-	Le site LinuxFr.org est géré par l'association LinuxFr.
+	Le site <em>LinuxFr.org</em> est géré par l’association LinuxFr.
 </p>
 <p>
-	L'association se réserve le droit de refuser l'accès au site.
+	L’association se réserve le droit de refuser l’accès au site.
 </p>
 <p>
-	Si un message vous semble contenir des propos diffamatoires, racistes, etc, veuillez nous en <a href="mailto:moderateurs_&#64;_linuxfr.org">avertir</a> dès que possible.
+	Si un message vous semble contenir des propos diffamatoires, racistes, etc., veuillez nous en <a href="mailto:moderateurs_&#64;_linuxfr.org">avertir</a> dès que possible.
 </p>
 <p>
-	Nous nous réservons le droit d'effacer toute intervention sur ce site, ainsi que de supprimer tout compte dont l'utilisation nous semblerait détournée.
+	Nous nous réservons le droit d’effacer toute intervention sur ce site, ainsi que de supprimer tout compte dont l’utilisation nous semblerait détournée.
 </p>
 <p>
-	En bref, on se réserve le droit de faire ce qu'on veut.
+	En bref, on se réserve le droit de faire ce qu’on veut.
 </p>
 
 <h2>Le code source de LinuxFr.org</h2>
 <p>
-	Le code source du site web LinuxFr.org est placé sous licence <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public License</a>.
+	Le code source du site Web <em>LinuxFr.org</em> est placé sous licence <a href="https://www.gnu.org/licenses/agpl.html">GNU Affero General Public License</a>.
 	Vous pouvez le télécharger sur <a href="/code_source_du_site">cette page</a>.
 </p>
 <p>
-	Si vous souhaitez remonter un bug ou proposer une évolution, vous pouvez le faire dans <a href="/suivi">le suivi.</a>
+	Si vous souhaitez remonter un bogue ou proposer une évolution, vous pouvez le faire dans <a href="/suivi">le suivi.</a>
 </p>
-<a href="http://www.nojhan.net/geekscottes/index.php?id=85"><img alt="Linux c'est fair" src="/images/dessins/geekscottes_084.png" title="Linux c'est fair - © Johann 'nojhan' Dréo : 2007-02-06 - Licence CC By-Sa 2.5" /></a>
+<a href="http://www.nojhan.net/geekscottes/index.php?id=85"><img alt="Linux c’est fair" src="/images/dessins/geekscottes_084.png" title="Linux c’est fair — © Johann « nojhan » Dréo : 2007-02-06 — Licence CC By‑SA 2.5" /></a>

--- a/db/pages/mentions_legales.html
+++ b/db/pages/mentions_legales.html
@@ -1,23 +1,23 @@
 <p>
-	Ce site est soumis au régime juridique français. À ce titre, il est un service de communication au public en ligne édité à titre non professionnel au sens de l'article 6, III, 2° de la loi 2004-575 du 21 juin 2004.
+	Ce site est soumis au régime juridique français. À ce titre, il est un service de communication au public en ligne édité à titre non professionnel au sens de l’article 6, chapitre Ⅱ de la loi 2004‑575 du 21 juin 2004.
 </p>
 
 <h2>Éditeur</h2>
 <p>
-        Ce site est édité par <a href="//linuxfr.org/informations">l'association LinuxFr</a>. Siège social : 154 rue de Picpus 75012 Paris - France.
+        Ce site est édité par <a href="//linuxfr.org/informations">l’association LinuxFr</a>. Siège social : 154 rue de Picpus, 75012 Paris - France.
 </p> 
 
 <h2>Hébergeur</h2>
 <p>
-	Ce site est hébergé sur les serveurs de la <a href="https://www.fondation-free.fr/">Fondation d'entreprise Free</a>. Siège social : 8 rue de la ville l'Évêque, 75008 Paris - France.
+	Ce site est hébergé sur les serveurs de la <a href="https://www.fondation-free.fr/">Fondation d’entreprise Free</a>. Siège social : 8 rue de la Ville‑l’Évêque, 75008 Paris - France.
 </p>
 
 <h2>Directeur de publication</h2>
 <p>
-	Le directeur de publication est M. Benoît Sibaud, &lt;team_@_linuxfr.org&gt;&nbsp;.
+	Le directeur de publication est M. Benoît Sibaud, &lt;team_@_linuxfr.org&gt;.
 </p>
 
 <h2>Nous contacter</h2>
 <p>
-	Pour toute question, vous pouvez nous contacter encore par courriel à l'adresse &lt;moderateurs_@_linuxfr.org&gt;&nbsp;.
+	Pour toute question, vous pouvez nous contacter, toujours par courriel, à l’adresse &lt;moderateurs_@_linuxfr.org&gt;.
 </p>

--- a/db/pages/plan.html
+++ b/db/pages/plan.html
@@ -1,75 +1,75 @@
-<a href="http://www.nojhan.net/geekscottes/index.php?id=122"><img src="/images/dessins/geekscottes_121.png" alt="Perdu sur le web" title="Perdu sur le web - © Johann 'nojhan' Dréo : 2009-01-10 - Licence CC By-Sa 3.0" /></a>
+<a href="http://www.nojhan.net/geekscottes/index.php?id=122"><img src="/images/dessins/geekscottes_121.png" alt="Perdu sur le Web" title="Perdu sur le Web — © Johann « nojhan » Dréo : 2009-01-10 — Licence CC By‑SA 3.0" /></a>
 
 <h2>Les dépêches</h2>
 <ul>
-	<li><a href="/news">Les dernières dépêches publiées</a></li>
-	<li><a href="/news.atom">Le flux ATOM des dépêches publiées</a></li>
-	<li><a href="/news/nouveau">Proposer une dépêche</a></li>
-        <li><a href="/redaction/news.atom">Le flux ATOM des dépêches en rédaction</a></li>
-        <li><a href="/redaction/news/moderation.atom">Le flux ATOM des dépêches en modération</a></li>
-	<li><a href="/sections">La liste des sections</a></li>
-        <li><a href="https://lists.linuxfr.org/wws/subscribe/linuxfr-news">S'abonner à la lettre quotidienne d'annonce</a></li>
+  <li><a href="/news">Les dernières dépêches publiées</a></li>
+  <li><a href="/news.atom">Le flux Atom des dépêches publiées</a></li>
+  <li><a href="/news/nouveau">Proposer une dépêche</a></li>
+  <li><a href="/redaction/news.atom">Le flux Atom des dépêches en rédaction</a></li>
+  <li><a href="/redaction/news/moderation.atom">Le flux Atom des dépêches en modération</a></li>
+  <li><a href="/sections">La liste des sections</a></li>
+  <li><a href="https://lists.linuxfr.org/wws/subscribe/linuxfr-news">S’abonner à la lettre d’information quotidienne</a></li>
 </ul>
 
 <h2>Les journaux des utilisateurs</h2>
 <ul>
-	<li><a href="/journaux">Les derniers journaux</a></li>
-	<li><a href="/journaux.atom">Le flux ATOM des journaux</a></li>
-	<li><a href="/journaux/nouveau">Écrire un journal</a></li>
+  <li><a href="/journaux">Les derniers journaux</a></li>
+  <li><a href="/journaux.atom">Le flux Atom des journaux</a></li>
+  <li><a href="/journaux/nouveau">Écrire un journal</a></li>
 </ul>
 
 <h2>Les forums</h2>
 <ul>
-	<li><a href="/forums">Les dernières questions dans les forums</a></li>
-	<li><a href="/forums.atom">Le flux ATOM des dernières questions</a></li>
-	<li><a href="/posts/nouveau">Poser une question dans les forums</a></li>
+  <li><a href="/forums">Les dernières questions dans les forums</a></li>
+  <li><a href="/forums.atom">Le flux Atom des dernières questions</a></li>
+  <li><a href="/posts/nouveau">Poser une question dans les forums</a></li>
 </ul>
 
 <h2>Les sondages</h2>
 <ul>
-	<li><a href="/sondages">Les derniers sondages</a></li>
-	<li><a href="/sondages.atom">Le flux ATOM des sondages</a></li>
-	<li><a href="/sondages/nouveau">Suggérer un sondage</a></li>
+  <li><a href="/sondages">Les derniers sondages</a></li>
+  <li><a href="/sondages.atom">Le flux Atom des sondages</a></li>
+  <li><a href="/sondages/nouveau">Suggérer un sondage</a></li>
 </ul>
 
-<h2>Le système de suivi des bugs et propositions d'évolutions</h2>
+<h2>Le système de suivi des bogues et propositions d’évolutions</h2>
 <ul>
-	<li><a href="/suivi">Le système de suivi</a></li>
-	<li><a href="/suivi.atom">Le flux ATOM des dernières entrées du suivi</a></li>
-	<li><a href="/suivi/comments.atom">Le flux ATOM des derniers commentaires du suivi</a></li>
-	<li><a href="/suivi/nouveau">Remonter un bug ou proposer une évolution</a></li>
+  <li><a href="/suivi">Le système de suivi</a></li>
+  <li><a href="/suivi.atom">Le flux Atom des dernières entrées du suivi</a></li>
+  <li><a href="/suivi/comments.atom">Le flux Atom des derniers commentaires du suivi</a></li>
+  <li><a href="/suivi/nouveau">Remonter un bogue ou proposer une évolution</a></li>
 </ul>
 
 <h2>Le wiki</h2>
 <ul>
-	<li><a href="/wiki">la page d'accueil du wiki</a></li>
-	<li><a href="/wiki.atom">Le flux ATOM des dernières pages crées dans le wiki</a></li>
-	<li><a href="/wiki/modifications.atom">Le flux ATOM des modifications dans le wiki</a></li>
-	<li><a href="/wiki/nouveau">Créer une page de wiki</a></li>
+  <li><a href="/wiki">la page d’accueil du wiki</a></li>
+  <li><a href="/wiki.atom">Le flux Atom des dernières pages créées dans le wiki</a></li>
+  <li><a href="/wiki/modifications.atom">Le flux Atom des modifications dans le wiki</a></li>
+  <li><a href="/wiki/nouveau">Créer une page de wiki</a></li>
 </ul>
 
-<h2>Les pages d'information</h2>
+<h2>Les pages d’information</h2>
 <ul>
-	<li><a href="/compte/inscription">S'inscrire</a></li>
-	<li><a href="/proposer-un-contenu">Proposer un contenu</a></li>
-	<li><a href="/mentions_legales">Nous contacter</a></li>
-	<li><a href="/faire_un_don">Faire un don</a></li>
-	<li><a href="/team">Team LinuxFr.org</a></li>
-	<li><a href="/informations">Informations sur le site</a></li>
-	<li><a href="/aide">Foire aux questions</a></li>
-	<li><a href="/regles_de_moderation">Règles de modération</a></li>
-	<li><a href="/statistiques">Statistiques</a></li>
-	<li><a href="/code_source_du_site">Code source du site</a></li>
-	<li><a href="/changelog">Changelog</a></li>
+  <li><a href="/compte/inscription">S’inscrire</a></li>
+  <li><a href="/proposer-un-contenu">Proposer un contenu</a></li>
+  <li><a href="/mentions_legales">Nous contacter</a></li>
+  <li><a href="/faire_un_don">Faire un don</a></li>
+  <li><a href="/team">L’équipe de LinuxFr.org</a></li>
+  <li><a href="/informations">Informations sur le site</a></li>
+  <li><a href="/aide">Foire aux questions</a></li>
+  <li><a href="/regles_de_moderation">Règles de modération</a></li>
+  <li><a href="/statistiques">Statistiques</a></li>
+  <li><a href="/code_source_du_site">Code source du site</a></li>
+  <li><a href="/changelog">Journal des modifications</a></li>
 </ul>
 
-<h2>Les pages réservées aux utilisateurs authentifiés</h2>
+<h2>Les pages réservées aux utilisatrices et utilisateurs authentifiés</h2>
 <ul>
-	<li><a href="/redaction">L'espace de rédaction</a></li>
-	<li><a href="/tableau-de-bord">Mon tableau de bord</a></li>
-	<li><a href="/compte/modifier">Mes préférences</a></li>
-	<li><a href="/stylesheet/modifier">Changer de CSS</a></li>
-	<li><a href="/tags">Les contenus que j'ai taggés</a></li>
-	<li><a href="/compte/password/nouveau">Mot de passe oublié</a></li>
-	<li><a href="/compte/confirmation/nouveau">En attente du courriel de confirmation</a></li>
+  <li><a href="/redaction">L’espace de rédaction</a></li>
+  <li><a href="/tableau-de-bord">Mon tableau de bord</a></li>
+  <li><a href="/compte/modifier">Mes préférences</a></li>
+  <li><a href="/stylesheet/modifier">Changer de CSS</a></li>
+  <li><a href="/tags">Les contenus que j’ai étiquetés</a></li>
+  <li><a href="/compte/password/nouveau">Mot de passe oublié</a></li>
+  <li><a href="/compte/confirmation/nouveau">En attente du courriel de confirmation</a></li>
 </ul>

--- a/db/pages/regles_de_moderation.html
+++ b/db/pages/regles_de_moderation.html
@@ -1,193 +1,197 @@
-<p>Cette page décrit l'ensemble des règles de modération, à la fois en terme de correction/publication (correction d'orthographe ou de syntaxe Markdown, modération de dépêches ou sondages, etc.) mais aussi de modération/suppression (rappel des règles, suppression, etc.).</p>
+<p>Cette page décrit l’ensemble des règles de modération, à la fois en termes de correction et de publication
+(correction orthographique ou de syntaxe Markdown, modération de dépêches ou sondages, etc.)
+mais aussi de modération et suppression (rappel des règles, suppression, etc.).</p>
+
+<p>Le site web LinuxFr.org est géré par <a href="https://linuxfr.org/informations">l'association LinuxFr</a>. La modération est déléguée à une <a href="https://linuxfr.org/team">équipe de bénévoles</a>.<p>
 
 <h2>Règles de modération des contenus, commentaires et comptes problématiques</h2>
 
-<p>Les <a href="//linuxfr.org/regles_de_moderation_du_problematique
-">règles de modération des contenus, commentaires et comptes problématiques
-</a> sont décrites sur une page séparée. Celle-ci commence par définir les rôles d'une équipe de modération, fait le point sur le statut de la modération sur le site au printemps 2012, puis décrit les règles retenues (donc les règles applicables à tous les contenus, commentaires et comptes sur le site). Elle traite ensuite de la perception du site et de la manière dont la modération doit intervenir.</p>
+<p>Les <a href="//linuxfr.org/regles_de_moderation_du_problematique">règles de modération des contenus,
+commentaires et comptes problématiques</a> sont décrites sur une page séparée.
+Celle‑ci commence par définir les rôles d’une équipe de modération, fait le point sur le statut
+de la modération sur le site au printemps 2012, puis décrit les règles retenues
+(donc les règles applicables à tous les contenus, commentaires et comptes sur le site).
+Elle traite ensuite de la perception du site et de la manière dont la modération doit intervenir.</p>
 
 <h2>Ligne éditoriale pour les dépêches</h2>
 
-<p>Les thèmes principaux de LinuxFr.org sont Linux et les logiciels libres.
-	D'autres thèmes peuvent être abordés. Les thèmes hors-sujet sont à renvoyer vers les journaux, voire aux calendes grecques.</p>
+<p>Les thèmes principaux de <em>LinuxFr.org</em> sont GNU/Linux et les logiciels libres.
+D’autres thèmes peuvent être abordés. Les thèmes hors sujet sont à renvoyer vers les journaux,
+voire aux calendes grecques.</p>
 
-<p>Évidemment, seulement les dépêches intéressantes doivent être approuvées.</p>
+<p>Évidemment, seules les dépêches intéressantes doivent être approuvées.</p>
 
-<p>Cependant un effort particulier doit être fait pour&nbsp;:</p>
+<p>Cependant un effort particulier doit être fait pour :</p>
 
 <ul>
-	<li><p>Éviter les doublons</p>
+<li><p>Éviter les doublons</p>
 
-		<p>En effet, qu'y a t-il de plus désagréable que de voir une dépêche passer
-			plusieurs fois dans le même mois&nbsp;? En général une dépêche sur un magazine
-			sorti depuis plusieurs jours a de fortes chances d'être déjà passée. 
-			Pour éviter ce problème, il est demandé aux modérateurs de visiter le site
-			_régulièrement_. En cas de départ en vacances ou d'absence prolongée, merci
-			de visiter les archives à votre retour, et d'attendre plusieurs jours
-			avant de recommencer à modérer les dépêches en attente.</p></li>
+<p>En effet, qu’y a‑t‑il de plus désagréable que de voir une dépêche passer
+plusieurs fois dans le même mois ? En général, une dépêche sur un magazine
+sorti depuis plusieurs jours a de fortes chances d’être déjà passée.
+Pour éviter ce problème, il est demandé aux modérateurs de visiter le site
+<em>régulièrement</em>. En cas de départ en vacances ou d’absence prolongée,
+merci de visiter les archives à votre retour, et d’attendre plusieurs jours
+avant de recommencer à modérer les dépêches en attente.</p></li>
 
-	<li><p>Éviter les fautes d'orthographe</p>
+<li><p>Éviter les fautes d’orthographe</p>
 
-		<p>Il est très désagréable de lire un texte bourré de fautes de grammaire,
-			d'orthographe, de ponctuation, d'anglicismes, etc. Cependant nous faisons
-			tous des fautes, et ce n'est pas grave, un modérateur les corrigera s'il en
-			reste. Cependant modérer n'est pas un travail de 10 secondes, à faire avant
-			de partir déjeuner. En résumé&nbsp;: il faut prendre du temps pour modérer&nbsp;! Rien
-			ne sert de modérer «&nbsp;en vitesse&nbsp;», c'est plus négatif qu'autre chose, et il
-			vaut mieux ne rien faire que faire des bêtises...</p>
-		<p>Donc faire attention aux fautes, et ne pas hésiter à corriger celles que
-			l'on voit dans des dépêches déjà validées.</p></li>
+<p>Il est très désagréable de lire un texte bourré d’anglicismes, de fautes de grammaire,
+d’orthographe, de ponctuation, etc. Mais, nous faisons tous des fautes,
+et ce n’est pas grave, un modérateur les corrigera s’il en reste. Cependant,
+modérer n’est pas un travail de dix secondes, à faire avant de partir déjeuner.
+En résumé : il faut prendre du temps pour modérer ! Rien ne sert de modérer
+« en vitesse », c’est plus négatif qu’autre chose, et il vaut mieux ne rien faire
+que faire des bêtises…</p>
+<p>Donc, faire attention aux fautes, et ne pas hésiter à corriger celles que
+l’on voit dans des dépêches déjà validées.</p></li>
 
-	<li><p>Rejeter les dépêches non rédigées</p>
+<li><p>Rejeter les dépêches non rédigées</p>
 
-		<p>Une dépêche doit être rédigée, un minimum étoffée, fournir un ou plusieurs
-			liens, introduire le contexte, résumer la situation, etc. Celles trop
-			courtes ou trop mal rédigées seront rejetées.</p></li>
+<p>Une dépêche doit être rédigée, un minimum étoffée, fournir un ou plusieurs
+liens, introduire le contexte, résumer la situation, etc. Celles trop
+courtes ou trop mal rédigées seront rejetées.</p></li>
 
-	<li><p>Rejeter les dépêches copier/coller</p>
+<li><p>Rejeter les dépêches copier‑coller</p>
 
-		<p>Une dépêche ne doit pas être une copie d'un texte recopié sur un autre
-			site, une dépêche d'agence de presse ou un article de magazine. Les
-			citations sont acceptées, pas le plagiat. Deux exceptions à cette règle
-                        sont à noter : la revue de presse de l'April (objet d'un partenariat avec
-                        LinuxFr.org) et les contenus proposés directement par leur auteur original,
-                        sous réserve que celui-ci soit reconnu entre les deux documents, que le contenu
-                        soit sous licence libre et qu'il respecte la charte éditoriale.</p></li>
+<p>Une dépêche ne doit pas être une copie d’un texte recopié depuis un autre site,
+une dépêche d’agence de presse ou un article de magazine.
+Les citations sont acceptées, pas le plagiat. Deux exceptions à cette règle
+sont à noter : la revue de presse de l’April (objet d’un partenariat avec
+<em>LinuxFr.org</em>) et les contenus proposés directement par leur auteur original,
+sous réserve que celui‑ci soit reconnu entre les deux documents, que le contenu
+soit sous licence libre et qu’il respecte la charte éditoriale.</p></li>
 
-	<li><p>Éviter de modérer ses propres dépêches</p>
+<li><p>Éviter de modérer ses propres dépêches</p>
 
-		<p>Les internautes ont l'air de ne pas apprécier qu'un modérateur propose
-			une dépêche, pour la valider tout de suite après. Attendez plutôt qu'un
-			autre passe par là (sauf exception où le temps presse), et qui pourra de
-			plus corriger vos fautes d'orthographe. :)</p></li>
+<p>Les internautes ont l’air de ne pas apprécier qu’un modérateur propose une dépêche
+et la valide tout de suite après. Attendez plutôt qu’un autre passe par là
+(sauf exception où le temps presse). Il pourra en outre corriger vos fautes
+de français. :)</p></li>
 
-	<li><p>Éviter de faire de la publicité gratuite</p>
+<li><p>Éviter de faire de la publicité gratuite</p>
 
-		<p>LinuxFr.org ne doit pas servir à des gens (particuliers ou société) comme
-			plate-forme de publicité. Aussi les communiqués de presse copiés/collés
-			rapidement dans le formulaire ne doivent pas être approuvés. Cependant des
-			exceptions peuvent être faites, au libre jugement du modérateur. Dans le
-			cas où une annonce d'un logiciel propriétaire est faite, il est de bon ton
-			de rappeler qu'il existe un équivalent libre si c'est le cas, et de mettre
-			un lien vers celui-ci.</p>
+<p><em>LinuxFr.org</em> ne doit pas servir à des gens (particuliers ou sociétés) comme
+plate‑forme publicitaire. Aussi, les communiqués de presse copiés‑collés
+rapidement dans le formulaire ne doivent pas être approuvés. Cependant, des
+exceptions peuvent être faites, au libre jugement du modérateur. Dans le
+cas où une annonce d’un logiciel propriétaire est faite, il est de bon ton
+de rappeler qu’il existe un équivalent libre si c’est le cas, et de mettre
+un lien vers celui‑ci.</p>
 
-		<p>Les dépêches concernant la création de nouveaux sites, de demande
-			d'aide pour un site nouvellement créé, etc ne DOIVENT PAS passer. En
-			effet, si nous le faisions LinuxFr.org serait pollué en permanence. Pour
-			qu'une telle dépêche soit validée il faut soit que le site existe depuis
-			longtemps, c'est à dire qu'il ait un contenu éditorial déjà important, ou
-			il faut qu'il innove réellement (un site sur un sujet spécial jamais abordé
-			sur le net). LinuxFr.org ne doit pas servir aux webmestres en mal de hits
-			pour avoir une audience plus importante, tout le monde peut installer un
-			CMS sur un sujet précis sinon...</p></li>
+<p>Les dépêches concernant la création de nouveaux sites, de demande d’aide pour un site
+nouvellement créé, etc., <strong>NE DOIVENT PAS</strong> passer.
+En effet, si nous le faisions, <em>LinuxFr.org</em> serait pollué en permanence.
+Pour qu’une telle dépêche soit validée, il faut soit que le site existe depuis
+longtemps, c’est‑à‑dire qu’il ait un contenu éditorial déjà important, ou il faut
+qu’il innove réellement (un site sur un sujet spécial jamais abordé sur le Net).
+<em>LinuxFr.org</em> ne doit pas servir aux webmestres cherchant à accroître
+le nombre de visites de leur site ; tout le monde peut installer un CMS sur un
+sujet précis sinon…</p></li>
 
-	<li><p>Éviter de mélanger sentiments et faits</p>
+<li><p>Éviter de mélanger sentiments et faits</p>
 
-		<p>Une dépêche doit séparer ce qui est un sentiment personnel des faits. Et même dans ce cas, il convient de faire attention à
-			faire apparaître clairement la personne qui s'exprime («&nbsp;nous&nbsp;»,
-			«&nbsp;je&nbsp;», etc.).</p></li>
+<p>Une dépêche doit séparer ce qui est un sentiment personnel des faits. Et même dans ce cas,
+il convient de faire attention à faire apparaître clairement la personne qui s’exprime
+(« nous », « je », etc.).</p></li>
 
-	<li><p>Vérifier les liens</p>
+<li><p>Vérifier les liens</p>
 
-		<p>Il faut vérifier les liens qui sont proposés, voir s'ils existent, et
-			s'ils parlent bien du sujet de la dépêche. Attention aussi à la langue associée à
-			chaque lien.</p></li>
+<p>Il faut vérifier les liens qui sont proposés, voir s’ils existent et s’ils parlent
+bien du sujet de la dépêche. Attention aussi à la langue associée àchaque lien.</p></li>
 
-	<li><p>Éviter les acronymes</p>
+<li><p>Éviter les acronymes</p>
 
-		<p>Les acronymes sont souvent utilisés par les habitués de LinuxFr.org.
-			Cependant une population non-négligeable ne les connaît pas. Il est
-			apprécié de les détailler dans une petite note du modérateur.</p></li>
+<p>Les acronymes sont souvent utilisés par les habitués de <em>LinuxFr.org</em>.
+Cependant, une population non négligeable ne les connaît pas. Il est
+apprécié de les détailler dans une petite note du modérateur.</p></li>
 
-	<li><p>Éviter les liens de liens de ...</p>
+<li><p>Éviter les liens de liens de…</p>
 
-		<p>Il arrive souvent qu'une dépêche soit proposée sur un sujet, et que le
-			lien proposé pointe vers un site de dépêche similaire à LinuxFr.org. Il faut
-			dans ce cas mettre le lien vers l'information originelle, et
-			éventuellement laisser celui vers le site de dépêche s'il est intéressant
-			et qu'il apporte réellement quelque chose. Sinon un simple "vu sur ..."
-			sera suffisant.</p></li>
+<p>Il arrive souvent qu’une dépêche soit proposée sur un sujet, et que le lien proposé
+pointe vers un site de dépêche similaire à <em>LinuxFr.org</em>.
+Il fautdans ce cas mettre le lien vers l’information originelle,
+et éventuellement laisser celui vers le site de dépêche s’il est intéressant
+et qu’il apporte réellement quelque chose. Sinon, un simple « vu sur… »
+sera suffisant.</p></li>
 
-	<li><p>Éviter les annonces de FooBar 0.0.34.15pre-RC3</p>
+<li><p>Éviter les annonces de « FooBar 0.0.34.15pre-RC3 »</p>
 
-		<p>Les dépêches concernant des versions mineures de logiciels doivent être
-			rejetées. LinuxFr.org n'a pas vocation à être Freshmeat ou le répertoire
-			FSF/UNESCO.</p></li>
+<p>Les dépêches concernant des versions mineures de logiciels doivent être rejetées.
+<em>LinuxFr.org</em> n’a pas vocation à être <em>Freshmeat</em> ou le répertoire
+FSF/UNESCO.</p></li>
 
-	<li><p>Faire attention aux nouvelles «&nbsp;Anonyme&nbsp;»</p>
+<li><p>Faire attention aux nouvelles publiées par « Anonyme »</p>
 
-		<p>Certaines nouvelles sont proposées en tant qu'anonyme. Il faut y faire
-			_très attention_. En effet elles ont souvent tendance à être de moins
-			bonne qualité, être fausses, ou simplement mal rédigées.</p></li>
+<p>Certaines nouvelles sont proposées par un auteur sans compte utilisateur.
+Il faut y faire<em>très attention</em>. En effet, elles ont souvent tendance
+à être de moins bonne qualité, être fausses ou simplement mal rédigées.</p></li>
 
-	<li><p>Discussions sur la liste de modération</p>
+<li><p>Discussions sur la liste de modération</p>
 
-		<p>Lorsque l'équipe de modération est contactée via sa liste de discussion,
-			par l'auteur d'une dépêche insatisfait de la modération ou par toute
-			personne souhaitant poser une question ou obtenir une information, les
-			modérateurs qui répondent sont priés de mettre la liste
-			en copie, pour que toute l'équipe puisse suivre la discussion, et de modérer
-			leurs propos car ils engagent l'équipe par leurs courriels.</p></li>
+<p>Lorsque l’équipe de modération est contactée via sa liste de diffusion,
+par l’auteur d’une dépêche insatisfait de la modération ou par toute
+personne souhaitant poser une question ou obtenir une information,
+les modérateurs qui répondent sont priés de mettre la liste en copie,
+pour que toute l’équipe puisse suivre la discussion, et de modérer
+leurs propos car ils engagent l’équipe par leurs courriels.</p></li>
 
-	<li><p>Être courtois et ouvert</p> 
+<li><p>Être courtois et ouvert</p> 
 
-		<p>De même lors de l'ajout d'un commentaire personnalisé lors de la
-			modération, il convient de rester poli et courtois envers le proposant.
-			Il est facile d'être trop cassant involontairement dans un tel commentaire.</p></li>
+<p>De même, lors de l’ajout d’un commentaire personnalisé lors de la modération,
+il convient de rester poli et courtois envers le proposant.
+Il est facile d’être involontairement trop cassant dans un tel commentaire.</p></li>
 
+<li><p>Indiquer les modifications faites</p>
 
-	<li><p>Indiquer les modifications faites</p>
-
-		<p>Les ajouts au contenu proposé doivent être indiqués par une NdM. Si les
-			retraits modifient profondément le texte, ils doivent être signalés aussi.
-			La terminologie de l'auteur doit être respectée, sauf si elle est
-			manifestement fausse (donc on garde Linux s'il dit Linux, GNU/Linux s'il
-			dit GNU/Linux, open source s'il dit open source, etc. Par contre les
-			«&nbsp;gestionnaires de fenêtres KDE et GNOME&nbsp;» sera converti en «&nbsp;les
-			gestionnaires de bureau KDE et GNOME&nbsp;», etc.).</p></li>
+<p>Les ajouts au contenu proposé doivent être indiqués par une note de modération (N. D. M.).
+Si les retraits modifient profondément le texte, ils doivent être signalés aussi.
+La terminologie de l’auteur doit être respectée, sauf si elle est manifestement fausse
+(donc on garde Linux s’il dit Linux, GNU/Linux s’il dit GNU/Linux, open source s’il dit
+open source, etc. En revanche, « les gestionnaires de fenêtres KDE et GNOME » sera converti
+en « les gestionnaires de bureau KDE et GNOME », etc.).</p></li>
 </ul>
 
 <h2>Liens utiles</h2>
 
 <p>Voici quelques liens utiles qui peuvent servir aux rédacteurs et aux modérateurs.</p>
 
-<p>Dictionnaires français</p>
+<p>Dictionnaires francophones</p>
 
 <ul>
-	<li><a href="https://fr.wiktionary.org/">https://fr.wiktionary.org/</a></li>
-	<li><a href="http://www.granddictionnaire.com">http://www.granddictionnaire.com</a></li>
-	<li><a href="http://atilf.atilf.fr/academie9.htm">http://atilf.atilf.fr/academie9.htm</a></li>
-	<li><a href="http://atilf.atilf.fr/tlf.htm">http://atilf.atilf.fr/tlf.htm</a></li>
-	<li><a href="https://www.lexilogos.com/francais_langue_dictionnaires.htm">https://www.lexilogos.com/francais_langue_dictionnaires.htm</a></li>
-	<li><a href="http://goldendict.org/">GoldenDict (logiciel)</a></li>
+<li><a href="https://fr.wiktionary.org/">Wiktionnaire</a> ;</li>
+<li><a href="http://www.granddictionnaire.com">le grand dictionnaire terminologique (québecois)</a> ;</li>
+<li><a href="https://atilf.atilf.fr/academie9.htm">outil de consultation du dictionnaire de l’Académie française</a> ;</li>
+<li><a href="http://atilf.atilf.fr/tlf.htm">TLFi : trésor de la langue française informatisé</a> ;</li>
+<li><a href="https://www.lexilogos.com/francais_langue_dictionnaires.htm">Lexilogos</a> ;</li>
+<li><a href="http://goldendict.org/">GoldenDict (logiciel)</a>.</li>
 </ul>
 
-<p>Dictionnaires anglais</p>
+<p>Dictionnaires anglophones</p>
 <ul>
-	<li><a href="https://en.wiktionary.org/">https://en.wiktionary.org/</a></li>
-	<li><a href="http://www.dictionary.com/">http://www.dictionary.com/</a></li>
-	<li><a href="https://www.m-w.com/">https://www.m-w.com/</a></li>
-	<li><a href="http://goldendict.org/">GoldenDict (logiciel)</a></li>
+<li><a href="https://en.wiktionary.org/">Wiktionary</a> ;</li>
+<li><a href="https://www.dictionary.com/">Dictionary.com</a> ;</li>
+<li><a href="https://www.merriam-webster.com/">Merriam‑Webster</a> ;</li>
+<li><a href="http://goldendict.org/">GoldenDict (logiciel)</a>.</li>
 </ul>
 
 <p>Conjugaison</p>
 <ul>
-	<li><a href="http://sensmotdire.gnunux.info/">http://sensmotdire.gnunux.info/</a></li>
-
-	<li><a href="http://www.leconjugueur.com/">http://www.leconjugueur.com/</a></li>
-	<li><a href="http://www.logos.it/">http://www.logos.it/</a></li>
+<li><a href="http://sensmotdire.gnunux.info/">sensmotdire</a> ;</li>
+<li><a href="https://www.leconjugueur.com/">Le Conjugueur</a> ;</li>
+<li><a href="https://www.logos.it/">Logos</a>.</li>
 </ul>
 
 <p>Jargon</p>
 <ul>
-	<li><a href="http://jargonf.org/">http://jargonf.org/</a></li>
-	<li><a href="https://www.debian.org/international/french/lexique">https://www.debian.org/international/french/lexique</a></li>
-	<li><a href="https://glossaire.traduc.org/">https://glossaire.traduc.org/</a></li>
+<li><a href="http://jargonf.org/">JargonF.org : Le jargon français</a> ;</li>
+<li><a href="https://www.debian.org/international/french/lexique">le lexique de Debian</a> ;</li>
+<li><a href="https://glossaire.traduc.org/">le glossaire de <em>traduc.org/</em></a>.</li>
 </ul>
 
 <p>Synonymes</p>
 <ul>
-	<li><a href="http://elsap1.unicaen.fr/dicosyn.html">http://elsap1.unicaen.fr/dicosyn.html</a></li>
+<li><a href="https://crisco2.unicaen.fr/des/synonymes/synonyme">DES : dictionnaire électronique des synonymes</a> ;</li>
 </ul>
 
 <h2>Messages automatiques de modération des dépêches</h2>

--- a/db/pages/regles_de_moderation_du_problematique.html
+++ b/db/pages/regles_de_moderation_du_problematique.html
@@ -1,205 +1,260 @@
 <h2>Sommaire</h2>
 <ul>
-<li><a href="#roles">Rôles d'une équipe de modération (4 points et tous importants)</a></li>
-<li><a href="#statutmoderation">Statut de la modération sur le site au printemps 2012</a></li>
-<li><a href="#regles">Règles définies</a></li>
-<li><a href="#perception">De la perception du site</a></li>
-<li><a href="#intervention">De l'intervention</a></li>
+  <li><a href="#roles">Rôles d’une équipe de modération (4 points et tous importants)</a></li>
+  <li><a href="#statutmoderation">Statut de la modération sur le site au printemps 2012</a></li>
+  <li><a href="#regles">Règles définies</a></li>
+  <li><a href="#perception">De la perception du site</a></li>
+  <li><a href="#intervention">De l’intervention</a></li>
 </ul>
 
-<h2 id="roles">Rôles d'une équipe de modération (4 points et tous importants) <a class="anchor" href="#roles">¶</a></h2>
 
+<h2 id="roles">Rôles d’une équipe de modération <a class="anchor" href="#roles">¶</a></h2>
+<p>Quatre points, tous importants :</p>
 <ol>
-<li>la <strong>modération a priori</strong> (acceptation/rejet, édition, ajout d'une NdM)</li>
-<li>la <strong>modération a posteriori</strong> (rejet, édition, ajout d'une NdM, sanction sur l'utilisateur/IP)</li>
-<li>le <strong>rappel de la loi</strong>, des règles du site ou de vie en société, via un commentaire</li>
-<li>le <strong>signalement des cas litigieux / incertains</strong> au reste de l'équipe pour discussion</li>
+  <li>la <strong>modération a priori</strong> (acceptation/rejet, édition, ajout d’une N. D. M.) ;</li>
+  <li>la <strong>modération a posteriori</strong> (rejet, édition, ajout d’une N. D. M., sanction sur l’utilisateur ou l’adresse IP) ;</li>
+  <li>le <strong>rappel de la loi</strong>, des règles du site ou de vie en société, via un commentaire ;</li>
+  <li>le <strong>signalement des cas litigieux ou incertains</strong> au reste de l’équipe pour discussion.</li>
 </ol>
 
-<h2 id="statutmoderation">Statut de la modération sur le site au printemps 2012 <a class="anchor" href="#statutmoderation">¶</a></h2>
-<ul>
-<li>la <strong>modération a priori</strong> par l'équipe de modération (AMR) concerne uniquement les dépêches et les sondages&nbsp;: il y a déjà une charte pour les dépêches, il est assez facile de discuter les points litigieux via les tribunes de modération+dépêches et la liste de diffusion notamment. L'équipe a conscience de son rôle et s'en acquitte plutôt bien. Mais la modération du site
-  <ul> 
-  <li>ne se limite pas uniquement aux corrections de français des dépêches.</li>
-  <li>assume les sondages, le passage en dépêche phare, confirme les tags</li>
-  </ul>
-</li>  
-<li>la <strong>modération a posteriori</strong> des contenus (dépêches, journaux, forums, wiki, suivi, forums) et commentaires par les utilisateurs via le karma (avec pour conséquence masquage, non indexation et non suivi des liens dans les moteurs de recherche). Ça marche plus ou moins bien, mais ça ne couvre pas tous les besoins de modération évidemment.</li>
-<li>les <strong>rappels aux règles</strong> via un commentaire&nbsp;: 
-  <ul>
-  <li>rien de prévu ou discuté au sein de l'équipe,</li>
-  <li>et c'est très peu pratiqué,</li>
-  <li>mais ça arrive et permet de relancer la discussion ou nuancer un propos sibyllin</li>
-  </ul>
-</li>
-<li>les <strong>signalements au reste de l'équipe</strong> pour discussion&nbsp;:
-  <ul>
-  <li>signalement peu pratiqué (et pas de voie privilégiée&nbsp;: par courriel&nbsp;? par irc&nbsp;? par jabber&nbsp;?)</li>
-  <li>ou alors uniquement en petit groupe (oui, plutôt, ou temporairement via la tribune de modo)</li>
-  <li>ponctuellement, par quelques modérateurs via courriel, peu de réponses a priori, pas de consensus (ou difficulté à l'atteindre) Cete méthode est assez lente. Si des réponses ont été effectuées sous l'entrée litigieuse c'est déjà un peu trop tard pour intervenir. Il me semble que sur certains sites, le commentaire est suspendu le temps de la modération et remis après si c'est OK ou effacé si c'est NOK.</li>
-  </ul>
-</li>
-<li>la <strong>modération a posteriori</strong> des contenus et commentaires&nbsp;:
-  <ul> 
-  <li>des règles larges peu directives<sup><a href="#ref1">1</a></sup>,</li>
-  <li>des possibilités techniques d'intervention nombreuses<sup><a href="#ref2">2</a></sup>,</li>
-  <li>des interventions de fait arbitraires,</li>
-  <li>trop peu de membres de l'équipe interviennent, manque de communication et de discussion au sein de l'équipe (tout le monde ne lit pas tout, signalement pas forcément diffusé à tous, doute dans le constat, etc.)</li>
-  </ul>
-</li>
+
+<h2 id="statutmoderation">Statut de la modération sur le site au printemps 2012 <a class="anchor" href="#statutmoderation">¶</a></h2>
+
+<h3>Modération a priori</h3>
+<p>La modération a priori par l’équipe de modération (AMR) concerne uniquement les dépêches et les sondages :
+  il y a déjà une charte pour les dépêches, il est assez facile de discuter les points litigieux via
+  les tribunes de modération et des dépêches et la liste de diffusion notamment, l’équipe a conscience de son rôle
+  et s’en acquitte plutôt bien. Mais la modération du site :</p>
+<ul> 
+  <li>ne se limite pas uniquement aux corrections de français des dépêches ;</li>
+  <li>assume les sondages, le passage en dépêche phare, confirme les étiquettes.</li>
 </ul>
 
-<p><a id="ref1">Référence <sup>1</sup></a></p>
+<h3>Modération a posteriori</h3>
+<p>La modération <em>a posteriori</em> des contenus (dépêches, journaux, forums, pages wiki, forums et entrées de suivi)
+et commentaires par les utilisateurs via le karma (avec pour conséquence masquage, non‑indexation et non‑suivi des liens
+dans les moteurs de recherche). Ça marche plus ou moins bien, mais ça ne couvre pas tous les besoins de modération, évidemment.</p>
+
+<h3>Les rappels aux règles via un commentaire<h3>
 <ul>
-<li>droit de refuser l'accès au site, droit d'effacer toute intervention sur ce site, ainsi que de supprimer tout compte dont l'utilisation nous semblerait détournée, droit de faire ce qu'on veut (cf <a href="/informations">linuxfr.org/informations</a>)</li>
-<li>fermeture de comptes multiples, droit de fermer les comptes utilisant des adresses jetables (cf <a href="/compte/inscription">/compte/inscription</a>)</li>
-<li>commentaires «&nbsp;appartenant à ceux qui les ont postés. Nous n'en sommes pas responsables&nbsp;» (sur chaque page de contenu)</li>
+  <li>rien de prévu ou discuté au sein de l’équipe ;</li>
+  <li>et c’est très peu pratiqué ;</li>
+  <li>mais ça arrive et permet de relancer la discussion ou nuancer un propos sibyllin.</li>
 </ul>
 
-<p><a id="ref2">Référence <sup>2</sup></a></p>
+<h3>Signalements au reste de l’équipe</h3>
+<p>Les signalements au reste de l’équipe pour discussion sont :</p>
 <ul>
-<li>les moyens (web ou SQL) d'intervenir sur tous 
-  <ul>
-  <li>les contenus,</li>
-  <li>les commentaires,</li>
-  <li>les comptes</li>
-  <li>et les tags.</li>
-  </ul>
-</li>
-<li>réédition ou suppression d'un
-  <ul>
-  <li>contenu</li>
-  <li>ou un commentaire,</li>
-  <li>fermeture/purge d'un compte,</li>
-  <li>privation de tribune,</li>
-  <li>suppression d'un compte,</li>
-  <li>hausse/baisse de karma</li>
-  </ul>
-</li>
+  <li>peu pratiqués (et pas de voie privilégiée : par courriel ? par IRC ? par XMPP ?) ;</li>
+  <li>souvent effectués uniquement en petit groupe (oui, plutôt, ou temporairement via la tribune de modération) ;</li>
+  <li>ponctuels, par quelques modérateurs via courriel ; peu de réponses a priori, pas de consensus (ou difficulté à l’atteindre) ;
+    cette méthode est assez lente, si des réponses ont été effectuées sous l’entrée litigieuse, c’est déjà un peu trop tard
+    pour intervenir ; il me semble que sur certains sites, le commentaire est suspendu le temps de la modération et remis après
+    si c’est OK ou effacé dans le cas contraire.</li>
 </ul>
 
-<h2 id="regles">Règles définies <a class="anchor" href="#regles">¶</a></h2>
-
-<h3 id="manifestement-illegal">Le manifestement illégal <a class="anchor" href="#manifestement-illegal">¶</a></h3>
-
-<p>&rarr; édition/suppression systématique + prévenir (le «&nbsp;manifestement&nbsp;» prêtant à interprétation)</p>
-
-<h3 id="contenus-pornographiques">Les contenus pornographiques <a class="anchor" href="#contenus-pornographiques">¶</a></h3>
-
-<p>Et probablement les liens vers du matériel pornographique. Sont illégaux ici car présence de mineurs, cf <a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000023711920&amp;cidTexte=LEGITEXT000006070719&amp;categorieLien=id&amp;dateTexte=20120702">article 227-24 du code pénal français</a>) &rarr; édition/suppression systématique</p> 
-
-<h3 id="hors-sujet">Le hors sujet / non accepté <a class="anchor" href="#hors-sujet">¶</a></h3>
-
-  <ul>
-  <li>les contenus, commentaires et comptes de spammeurs &rarr; édition/suppression systématique</li>
-  <li>les comptes multiples &rarr; édition/suppression systématique</li>
-  <li>les abus de ressources  &rarr; édition/suppression systématique</li>
-  <li>les contenus creux / vides &rarr; laisser le système de notation régler le problème des contenus creux/vides car il est difficile de placer la limite entre «&nbsp;pas très intéressant&nbsp;» et contenus creux/vides</li>
-  <li>ce qui n'a pas sa place à tel ou tel endroit&nbsp;: par exemple limiter l'utilisation du wiki à tel ou tel sujet&nbsp;? les forums aux questions&nbsp;? &rarr; les dérives sont limitées, laisser le système de notation et les commentaires des visiteurs régler le problème du bon endroit (et éventuellement déplacer ensuite au besoin)</li>
-  </ul>
-
-<h3 id="derangeant">Le dérangeant divers et varié (et peut-être illégal) <a class="anchor" href="#derangeant">¶</a></h3>
-
-<p>&rarr; pas d'édition/suppression sans discussion, commentaire de rappel à systématiser pour éviter les dérives</p>
-
-  <ul>
-  <li>le discriminatoire (<a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006417831&amp;cidTexte=LEGITEXT000006070719">article 225-1 du code pénal français</a>)&nbsp;: origine, sexe, situation de famille, grossesse, apparence physique, patronyme, état de santé, handicap, caractéristiques génétiques, mœurs, orientation sexuelle, âge, opinions politiques, activités syndicales, (non-)appartenance vraie/supposée à ethnie/nation/race/religion</li>
-  <li>le possiblement diffamatoire</li>
-  <li>le désagréable/désobligeant/injurieux/agressif/attaque personnelle</li>
-  <li>le contenu politique, le prosélytisme politique</li>
-  <li>le contenu religieux/sectaire, le prosélytisme religieux/sectaire</li>
-  <li>les controverses sociétales (avortement, peine de mort, sexualité, laïcité, désobéissance civile, géopolitique)</li>
-  <li>les critiques virulentes (les autres n'étant pas problématique) de l'équipe de site et de sa politique</li>
-  <li>des liens vers des contenus dérangeants et peut-être illégaux</li>
-  <li>...</li>
-  </ul>
-
-<h3 id="pure-forme">Les corrections de pure forme <a class="anchor" href="#pure-forme">¶</a></h3>
-
-<p>Orthographe, erreur de lien, etc. &rarr; édition uniquement.</p>
-
-<h3 id="avantages-limites">Avantages et limites d'une politique de modération <a href="#avantages-limites">¶</a></h3>
-
-<p>Une politique de modération ne réglera jamais tous les cas. D'où l'intérêt du point 4 des rôles d'une équipe de modération.</p>
-
-<p>Avoir une politique de modération&nbsp;: c'est avoir des règles connues de tous, équipe du site et visiteurs. C'est permettre de traiter une grande partie des cas en sachant comment/pourquoi. </p>
-
-<p>C'est savoir plus clairement ce que l'on doit faire, l'assumer et savoir que c'est ce qu'il fallait faire.</p>
-
-<p>Ne pas avoir de politique de modération&nbsp;: c'est fonctionner uniquement à l'arbitraire, à l'humeur du moment d'un modérateur, c'est être isolé quand il faut décider, agir et assumer.</p>
-
-<p>Avoir une politique de modération réduit fortement l'arbitraire, même s'il est toujours possible d'interpréter à sa façon.</p>
-
-<p>L'équipe de modération et l'association portant le site se réservent le droit de supprimer purement et simplement toute contribution publique si son contenu ne respecte pas les critères définis ici. Toutefois l'équipe et l’association n’ont pas qualité pour juger de la légalité d’un contenu : une décision de justice en bonne et due forme est requise pour cela.</p>
-
-<h2 id="perception">De la perception du site <a class="anchor" href="#perception">¶</a></h2>
-
+<h3>Modération a posteriori</h3>
+  <p>La modération <em>a posteriori</em> des contenus et commentaires s’effectue avec :
 <ul>
-<li>ce qui a été édité ou supprimé n'est plus ni visible ni accessible ni indexé par les moteurs de recherche&nbsp;;</li>
-<li>les contenus restants qui, avec un karma strictement négatif, ne sont plus indexés par les moteurs (mais restent visibles dans les index du site) et les liens des commentaires de ces contenus ne sont pas suivis par les moteurs (actuellement les liens dans ces contenus sont suivis via les pages d'index du site)&nbsp;;</li>
-<li>actuellement, les commentaires à karma strictement négatif des contenus à karma positif sont indexés et leurs liens suivis&nbsp;;</li>
-<li>les contenus et commentaires avec un karma strictement positif sont largement visibles (par défaut). Les autres ne sont vus que par ceux qui ont volontairement abaissé le seuil d'affichage. Dans tous les cas, ils restent accessibles si quelqu'un pointe vers eux.</li>
+  <li>des règles larges, peu directives<sup><a href="#ref1">1</a></sup> ;</li>
+  <li>des possibilités techniques d’intervention nombreuses<sup><a href="#ref2">2</a></sup> ;</li>
+  <li>des interventions de fait arbitraires ;</li>
+  <li>trop peu de membres de l’équipe, un manque de communication et de discussion
+    au sein de l’équipe (tout le monde ne lit pas tout, signalement pas forcément diffusé à tous,
+    doute dans le constat, etc.).</li>
 </ul>
 
-<p>Ce qui est visible, accessible ou indexé est ce sur quoi le site est perçu et jugé&nbsp;: c'est-à-dire ce qui est mis par les utilisateurs _et_ les éventuels commentaires de réaction de l'équipe de modération. Si des contenus jugés choquants sont laissés, l'équipe sera taxée de laxiste, je-m'en-foutiste, passive et donc consentante, manquant d'envie de s'en occuper, de faire l'autruche, d'être cynique, se cachant derrière une liberté d'expression absolue. Ces critiques seront adressées via le site, ou plus probablement via d'autres canaux (numériques ou réels) et contribueront à la «&nbsp;réputation&nbsp;» du site.</p>
-
-<p>Par ailleurs cela peut produire de l'auto-censure&nbsp;:</p>
-
+<p><a id="ref1">Référence <sup>1</sup></a></p>
 <ul>
-<li>ne pas proposer des contenus</li>
-<li>ou de commentaires pour ne pas se voir associer à ceux existants,</li>
-<li>ne pas s'exprimer sur tel ou tel sujet polémique,</li>
-<li>ne pas s'exposer à des attaques personnelles ou à lynchage public,</li>
-<li>ne pas intervenir, en pensant adopter une «&nbsp;neutralité absolue&nbsp;», peut donc aussi limiter la liberté d'expression.</li>
+  <li>droit de refuser l’accès au site, droit d’effacer toute intervention sur ce site,
+    ainsi que de supprimer tout compte dont l’utilisation nous semblerait détournée,
+    droit de faire ce qu’on veut (<em>cf.</em> <a href="/informations">linuxfr.org/informations</a>) ;</li>
+  <li>fermeture de comptes multiples, droit de fermer les comptes utilisant des adresses jetables
+    (<em>cf.</em> <a href="/compte/inscription">/compte/inscription</a>) ;</li>
+  <li>commentaires « appartenant à ceux qui les ont postés. Nous n’en sommes pas responsables »
+    (sur chaque page de contenu).</li>
+</ul>
+
+<p><a id="ref2">Référence <sup>2</sup></a> :</p>
+<ul>
+  <li>les moyens (Web ou SQL) d’intervenir sur tous :
+    <ul>
+      <li>les contenus,</li>
+      <li>les commentaires,</li>
+      <li>les comptes,</li>
+      <li>et les étiquettes ;</li>
+    </ul>
+  </li>
+  <li>la réédition ou suppression :
+    <ul>
+      <li>d’un contenu,</li>
+      <li>d’un commentaire,</li>
+      <li>la fermeture et la purge d’un compte,</li>
+      <li>la privation de tribune,</li>
+      <li>la suppression d’un compte,</li>
+      <li>la hausse ou la baisse de karma.</li>
+    </ul>
+  </li>
+</ul>
+
+
+<h2 id="regles">Règles définies <a class="anchor" href="#regles">¶</a></h2>
+
+<h3 id="manifestement-illegal">Le manifestement illégal <a class="anchor" href="#manifestement-illegal">¶</a></h3>
+<p>→ édition ou suppression systématique + prévenir (le « manifestement » prêtant à interprétation).</p>
+
+<h3 id="contenus-pornographiques">Les contenus pornographiques <a class="anchor" href="#contenus-pornographiques">¶</a></h3>
+<p>Et probablement les liens vers du matériel pornographique, sont illégaux ici car présence de mineurs,
+  <em>cf.</em> <a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000023711920&amp;cidTexte=LEGITEXT000006070719&amp;categorieLien=id&amp;dateTexte=20120702">article 227‑24 du code pénal français</a>)
+  → édition ou suppression systématique.</p> 
+
+<h3 id="hors-sujet">Le hors‑sujet ou non accepté <a class="anchor" href="#hors-sujet">¶</a></h3>
+<ul>
+  <li>les contenus, commentaires et comptes de spammeurs → édition/suppression systématique ;</li>
+  <li>les comptes multiples → édition ou suppression systématique ;</li>
+  <li>les abus de ressources → édition ou suppression systématique ;</li>
+  <li>les contenus creux ou vides → laisser le système de notation régler le problème des contenus creux ou vides
+    car il est difficile de placer la limite entre « pas très intéressant » et contenus creux ou vides ;</li>
+  <li>ce qui n’a pas sa place à tel ou tel endroit : par exemple, limiter l’utilisation du wiki à tel ou tel sujet ?
+    les foires aux questions ? → les dérives sont limitées, laisser le système de notation et les commentaires
+    des visiteurs régler le problème du bon endroit (et, éventuellement, déplacer ensuite au besoin).</li>
+</ul>
+
+<h3 id="derangeant">Le dérangeant divers et varié (et peut‑être illégal) <a class="anchor" href="#derangeant">¶</a></h3>
+<p>→ pas d’édition ou de suppression sans discussion, commentaire de rappel à systématiser pour éviter les dérives :</p>
+<ul>
+  <li>le discriminatoire (<a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006417831&amp;cidTexte=LEGITEXT000006070719">article 225-1 du code pénal français</a>) :
+    origine, sexe, situation de famille, grossesse, apparence physique, patronyme, état de santé, handicap,
+    caractéristiques génétiques, mœurs, orientation sexuelle, âge, opinions politiques, activités syndicales,
+    (non‑)appartenance vraie ou supposée à une ethnie, nation, race ou religion ;</li>
+  <li>le possiblement diffamatoire ;</li>
+  <li>le désagréable, désobligeant, injurieux, agressif ou l’attaque personnelle ;</li>
+  <li>le contenu politique, le prosélytisme politique ;</li>
+  <li>le contenu religieux ou sectaire, le prosélytisme religieux ou sectaire ;</li>
+  <li>les controverses sociétales (avortement, peine de mort, sexualité, laïcité, désobéissance civile, géopolitique…) ;</li>
+  <li>les critiques virulentes (les autres n’étant pas problématiques) de l’équipe du site et de sa politique ;</li>
+  <li>des liens vers des contenus dérangeants et peut‑être illégaux ;</li>
+  <li>etc.</li>
+</ul>
+
+<h3 id="pure-forme">Les corrections de pure forme <a class="anchor" href="#pure-forme">¶</a></h3>
+<p>Orthographe, erreur de lien, etc. → édition uniquement.</p>
+
+<h3 id="avantages-limites">Avantages et limites d’une politique de modération <a href="#avantages-limites">¶</a></h3>
+<p>Une politique de modération ne réglera jamais tous les cas. D’où l’intérêt du point 4 des rôles d’une équipe de modération.</p>
+
+<p>Avoir une politique de modération : c’est avoir des règles connues de tous, équipe du site et visiteurs.
+  C’est permettre de traiter une grande partie des cas en sachant comment et pourquoi.</p>
+<p>C’est savoir plus clairement ce que l’on doit faire, l’assumer et savoir que c’est ce qu’il fallait faire.</p>
+<p>Ne pas avoir de politique de modération : c’est fonctionner uniquement à l’arbitraire, à l’humeur du moment d’un modérateur,
+  c’est être isolé quand il faut décider, agir et assumer.</p>
+<p>Avoir une politique de modération réduit fortement l’arbitraire, même s’il est toujours possible d’interpréter à sa façon.</p>
+<p>L’équipe de modération et l’association portant le site se réservent le droit de supprimer purement et simplement toute
+  contribution publique si son contenu ne respecte pas les critères définis ici. Toutefois l’équipe et l’association n’ont pas
+  qualité pour juger de la légalité d’un contenu : une décision de justice en bonne et due forme est requise pour cela.</p>
+
+
+<h2 id="perception">De la perception du site <a class="anchor" href="#perception">¶</a></h2>
+<ul>
+  <li>ce qui a été édité ou supprimé n’est plus ni visible, ni accessible, ni indexé par les moteurs de recherche ;</li>
+  <li>les contenus restants qui, avec un karma strictement négatif, ne sont plus indexés par les moteurs de recherche
+    (mais restent visibles dans les index du site) et les liens des commentaires de ces contenus ne sont pas suivis par
+    les moteurs (actuellement les liens dans ces contenus sont suivis via les pages d’index du site) ;</li>
+  <li>actuellement, les commentaires à karma strictement négatif des contenus à karma positif sont indexés et leurs liens suivis ;</li>
+  <li>les contenus et commentaires avec un karma strictement positif sont largement visibles (par défaut), les autres
+    ne sont vus que par ceux qui ont volontairement abaissé le seuil d’affichage ; dans tous les cas, ils restent accessibles
+    si quelqu’un pointe vers eux.</li>
+</ul>
+
+<p>Ce qui est visible, accessible ou indexé est ce sur quoi le site est perçu et jugé, c’est‑à‑dire ce qui est mis par
+  les utilisateurs <em>et</em> les éventuels commentaires de réaction de l’équipe de modération. Si des contenus jugés
+  choquants sont laissés, l’équipe sera taxée de laxiste, je‑m’en‑foutiste, passive et donc consentante, manquant d’envie
+  de s’en occuper, de faire l’autruche, d’être cynique, se cachant derrière une liberté d’expression absolue.
+  Ces critiques seront adressées via le site, ou plus probablement via d’autres canaux (numériques ou réels)
+  et contribueront à la « réputation » du site.</p>
+
+<p>Par ailleurs, cela peut produire de l’auto‑censure :</p>
+<ul>
+  <li>ne pas proposer de contenus ;</li>
+  <li>ou de commentaires, pour ne pas se voir associer à ceux existants ;</li>
+  <li>ne pas s’exprimer sur tel ou tel sujet polémique ;</li>
+  <li>ne pas s’exposer à des attaques personnelles ou à un lynchage public ;</li>
+  <li>ne pas intervenir, en pensant adopter une « neutralité absolue », peut donc aussi limiter la liberté d’expression.</li>
 </ul>
  
-<p>D'où le point 3 des rôles de l'équipe de modération, le rappel via commentaire afin de</p>
+<p>D’où le point 3 des rôles de l’équipe de modération, le rappel via commentaire afin de :</p>
 <ul>
-<li>soit défendre ceux qui seraient empêchés de s'exprimer ou pris à parti,</li>
-<li>soit pour rappeler les règles par un lien vers celles-ci ou par une citation partielle.</li>
+  <li>soit défendre ceux qui seraient empêchés de s’exprimer ou pris à parti ;</li>
+  <li>soit pour rappeler les règles par un lien vers celles‑ci ou par une citation partielle.</li>
 </ul>
 
-<p>Nos visiteurs nous jugeront aussi sur ce qui a été édité ou supprimé&nbsp;:</p>
-
+<p>Nos visiteurs nous jugeront aussi sur ce qui a été édité ou supprimé :</p>
 <ul>
-<li>si la modération jugée est abusive, arbitraire, à la tête du client, fonction de l'âge du capitaine, si les règles sont jugées peu explicites ou mal appliquées, si d'aucuns crient à la censure ou au politiquement correct, etc.,
-  <ul> 
-  <li>cela contribuera tout autant à la réputation du site,</li>
-  <li>produit des flopées de commentaires et contenus pour en discuter,</li>
-  <li>et pourra aussi produire de l'auto-censure.</li>
-  </ul>
-</li>
-<li>d'où l'intérêt d'avoir une politique claire, publiée, de la rappeler, d'avoir une action transparente et expliquée</li>
-<li>politique claire ou pas, plusieurs personnes (dont « l'humeur du moment »/la sensibilité/l'interprétation peut varier) modèrent le site, des "erreurs" seront commises (oublis, différences de traitement, etc...)</li>
+  <li>si la modération jugée est abusive, arbitraire, à la tête du client, fonction de l’âge du capitaine, si les règles
+    sont jugées peu explicites ou mal appliquées, si d’aucuns crient à la censure ou au politiquement correct, etc. :
+    <ul> 
+      <li>cela contribuera tout autant à la réputation du site,</li>
+      <li>produit des flopées de commentaires et contenus pour en discuter,</li>
+      <li>et pourra aussi produire de l’auto‑censure ;</li>
+    </ul>
+  </li>
+  <li>d’où l’intérêt d’avoir une politique claire, publiée, de la rappeler, d’avoir une action transparente et expliquée ;</li>
+  <li>politique claire ou pas, plusieurs personnes (dont « l’humeur du moment », la sensibilité et l’interprétation
+    peuvent varier) modèrent le site, des « erreurs » seront commises (oublis, différences de traitement, etc.).</li>
 </ul>
 
-<h3 id="resume">Résumé <a class="anchor" href="#resume">¶</a></h3>
+<h3 id="resume">Résumé <a class="anchor" href="#resume">¶</a></h3>
 <ul>
-<li>intervenir oriente les commentaires, les contenus et l'esprit général du site. Ne pas intervenir aussi.</li>
-<li>que l'équipe de modération intervienne ou pas, il faudra bien au final qu'elle assume son action/inaction, qu'elle explique son choix/non choix.</li>
+  <li>intervenir oriente les commentaires, les contenus et l’esprit général du site ; ne pas intervenir aussi ;</li>
+  <li>que l’équipe de modération intervienne ou pas, il faudra bien au final qu’elle assume son action ou inaction,
+    qu’elle explique son choix ou son absence de choix.</li>
 </ul>
 
-<h2 id="intervention">De l'intervention <a class="anchor" href="#intervention">¶</a></h2>
 
+<h2 id="intervention">De l’intervention <a class="anchor" href="#intervention">¶</a></h2>
 <ul>
-<li>Qui&nbsp;: tout un chacun dans l'équipe de modération. Chacun accepte de faire appliquer la politique de modération prévue, et donc d'intervenir sur contenus et commentaires, de faire des rappels dans un commentaire, de signaler les cas litigieux, lorsque cela doit être fait. Ceux qui ne le feraient pas ne sont pas à leur place dans une équipe de modération dont c'est justement le rôle&nbsp;: cela peut vouloir dire qu'ils seraient plus à l'aise dans l'équipe de rédaction par exemple.</li>
-
-<li>Quand&nbsp;: chaque fois que cela est nécessaire. Chaque fois qu'un membre de l'équipe visite le site, comme tout utilisateur. Mais aussi plus proactivement, c'est-à-dire en parcourant régulièrement le site pour assurer son rôle, ce que ne ferait pas forcément un simple visiteur.</li>
-
-<li>Comment&nbsp;: les fonctions d'intervention sont pour partie disponibles depuis l'interface web (donc les utiliser), pour partie accessibles uniquement aux admin. du site ou aux admin. sys. (donc signaler), et la possibilité de faire un rappel dans un commentaire est disponible pour tous. Dans un souci de transparence, les actions de modération doivent être enregistrées (qui a fait quoi, quand, pourquoi) et publiées. Et les actions peuvent toujours être contestées en écrivant à l'équipe de modération.</li>
+  <li>qui : tout un chacun dans l’équipe de modération ; chacun accepte de faire appliquer la politique de modération prévue,
+    et donc d’intervenir sur les contenus et commentaires, de faire des rappels dans un commentaire, de signaler les cas
+    litigieux, lorsque cela doit être fait ; ceux qui ne le feraient pas ne sont pas à leur place dans une équipe de modération
+    dont c’est justement le rôle : cela peut vouloir dire qu’ils seraient plus à l’aise dans l’équipe de rédaction, par exemple ;</li>
+  <li>quand : chaque fois que cela est nécessaire ; chaque fois qu’un membre de l’équipe visite le site, comme tout utilisateur,
+    mais aussi plus proactivement, c’est‑à‑dire en parcourant régulièrement le site pour assurer son rôle, ce que ne ferait pas
+    forcément un simple visiteur ;</li>
+  <li>comment : les fonctions d’intervention sont pour partie disponibles depuis l’interface Web (donc les utiliser),
+    pour partie accessibles uniquement aux administrateurs du site ou aux administrateurs système (donc, signaler),
+    et la possibilité de faire un rappel dans un commentaire est disponible pour tous ; dans un souci de transparence,
+    les actions de modération doivent être enregistrées (qui a fait quoi, quand, pourquoi) et publiées, et les actions peuvent
+    toujours être contestées en écrivant à l’équipe de modération.</li>
 </ul>
 
-<p>Remarque&nbsp;: simplement noter un commentaire/contenu ne relève pas du rôle de l'équipe de modération, c'est accessible à chaque visiteur (et c'est un choix personnel). Se limiter à cliquer sur pertinent ou inutile est donc insuffisant pour un membre de l'équipe de modération face à un commentaire/contenu problématique. Et l'équipe de modération n'a pas plus le droit de se coordonner pour s'en prendre massivement à un contenu/commentaire/utilisateur que n'importe quel groupe de visiteurs. Bref les appels à moinsage/plussage massifs ne doivent pas avoir lieu. Pour autant, l'équipe de modération se réserve le droit de supprimer des contenus illégaux ou nuisant à l'ambiance sur le site, à charge de gérer les réactions en expliquant le contexte donnant lieu à cette action.</p>
+<p>Remarque : simplement noter un commentaire ou contenu ne relève pas du rôle de l’équipe de modération, c’est accessible à
+  chaque visiteur (et c’est un choix personnel) ; se limiter à cliquer sur pertinent ou inutile est donc insuffisant pour un
+  membre de l’équipe de modération face à un commentaire ou contenu problématique, et l’équipe de modération n’a pas plus le
+  droit de se coordonner pour s’en prendre massivement à un contenu, un commentaire ou un utilisateur que n’importe quel
+  groupe de visiteurs. Bref, les appels à « moinsage » ou « plussage » massifs ne doivent pas avoir lieu. Pour autant,
+  l’équipe de modération se réserve le droit de supprimer des contenus illégaux ou nuisant à l’ambiance sur le site,
+  à charge de gérer les réactions en expliquant le contexte donnant lieu à cette action.</p>
 
-<p>Lorsqu'un problème est signalé sur la liste de modération, il n'est pas envisageable de patienter jusqu'à ce que tout le monde se soit exprimé. Si trois personnes ou plus, comprenant au moins deux membres de l'association LinuxFr, se sont toutes exprimées pour la même décision, elle est considérée comme adoptée. Une décision ne devrait pas prendre plus de 24h&nbsp;; passé ce délai, tout membre de l'association peut intervenir sur les contenus/commentaires/comptes comme il lui semble nécessaire de le faire.</p>
+<p>Lorsqu’un problème est signalé sur la liste de modération, il n’est pas envisageable de patienter jusqu’à ce que tout le
+  monde se soit exprimé. Si trois personnes ou plus, comprenant au moins deux membres de l’association LinuxFr, se sont toutes
+  exprimées pour la même décision, elle est considérée comme adoptée. Une décision ne devrait pas prendre plus de 24 h ;
+  passé ce délai, tout membre de l’association peut intervenir sur les contenus, commentaires ou comptes comme il lui semble
+  nécessaire de le faire.</p>
 
-<p>En cas de désaccord prolongé (que la discussion n'a pas permis de supprimer),</p>
-
-<ul> 
-<li>L'avis du directeur de publication est prépondérant, puisqu'il assume la responsabilité du site. Il est mentionné sur la page <a href="/mentions_legales">Mentions légales</a> (Benoît Sibaud au printemps 2012)</li>
-<li>L'avis du président de l'association portant le site est ensuite prépondérant.</li>
-<li>L'avis de l'équipe peut être pris en compte pour nuancer la réaction, dans le cas d'une participation significative et effective (dans les temps effectif de réactivité nécessaire), une analyse a posteriori peut être effectuée et discutée pour prise en compte éventuelle, si nécessaire.</li>
-<li>L'avis de l'équipe peut être retenu sur le long terme, sous réserve qu'ils soit significatif et prenant en compte les remontées des utilisateurs du site.</li>
+<p>En cas de désaccord prolongé (que la discussion n’a pas permis de supprimer) :</p>
+<ul>
+  <li>l’avis du directeur de publication est prépondérant, puisqu’il assume la responsabilité du site, il est mentionné sur
+    la page « <a href="/mentions_legales">Mentions légales</a> » (Benoît Sibaud, au printemps 2012) ;</li>
+  <li>l’avis du président de l’association portant le site est ensuite prépondérant ;</li>
+  <li>l’avis de l’équipe peut être pris en compte pour nuancer la réaction, dans le cas d’une participation significative
+    et effective (dans les temps effectif de réactivité nécessaire), une analyse <em>a posteriori</em> peut être effectuée
+    et discutée pour prise en compte éventuelle, si nécessaire ;</li>
+  <li>l’avis de l’équipe peut être retenu sur le long terme, sous réserve qu’il soit significatif et prenant en compte les
+    remontées des utilisateurs du site.</li>
 </ul>
 
-<p>Soutien&nbsp;: même si la coordination est principalement informelle, il y a peu de désaccords et de fait un soutien affiché entre modérateurs. Il y a une logique qu'il n'y a que ceux qui ne font rien qui ne font pas d'erreur d'une part, mais aussi d'autre part notre bon sens qui nous indique à chacun que nous aurions sans doute fait pareil. Sans chercher de légitimité parmi ceux qui ne disent rien parce qu'ils soutiennent, un petit mot de temps en temps pour initier la discussion ou la réflexion permettrait de confirmer un consensus... (même si un +1 peut être très énervant).</p>
+<p>Soutien : même si la coordination est principalement informelle, il y a peu de désaccords et, de fait, un soutien affiché
+  entre modérateurs. Il est logique qu’il n’y a que ceux qui ne font rien qui ne font pas d’erreur, d’une part ; mais aussi,
+  d’autre part, notre bon sens nous indique à chacun que nous aurions sans doute fait pareil. Sans chercher de légitimité
+  parmi ceux qui ne disent rien parce qu’ils soutiennent, un petit mot de temps en temps pour initier la discussion ou la
+  réflexion permet de confirmer un consensus… (même si un « +1 » peut être très énervant).</p>

--- a/db/pages/statistiques.html
+++ b/db/pages/statistiques.html
@@ -1,18 +1,20 @@
 <ul>
-  <li><a href="/webalizer">Statistiques web</a> (<a href="/webalizer/data.csv">statistiques principales en CSV</a>)</li>
+  <li><a href="/webalizer">Statistiques Web</a> (<a href="/webalizer/data.csv">statistiques principales en CSV</a>)</li>
   <li><a href="/images/load/">Charge serveur</a></li>
   <li>Statistiques sur nos bases de données
     <ul>
       <li><a href="/statistiques/prizes">aide au choix des primables</a></li>
       <li><a href="/statistiques/applications">applications (API OAuth2)</a></li>
-      <li><a href="/statistiques/top">classements top ou flop</a></li>
+      <li><a href="/statistiques/top">autrices et auteurs les plus prolifiques</a></li>
       <li><a href="/statistiques/comments">commentaires</a></li>
       <li><a href="/statistiques/contents">contenus</a></li>
       <li><a href="/statistiques/moderation">modération</a></li>
       <li><a href="/statistiques/redaction">rédaction</a></li>
-      <li><a href="/statistiques/tracker">suivi des suggestions et bugs</a></li>
-      <li><a href="/statistiques/tags">tags</a></li>
-      <li><a href="/statistiques/users">utilisateurs</a></li>
+      <li><a href="/statistiques/tracker">suivi des bogues et suggestions</a></li>
+      <li><a href="/statistiques/tags">étiquettes</a></li>
+      <li><a href="/statistiques/users">utilisatrices et utilisateurs</a></li>
+      <li><a href="/statistiques/anonymous">le compte Anonyme</a></li>
+      <li><a href="/statistiques/collective">le compte Collectif</a></li>
     </ul>
   </li>
 </ul>

--- a/db/pages/team.html
+++ b/db/pages/team.html
@@ -1,47 +1,53 @@
 <h2>Les modérateurs</h2>
 <p>
-	Le site LinuxFr.org tourne entre autres grâce aux modérateurs qui passent (tout ?) leur temps à regarder les contenus soumis par les utilisateurs (vous), éditer les bonnes dépêches, valider les meilleures, et parfois faire passer des doublons.
+Le site <em>LinuxFr.org</em> fonctionne, entre autres, grâce aux modératrices et modérateurs
+qui passent (tout ?) leur temps à regarder les contenus soumis par les utilisatrices et utilisateurs
+(vous), éditer les bonnes dépêches, valider les meilleures, et parfois supprimer des doublons.
 </p>
 <p>
-	En cas de problème sur un contenu, sur votre compte LinuxFr.org, vous pouvez les contacter collectivement par courriel &lt;moderateurs_@_linuxfr.org&gt;.
-	Ils tenteront de vous répondre dès que possible (parfois quelques jours).
+En cas de problème sur un contenu, sur votre compte <em>LinuxFr.org</em>, vous pouvez les contacter
+collectivement par courriel à l’adresse &lt;moderateurs_@_linuxfr.org&gt;.
+Ils tenteront de vous répondre dès que possible (parfois quelques jours après).
 </p>
 <p>
-	Les modérateurs actuels sont :
+Les modératrices et modérateurs actuels sont :
 </p>
 {{moderator_list}}
 
-<h2>Les animateurs de l'espace de rédaction</h2>
+<h2>Les animateurs de l’espace de rédaction</h2>
 <p>
-  Ils s'occupent de l'espace de rédaction collaborative de LinuxFr.org.
-  Ils sont notamment abonnés à la liste de rédaction &lt;redacteurs_@_linuxfr.org&gt; (qui est par ailleurs <a href="https://lists.linuxfr.org/wws/arc/redacteurs">ouverte à tous</a>).
+Ils s’occupent de l’espace de rédaction coopérative de <em>LinuxFr.org</em>.
+Ils sont notamment abonnés à la liste de diffusion &lt;redacteurs_@_linuxfr.org&gt;
+(qui est par ailleurs <a href="https://lists.linuxfr.org/wws/arc/redacteurs">ouverte à tous</a>).
 <p>
 <p>
-  Les animateurs actuels sont :
+  Les animatrices et animateurs actuels sont :
 </p>
 {{editor_list}}
 
 <h2>Les administrateurs</h2>
 <p>
-	Les serveurs de LinuxFr.org sont administrés par une équipe très compétente (si si, je vous assure).
-	Vous pouvez les contacter par courriel &lt;team_@_linuxfr.org&gt;.
+Les serveurs de <em>LinuxFr.org</em> sont administrés par une équipe très compétente (si si, je vous assure).
+Vous pouvez les contacter par courriel à l’adresse &lt;team_@_linuxfr.org&gt;.
 </p>
 <p>
-	Les administrateurs actuels sont :
+Les administrateurs actuels sont :
 </p>
 {{admin_list}}
 
 <h2>Les heureux donateurs</h2>
 <p>
-	Certains personnes semblent vouloir nous envoyer de l'argent et nous les en remercions.
+Certaines personnes semblent vouloir nous envoyer de l’argent et nous les en remercions.
 </p>
 
 <h2>Les graphistes</h2>
 <p>
-	Diverses personnes nous ont fourni des logos, bannières et feuilles de style, ponctuant les changements de version du site.
+Diverses personnes nous ont fourni des logos, bannières et feuilles de style,
+ponctuant les changements de version du site.
 </p>
 
 <h2>Les lecteurs</h2>
 <p>
-	Les lecteurs de LinuxFr.org jouent eux aussi un rôle important en proposant des contenus de qualité (dépêches, journaux, etc.) tout au long de l'année.
+Les lectrices et lecteurs de <em>LinuxFr.org</em> jouent eux aussi un rôle important en proposant
+des contenus de qualité (dépêches, journaux, etc.) tout au long de l’année.
 </p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,25 +5,25 @@ Logo.image = '/images/logos/linuxfr2_classic.png'
 
 # Langs
 Lang['fr'] = 'Français'
-Lang['en'] = 'Anglais'
 Lang['de'] = 'Allemand'
-Lang['it'] = 'Italien'
-Lang['es'] = 'Espagnol'
-Lang['fi'] = 'Finnois'
+Lang['en'] = 'Anglais'
 Lang['eu'] = 'Basque'
-Lang['ja'] = 'Japonais'
-Lang['ru'] = 'Russe'
-Lang['pt'] = 'Portugais'
-Lang['nl'] = 'Néerlandais'
-Lang['da'] = 'Danois'
-Lang['el'] = 'Grec'
-Lang['sv'] = 'Suédois'
-Lang['cn'] = 'Chinois'
-Lang['pl'] = 'Polonais'
 Lang['ct'] = 'Catalan'
-Lang['no'] = 'Norvégien'
+Lang['cn'] = 'Chinois'
 Lang['ko'] = 'Coréen'
+Lang['da'] = 'Danois'
+Lang['es'] = 'Espagnol'
 Lang['ee'] = 'Estonien'
+Lang['fi'] = 'Finnois'
+Lang['el'] = 'Grec'
+Lang['it'] = 'Italien'
+Lang['ja'] = 'Japonais'
+Lang['nl'] = 'Néerlandais'
+Lang['no'] = 'Norvégien'
+Lang['pl'] = 'Polonais'
+Lang['pt'] = 'Portugais'
+Lang['ru'] = 'Russe'
+Lang['sv'] = 'Suédois'
 Lang['xx'] = '!? hmmm ?!'
 Lang['wq'] = 'Code/binaire'
 
@@ -33,32 +33,32 @@ Lang['wq'] = 'Code/binaire'
 end
 
 # Responses
-Response.create!(title: "Copie de dépêche externe",    content: "La dépêche que vous avez proposée n'est qu'une copie d'un article\nprovenant d'un autre site (en partie ou en entier).\nNous refusons ce genre d'article, même si la source est citée.")
-Response.create!(title: "Dépêche trop courte",         content: "La dépêche que vous avez proposée a été considérée trop courte pour être\nvalidée sur LinuxFr.org. En effet, nous n'acceptons que des dépêches de\nplusieurs lignes, comme celles qui passent sur le site habituellement.")
-Response.create!(title: "Dépêche déjà publiée",        content: "Le sujet de la dépêche que vous avez proposée a déjà fait l'objet d'une\ndépêche publiée sur LinuxFr.org. Pour cette raison, votre dépêche a été\nrefusée.")
-Response.create!(title: "Dépêche déjà proposée",       content: "Une ou plusieurs autres dépêches sur le même sujet a (ont) déjà été\nproposée(s) par un (ou plusieurs) autre(s) internaute(s). Dès qu'un\nmodérateur pourra s'en occuper, il utilisera celle qui lui semble la\nmieux rédigée.")
-Response.create!(title: "Dépêche hors sujet",          content: "La dépêche que vous avez envoyée est hors-sujet par rapport au site. Si\nLinuxFr.org valide parfois les dépêches hors-sujet, celle-ci n'a pas\nretenu l'attention des modérateurs.")
-Response.create!(title: "Redirection forum",           content: "Une entrée dans un forum serait plus adaptée pour poser cette question.\nNous tenons à vous remercier de l'avoir proposée, et nous\nvous encourageons à la poser dans un des forums du site.\n\nhttps://linuxfr.org/posts/nouveau")
-Response.create!(title: "Redirection journal",         content: "Votre journal est peut-être plus adapté pour passer cette information.\n\nhttps://linuxfr.org//journaux/nouveau")
-Response.create!(title: "Problèmes de rédaction",      content: "Cette dépêche pose des problèmes de rédaction, et il nous est difficile\nde la valider telle quelle. Pourriez-vous re-rédiger cette dépêche s'il\nvous plaît ?")
-Response.create!(title: "Site (presque) vide",         content: "LinuxFr.org préfère valider des dépêches de ce type quand le site est\ndéjà bien avancé. Si d'ici quelques temps, c'est le cas, n'hésitez pas\nà re-proposer une dépêche.")
-Response.create!(title: "Version mineure du logiciel", content: "Votre dépêche traite d'une version mineure d'un logiciel, et n'apporte\nrien de fort d'un point de vue information. Pour cette raison elle a été\nrefusée.")
+Response.create!(title: "Copie de dépêche externe",    content: "La dépêche que vous avez proposée n’est qu’une copie d’un article\nprovenant d’un autre site (en partie ou en entier).\nNous refusons ce genre d’article, même si la source est citée.")
+Response.create!(title: "Dépêche trop courte",         content: "La dépêche que vous avez proposée a été considérée trop courte pour être\nvalidée sur LinuxFr.org. En effet, nous n’acceptons que des dépêches de\nplusieurs lignes, comme celles qui passent sur le site habituellement.")
+Response.create!(title: "Dépêche déjà publiée",        content: "Le sujet de la dépêche que vous avez proposée a déjà fait l’objet d’une\ndépêche publiée sur LinuxFr.org. Pour cette raison, votre dépêche a été\nrefusée.")
+Response.create!(title: "Dépêche déjà proposée",       content: "Une ou plusieurs autres dépêches sur le même sujet a (ont) déjà été\nproposée(s) par un (ou plusieurs) autre(s) internaute(s). Dès qu’un\nmodérateur pourra s’en occuper, il utilisera celle qui lui semble la\nmieux rédigée.")
+Response.create!(title: "Dépêche hors sujet",          content: "La dépêche que vous avez envoyée est hors sujet par rapport au site. Si\nLinuxFr.org valide parfois les dépêches hors sujet, celle‑ci n’a pas\nretenu l’attention des modérateurs.")
+Response.create!(title: "Problèmes de rédaction",      content: "Cette dépêche pose des problèmes de rédaction, et il nous est difficile\nde la valider telle quelle. Pourriez‑vous re‑rédiger cette dépêche s’il\nvous plaît ?")
+Response.create!(title: "Redirection forum",           content: "Une entrée dans un forum serait plus adaptée pour poser cette question.\nNous tenons à vous remercier de l’avoir proposée, et nous\nvous encourageons à la poser dans un des forums du site.\n\nhttps://linuxfr.org/posts/nouveau")
+Response.create!(title: "Redirection journal",         content: "Votre journal est peut‑être plus adapté pour passer cette information.\n\nhttps://linuxfr.org//journaux/nouveau")
+Response.create!(title: "Site (presque) vide",         content: "LinuxFr.org préfère valider des dépêches de ce type quand le site est\ndéjà bien avancé. Si tel est le cas dans quelque temps, n’hésitez pas\nà proposer une nouvelle dépêche.")
+Response.create!(title: "Version mineure du logiciel", content: "Votre dépêche traite d’une version mineure d’un logiciel, et n’apporte\nrien de fort d’un point de vue information. Pour cette raison, elle a été\nrefusée.")
 
 # Friend sites
+FriendSite.create!(title: "Agenda du Libre", url: "https://www.agendadulibre.org/")
 FriendSite.create!(title: "April", url: "https://www.april.org/")
-FriendSite.create!(title: "Agenda du libre", url: "https://www.agendadulibre.org/")
-FriendSite.create!(title: "Framasoft", url: "https://www.framasoft.net/")
-FriendSite.create!(title: "Lolix", url: "http://fr.lolix.org/")
-FriendSite.create!(title: "JeSuisLibre", url: "http://www.jesuislibre.org/")
 FriendSite.create!(title: "Éditions Diamond", url: "https://boutique.ed-diamond.com/")
-FriendSite.create!(title: "Veni, Vedi, Libri", url: "https://vvlibri.org/")
-FriendSite.create!(title: "LinuxGraphic", url: "https://www.linuxgraphic.org/")
 FriendSite.create!(title: "Éditions ENI", url: "https://www.editions-eni.fr/livres/open-source/.12659ab71294b44082200c97a40710bc.html")
-FriendSite.create!(title: "La Quadrature du Net", url: "https://www.laquadrature.net/")
+FriendSite.create!(title: "Éditions Eyrolles", url: "http://www.editions-eyrolles.com/Recherche/?q=linux")
+FriendSite.create!(title: "Framasoft", url: "https://www.framasoft.net/")
 FriendSite.create!(title: "Grafik Plus", url: "https://www.gp3.fr/")
+FriendSite.create!(title: "JeSuisLibre", url: "http://www.jesuislibre.org/")
+FriendSite.create!(title: "La Quadrature du Net", url: "https://www.laquadrature.net/")
 FriendSite.create!(title: "Léa-Linux", url: "http://lea-linux.org/")
+FriendSite.create!(title: "LinuxGraphic", url: "https://www.linuxgraphic.org/")
+FriendSite.create!(title: "Lolix", url: "http://fr.lolix.org/")
+FriendSite.create!(title: "Veni, Vedi, Libri", url: "https://vvlibri.org/")
 FriendSite.create!(title: "TuxFamily", url: "https://tuxfamily.org")
-FriendSite.create!(title: "Eyrolles", url: "http://www.editions-eyrolles.com/Recherche/?q=linux")
 
 # Pages
 dir = File.join(File.dirname(__FILE__), 'pages')
@@ -93,20 +93,18 @@ Le wiki de LinuxFr.org
 
 Fonctionnement
 --------------
-
-Cet espace est un [wiki](https://fr.wikipedia.org/wiki/Wiki), c'est-à-dire un endroit où tous les utilisateurs (du moins, ceux qui sont authentifiés) peuvent écrire.
-Pour créer une page, le plus simple est de faire un lien vers cette page en utilisant la syntaxe `[[[`MaPage`]]]` puis de cliquer sur ce lien.
-Si la page n'existe pas encore, un formulaire vous sera proposée pour la créer.
+Cet espace est un [wiki](https://fr.wikipedia.org/wiki/Wiki), c’est‑à‑dire un endroit où tous les utilisateurs (du moins, ceux qui sont authentifiés) peuvent écrire.
+Pour créer une page, le plus simple est de faire un lien vers cette dernière en utilisant la syntaxe `[[[`MaPage`]]]`, puis de cliquer sur ce lien.
+Si la page n’existe pas encore, un formulaire vous sera proposé pour la créer.
 
 Les pages principales
 ---------------------
+C’est à **vous** de jouer et de créer ces pages. ;-)
+Voici quelques pages qu’il serait intéressant d’avoir :
 
-C'est à **vous** de jouer et de créer ces pages ;-)
-Voici quelques pages qu'il serait intéressant d'avoir :
-
-- [[[FAQ]]] : une foire aux questions pour aider les débutants (et les utilisateurs plus réguliers) à mieux connaître le site
-- [[[PierreTramo]]], [[[42]]], [[[Templeet]]] : le bestiaire de LinuxFr.org
-- [[[Astuces]]] : des astuces sur Linux et les Logiciels Libres.
+- [[[FAQ]]] : une foire aux questions pour aider les débutants (et les utilisateurs plus réguliers) à mieux connaître le site ;
+- [[[PierreTramo]]], [[[42]]], [[[Templeet]]] : le bestiaire de _LinuxFr.org_ ;
+- [[[Astuces]]] : des astuces sur GNU/Linux et les logiciels libres.
 EOS
 wp.save!
 wp.reload

--- a/public/errors/400.html
+++ b/public/errors/400.html
@@ -15,13 +15,13 @@
 			<li><a href="/news" title="Actualités, événements et autres nouveautés">Dépêches</a></li>
 			<li><a href="/journaux" title="Journaux personnels de nos visiteurs">Journaux</a></li>
       <li><a title="Liens remarquables" href="/liens">Liens</a></li>
-			<li><a href="/forums" title="Questions/réponses, petites annonces">Forums</a></li>
+			<li><a href="/forums" title="Questions‑réponses, petites annonces">Forums</a></li>
 			<li><a href="/wiki" title="Pages wiki">Wiki</a></li>
       <li><a title="Participez à la rédaction des dépêches" href="/redaction">Rédaction</a></li>
 		</ul>
 		<form accept-charset="UTF-8" action="/recherche" method="get">
-			<label for="query" id="label_query">Recherche :</label>
-			<input id="query" name="q" type="search" placeholder="Entrer un mot-clé" />
+			<label for="query" id="label_query">Recherche :</label>
+			<input id="query" name="q" type="search" placeholder="Entrer un mot‑clef" />
 			<input id="search_submit" title="Rechercher" type="submit" value="Rechercher" />
 		</form>
 	</nav>
@@ -35,7 +35,7 @@
 	<section id="container">
 		<h1>Erreur 404</h1>
 		<p>
-			Oups, la page demandée n'existe pas&nbsp;: page supprimée&nbsp;? lien cassé&nbsp;? URL incorrecte&nbsp;?
+			Oups, la page demandée n’existe pas : page supprimée ? lien cassé ? URL incorrecte ?
 		</p>
 		<iframe src="//notfound-static.fwebservices.be/404/index.html?lang=fr&amp;key=290b284d9e401b0a1b25ddb281cf5bf0" width="100%" height="650" frameborder="0"></iframe>
 	</section>

--- a/public/errors/403.html
+++ b/public/errors/403.html
@@ -1,43 +1,38 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+  <head>
 	<meta charset="utf-8">
 	<title>LinuxFr.org &gt;&gt; Erreur 403</title>
 	<link href="/assets/application.css" media="screen, projection" rel="stylesheet" type="text/css" />
 	<link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-</head>
-
-<body id="error400">
-	<div id="top"></div>
-	<nav id="site">
-		<div class="go_to_content"><a href="#container">Aller au contenu</a></div>
-		<ul>
-			<li><a href="/news" title="Actualités, événements et autres nouveautés">Dépêches</a></li>
-			<li><a href="/journaux" title="Journaux personnels de nos visiteurs">Journaux</a></li>
-      <li><a title="Liens remarquables" href="/liens">Liens</a></li>
-			<li><a href="/forums" title="Questions/réponses, petites annonces">Forums</a></li>
-			<li><a href="/wiki" title="Pages wiki">Wiki</a></li>
-      <li><a title="Participez à la rédaction des dépêches" href="/redaction">Rédaction</a></li>
-		</ul>
-		<form accept-charset="UTF-8" action="/recherche" method="get">
-			<label for="query" id="label_query">Recherche :</label>
-			<input id="query" name="q" type="search" placeholder="Entrer un mot-clé" />
-			<input id="search_submit" title="Rechercher" type="submit" value="Rechercher" />
-		</form>
-	</nav>
-
-	<aside id="sidebar">
-		<header id="branding">
-			<h1 style="background-image: url('/images/logos/logo-linuxfr-cadre-ombre.png');" title="Le logo de LinuxFr.org"><a href="/">LinuxFr.org</a></h1>
-		</header>
-	</aside>
-
-	<section id="container">
-		<h1>Erreur 403</h1>
-		<p>
-			Accès interdit à cette page !
-		</p>
-		<img src="/images/403.png" alt="" />
-	</section>
-</body>
+  </head>
+  <body id="error400">
+    <div id="top"></div>
+    <nav id="site">
+      <div class="go_to_content"><a href="#container">Aller au contenu</a></div>
+      <ul>
+        <li><a href="/news" title="Actualités, événements et autres nouveautés">Dépêches</a></li>
+        <li><a href="/journaux" title="Journaux personnels de nos visiteurs">Journaux</a></li>
+        <li><a title="Liens remarquables" href="/liens">Liens</a></li>
+        <li><a href="/forums" title="Questions‑réponses, petites annonces">Forums</a></li>
+        <li><a href="/wiki" title="Pages wiki">Wiki</a></li>
+        <li><a title="Participez à la rédaction des dépêches" href="/redaction">Rédaction</a></li>
+      </ul>
+      <form accept-charset="UTF-8" action="/recherche" method="get">
+        <label for="query" id="label_query">Recherche :</label>
+        <input id="query" name="q" type="search" placeholder="Entrer un mot‑clef" />
+        <input id="search_submit" title="Rechercher" type="submit" value="Rechercher" />
+      </form>
+    </nav>
+    <aside id="sidebar">
+      <header id="branding">
+        <h1 style="background-image: url('/images/logos/logo-linuxfr-cadre-ombre.png');" title="Le logo de LinuxFr.org"><a href="/">LinuxFr.org</a></h1>
+      </header>
+    </aside>
+    <section id="container">
+      <h1>Erreur 403</h1>
+      <p>Accès interdit à cette page !</p>
+      <img src="/images/403.png" alt="" />
+    </section>
+  </body>
 </html>

--- a/public/errors/500.html
+++ b/public/errors/500.html
@@ -15,13 +15,13 @@
 			<li><a href="/news" title="Actualités, événements et autres nouveautés">Dépêches</a></li>
 			<li><a href="/journaux" title="Journaux personnels de nos visiteurs">Journaux</a></li>
       <li><a title="Liens remarquables" href="/liens">Liens</a></li>
-			<li><a href="/forums" title="Questions/réponses, petites annonces">Forums</a></li>
+			<li><a href="/forums" title="Questions‑réponses, petites annonces">Forums</a></li>
 			<li><a href="/wiki" title="Pages wiki">Wiki</a></li>
       <li><a title="Participez à la rédaction des dépêches" href="/redaction">Rédaction</a></li>
 		</ul>
 		<form accept-charset="UTF-8" action="/recherche" method="get">
-			<label for="query" id="label_query">Recherche :</label>
-			<input id="query" name="q" type="search" placeholder="Entrer un mot-clé" />
+			<label for="query" id="label_query">Recherche :</label>
+			<input id="query" name="q" type="search" placeholder="Entrer un mot‑clé" />
 			<input id="search_submit" title="Rechercher" type="submit" value="Rechercher" />
 		</form>
 	</nav>
@@ -35,10 +35,10 @@
 	<section id="container">
 		<h1>Erreur 500</h1>
 		<p>
-			Oops, la page demandée ne peut être servie car une erreur s'est produite.
-			L'erreur va être enregistrée, permettant à l'équipe en charge du site de la corriger.
+			Oups, la page demandée ne peut être servie car une erreur s’est produite.
+			L’erreur va être enregistrée, permettant à l’équipe en charge du site de la corriger.
 			Vous pouvez créer <a href="/suivi/nouveau">une entrée dans le suivi</a> pour donner
-			des informations sur la manière dont cette erreur s'est produite et être averti de sa résolution.
+			des informations sur la manière dont cette erreur s’est produite et être averti de sa résolution.
 		</p>
 	</section>
 </body>


### PR DESCRIPTION
Based on PR https://github.com/linuxfrorg/linuxfr.org/pull/262 from DevDef (due to timeout on GitHub interface, review was not possible, so I created a new branch and PR, the main change is the removal of "use non-breaking spaces to avoid orphan words" to let CSS and browsers do their job):

-    use true apostophes and true hyphens
-    use non-breaking spaces and thin spaces according to French orthotypographic rules
-    replace HTML entities by Unicode characters
-    fix some typos
-    use better French words (e.g. étiquette instead of tag)
-    some rewording
-    try to be more gender-neutral (e.g. “Êtes-vous sur(e)” → “Confirmez-vous“, utilisateurs et utilisatrices)
