### PR TITLE
footer: hide comments of invisible content

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,7 +31,7 @@ class Comment < ActiveRecord::Base
   scope :under,        ->(path) { where("materialized_path LIKE ?", "#{path}_%") }
   scope :published,    -> { where(state: 'published') }
   scope :on_dashboard, -> { published.order(created_at: :desc) }
-  scope :footer,       -> { published.order(created_at: :desc).limit(12).select([:id, :node_id, :title]) }
+  scope :footer,       -> { published.joins(:node).merge(Node.visible).order(created_at: :desc).limit(12).select([:id, :node_id, :title]) }
 
   validates :title,     presence: { message: "Le titre est obligatoire" },
                         length: { maximum: 100, message: "Le titre est trop long" }


### PR DESCRIPTION
As the list of last comments in footer contains link to the content with anchor to comment,
the server will responses with 'forbidden access' (due to the content invisible state).

Note: it add a SQL join between Comment and Node which could impact performances

See [this suivi request](https://linuxfr.org/suivi/enlever-les-contenus-marques-comme-spam-dans-la-liste-derniers-commentaires)