### PR TITLE
redaction: split draft list according to update activity

### DIFF
--- a/app/assets/stylesheets/parts/redaction.scss
+++ b/app/assets/stylesheets/parts/redaction.scss
@@ -329,7 +329,8 @@ body#redaction-index {
     margin: 5px 0 15px 0;
   }
   #news,
-  #candidate_news {
+  #candidate_news,
+  #inactive_news {
     display: flex;
     flex-wrap: wrap;
   }

--- a/app/controllers/redaction_controller.rb
+++ b/app/controllers/redaction_controller.rb
@@ -3,8 +3,10 @@ class RedactionController < ApplicationController
   append_view_path NoNamespaceResolver.new
 
   def index
+    activity_threshold = Date.today - 3.month
     @boards = Board.limit(25, Board.writing)
-    @drafts = News.draft.sorted
+    @drafts = News.draft.where("updated_at >= ?", activity_threshold).sorted
+    @inactive_drafts = News.draft.where("updated_at < ?", activity_threshold).sorted
     @news   = News.candidate.sorted
     @stats  = Statistics::Redaction.new
   end

--- a/app/views/redaction/_drafts.html.haml
+++ b/app/views/redaction/_drafts.html.haml
@@ -1,0 +1,14 @@
+- drafts.each do |n|
+  - activity=(n.node.board_status(current_account) == :new_board)
+  .news{:class => ("activity" if activity)}
+    .pen
+      = link_to [:redaction, n] do
+        %img{src: "/images/icones/pen.svg", alt: "Éditer la dépêche"}
+    .meta
+      - if activity
+        = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l’activité sur cette dépêche", width: "16px"
+      = n.user.try(:name) || n.author_name
+      - if n.nb_editors > 0
+        = "& #{pluralize n.nb_editors, "participant"}"
+    %h3= link_to n.title, [:redaction, n]
+    Modifiée le #{n.updated_at.to_s :date} à #{n.updated_at.to_s :time}

--- a/app/views/redaction/index.html.haml
+++ b/app/views/redaction/index.html.haml
@@ -25,27 +25,20 @@
     - else
       = link_to "Connaissez‑vous le moteur de recherche de photos sous licence Creative Commons ?", "https://ccsearch.creativecommons.org/?search=tux&licenses=ALL-%24&licenses=ALL-MOD&search_fields=title&search_fields=creator&search_fields=tags&per_page=20&work_types=photos&providers=500px&providers=flickr"
 
-  %h2 #{pluralize @drafts.count, "dépêche"} en cours de rédaction
+  %h2 #{pluralize @drafts.count + @inactive_drafts.count, "dépêche"} en cours de rédaction
   - feed "Flux atom des dépêches en cours de rédaction", "/redaction/news.atom"
   = button_to "Commencer une nouvelle dépêche", "/redaction/news", class: "create_news"
-  - if @drafts.empty?
+  - if @drafts.empty? and @inactive_drafts.empty?
     %p Aucune dépêche.
   - else
-    #news
-      - @drafts.each do |n|
-        - activity=(n.node.board_status(current_account) == :new_board)
-        .news{:class => ("activity" if activity)}
-          .pen
-            = link_to [:redaction, n] do
-              %img{src: "/images/icones/pen.svg", alt: "Éditer la dépêche"}
-          .meta
-            - if activity
-              = image_tag "/images/icones/chat.svg", alt: "Nouveaux !", title: "Il y a de l’activité sur cette dépêche", width: "16px"
-            = n.user.try(:name) || n.author_name
-            - if n.nb_editors > 0
-              = "& #{pluralize n.nb_editors, "participant"}"
-          %h3= link_to n.title, [:redaction, n]
-          Modifiée le #{n.updated_at.to_s :date} à #{n.updated_at.to_s :time}
+    - if @drafts.any?
+      #news
+        = render 'drafts', drafts: @drafts
+    - if @inactive_drafts.any?
+      %details
+        %summary #{pluralize @inactive_drafts.count, "dépêche"} sans activité récente
+        #inactive_news
+          = render 'drafts', drafts: @inactive_drafts
 
   %h2 #{pluralize @news.count, "dépêche"} en cours de modération
   - feed "Flux Atom des dépêches en cours de modération", "/redaction/news/moderation.atom"

--- a/app/views/redaction/index.html.haml
+++ b/app/views/redaction/index.html.haml
@@ -53,8 +53,10 @@
   %h2 #{pluralize @news.count, "dépêche"} en cours de modération
   - feed "Flux Atom des dépêches en cours de modération", "/redaction/news/moderation.atom"
   .notice
-    L’accès à l’espace de modération est réservé aux modérateurs et aux administrateurs.
-    Seuls les titres des dépêches en modération sont visibles des autres utilisateurs authentifiés.
+    %p
+      L’accès à l’espace de modération est réservé aux modérateurs et aux administrateurs.
+      %br
+      Seuls les titres des dépêches en modération sont visibles des autres.
   - if @news.empty?
     Aucune dépêche.
   - else

--- a/app/views/redaction/index.html.haml
+++ b/app/views/redaction/index.html.haml
@@ -36,7 +36,17 @@
         = render 'drafts', drafts: @drafts
     - if @inactive_drafts.any?
       %details
-        %summary #{pluralize @inactive_drafts.count, "dépêche"} sans activité récente
+        %summary #{pluralize @inactive_drafts.count, "dépêche"} à adopter
+        .notice
+          %p
+            Les dépêches suivantes n’ont plus d’activités depuis plus de 3 mois
+            et peuvent être adoptées pour être finalisées et publiées par
+            d’autres rédacteurs.
+        %p
+          Pour adopter une dépêche, vous pouvez demander dans la tribune de
+          rédaction de devenir l’auteur de la dépêche. Ainsi, l’équipe de
+          modération vous donnera le rôle d’auteur de la dépêche et vous
+          pourrez terminer le processus de publication.
         #inactive_news
           = render 'drafts', drafts: @inactive_drafts
 


### PR DESCRIPTION
See corresponding [suivi request](https://linuxfr.org/suivi/reduire-la-liste-de-depeche-en-cours-de-redactions).