### PR TITLE
tracker: assigned_to_user_id has to contain the user.id and not the account.id

### DIFF
--- a/app/views/trackers/_form.html.haml
+++ b/app/views/trackers/_form.html.haml
@@ -19,7 +19,7 @@
     = form.select :state, Tracker::States.invert
   %p
     = form.label :assigned_to_user_id, "Assigné à"
-    = form.collection_select :assigned_to_user_id, Account.admin, :id, :login, include_blank: true
+    = form.collection_select :assigned_to_user_id, Account.admin, :user_id, :login, include_blank: true
 %p
   = form.submit "Prévisualiser", id: "tracker_preview"
   = form.submit "Soumettre", 'data-disable-with' => "Enregistrement en cours" if @preview_mode || @tracker.persisted?

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -22,7 +22,7 @@
     = f.collection_select :category_id, Category.all, :id, :title, include_blank: true
   %p
     = f.label :assigned_to_user_id, "Assigné à : "
-    = f.collection_select :assigned_to_user_id, Account.admin, :id, :name, include_blank: true
+    = f.collection_select :assigned_to_user_id, Account.admin, :user_id, :name, include_blank: true
   %p
     = label_tag :order, "Trier par : "
     = select_tag :order, options_for_select({ "Date d’ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)

--- a/db/migrate/20210131231806_fix_assigned_user_id_from_tracker.rb
+++ b/db/migrate/20210131231806_fix_assigned_user_id_from_tracker.rb
@@ -1,0 +1,17 @@
+class FixAssignedUserIdFromTracker < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+    UPDATE trackers
+    SET assigned_to_user_id = (SELECT user_id FROM accounts WHERE accounts.id = trackers.assigned_to_user_id)
+    WHERE assigned_to_user_id is NOT NULL;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+    UPDATE trackers
+    SET assigned_to_user_id = (SELECT id FROM accounts WHERE accounts.user_id = trackers.assigned_to_user_id)
+    WHERE assigned_to_user_id is NOT NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_18_110400) do
+ActiveRecord::Schema.define(version: 2021_01_31_231806) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
On my development environment, my account ids does not match with the user ids.

Fortunately, this permits me to see an error in the tracker system where we store the `accounts.id` in the `trackers.assigned_to_user_id` column.

This PR is updating values for the HTML forms and migrates data to use the correct values.