### PR TITLE
tags: on destroy, destroy taggings too to update the counter_cache

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -32,7 +32,7 @@ class TagsController < ApplicationController
 
   def destroy
     @tag = Tag.where(name: params[:id]).first
-    @node.taggings.where(tag_id: @tag.id, user_id: current_account.user_id).delete_all if @tag
+    @node.taggings.where(tag_id: @tag.id, user_id: current_account.user_id).destroy_all if @tag
     respond_to do |wants|
      wants.json { render json: { notice: "Étiquette enlevée" } }
      wants.html { redirect_to_content @node.content }


### PR DESCRIPTION
As requested on the [suivi](https://linuxfr.org/suivi/decrementer-le-taggings_count-en-cas-de-suppression-d-etiquette):

The counter_cache option works with call backs on records.
The use of `#destroy` methods instead of `#delete` allows rails to run
call backs before deletion and thus it allows the counter_cache to update the tag.taggings_count counter.

See: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_all