### PR TITLE
comments: wikify_body set nofollow if user account has been closed

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -39,7 +39,7 @@ class Comment < ActiveRecord::Base
 
   wikify_attr :body
   def wikify_body
-    nofollow = user.account.karma < 50
+    nofollow = user.account.blank? || user.account.karma < 50
     self.body = wikify(wiki_body, nofollow: nofollow)
   end
 


### PR DESCRIPTION
See the [suivi request](https://linuxfr.org/suivi/commentaire-d-un-compte-supprime-non-editable-par-un-admin#comment-1815141).