### PR TITLE
db/seeds: add default LinuxFr.org Section to be able to create News

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -87,6 +87,9 @@ anon.save!
 # Collective user
 User.create! name: "Collectif"
 
+# Default section is defined by it's title (required to be able to create news)
+Section.create! title: "LinuxFr.org"
+
 # Wiki
 wp = WikiPage.new
 wp.title = WikiPage::HomePage


### PR DESCRIPTION
As the `LinuxFr.org` section is the default section to create collaborative news, it is almost required to exists in the database.

So, I want to propose to set it up on new environment deployment with the database seed.