### PR TITLE
db/seeds: add default admin account

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,6 +84,19 @@ anon.encrypted_password = "XXX"
 anon.skip_confirmation!
 anon.save!
 
+# Admin account
+admin = Account.new
+admin.login = "admin"
+admin.role = "admin"
+admin.email = "admin@dlfp.lo"
+admin.skip_confirmation!
+admin.save!
+
+# Reset automatically generated password
+admin.password = "admin"
+admin.password_confirmation = "admin"
+admin.save!
+
 # Collective user
 User.create! name: "Collectif"
 


### PR DESCRIPTION
This PR create on every new deployment a default admin account with the admin password.

That allows new developers to easily do first modifications on the code without the need to directly run some SQL magic script.