### PR TITLE
Create a maintainer role to manage trackers

### DIFF
--- a/app/controllers/admin/maintainers_controller.rb
+++ b/app/controllers/admin/maintainers_controller.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+class Admin::MaintainersController < AdminController
+  before_action :load_account
+
+  def create
+    @account.give_maintainer_rights!
+    Board.amr_notification("Le compte #{@account.login} #{user_url @account.login} a reçu le rôle mainteneur par #{current_user.name} #{user_url(current_user)}")
+    redirect_to @account.user, notice: "Nouveau rôle : mainteneur"
+  end
+
+  def destroy
+    @account.remove_all_rights!
+    Board.amr_notification("Le compte #{@account.login} #{user_url @account.login} a perdu le rôle mainteneur par #{current_user.name} #{user_url(current_user)}")
+    redirect_to @account.user, notice: "Rôle retiré : mainteneur"
+  end
+
+protected
+
+  def load_account
+    @account = Account.find(params[:account_id])
+  end
+
+end

--- a/app/controllers/trackers_controller.rb
+++ b/app/controllers/trackers_controller.rb
@@ -88,7 +88,7 @@ class TrackersController < ApplicationController
 protected
 
   def tracker_params
-    if current_account.try(:admin?)
+    if current_account.try(:admin?) or current_account.try(:maintainer?)
       params.require(:tracker).permit!
     else
       params.require(:tracker).permit(:title, :wiki_body, :category_id, :state)

--- a/app/controllers/trackers_controller.rb
+++ b/app/controllers/trackers_controller.rb
@@ -88,7 +88,7 @@ class TrackersController < ApplicationController
 protected
 
   def tracker_params
-    if current_account.try(:admin?) or current_account.try(:maintainer?)
+    if current_account.try(:tracker_admin?)
       params.require(:tracker).permit!
     else
       params.require(:tracker).permit(:title, :wiki_body, :category_id, :state)

--- a/app/helpers/static_helper.rb
+++ b/app/helpers/static_helper.rb
@@ -26,6 +26,10 @@ module StaticHelper
     people_list Account.moderator
   end
 
+  def helper_maintainer_list
+    people_list Account.maintainer
+  end
+
   def helper_friend_sites_list
     sites = FriendSite.all.map { |s| content_tag(:li, link_to(s.title, s.url)) }
     content_tag(:ul, safe_join(sites), class: "people-list")

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -128,7 +128,8 @@ class Account < ActiveRecord::Base
 ### Role ###
 
   scope :active,    -> { where("role != 'inactive'") }
-  scope :maintainer, -> { where(role: %w[admin maintainer]) }
+  scope :maintainer, -> { where(role: "maintainer") }
+  scope :tracker_admin, -> { where(role: %w[admin maintainer]) }
   scope :moderator, -> { where(role: "moderator") }
   scope :editor,    -> { where(role: "editor") }
   scope :admin,     -> { where(role: "admin") }
@@ -160,6 +161,11 @@ class Account < ActiveRecord::Base
     roles = previous_changes["role"]
     return if roles.nil?
     logs.create(description: "Changement de rôle : #{roles.join ' → '}", user_id: amr_id)
+  end
+
+  # A tracker admin can update, assign and delete a node of the tracker
+  def tracker_admin?
+    admin? || maintainer?
   end
 
   # An AMR is someone who is either an admin or a moderator

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -39,6 +39,7 @@
 # There are several levels of users:
 #   * anonymous     -> they have no account and can only read public contents
 #   * authenticated -> they can read public contents and submit new ones
+#   * maintainer    -> they can manage the tracker system
 #   * moderator     -> they make the order and the security ruling
 #   * editor        -> they edit the news in the redaction space
 #   * admin         -> the almighty users
@@ -127,6 +128,7 @@ class Account < ActiveRecord::Base
 ### Role ###
 
   scope :active,    -> { where("role != 'inactive'") }
+  scope :maintainer, -> { where(role: %w[admin maintainer]) }
   scope :moderator, -> { where(role: "moderator") }
   scope :editor,    -> { where(role: "editor") }
   scope :admin,     -> { where(role: "admin") }
@@ -136,6 +138,7 @@ class Account < ActiveRecord::Base
     event :inactivate            do transition all             => :inactive  end
     event :reactivate            do transition :inactive       => :visitor   end
     event :remove_all_rights     do transition all - :inactive => :visitor   end
+    event :give_maintainer_rights do transition all - :inactive => :maintainer end
     event :give_moderator_rights do transition all - :inactive => :moderator end
     event :give_editor_rights    do transition all - :inactive => :editor    end
     event :give_admin_rights     do transition all - :inactive => :admin     end
@@ -145,6 +148,7 @@ class Account < ActiveRecord::Base
   def display_role(hasContents)
     case role
     when 'visitor' then hasContents ? 'contributeur' : 'visiteur'
+    when 'maintainer' then 'mainteneur'
     when 'editor' then 'animateur'
     when 'moderator' then 'modérateur'
     when 'admin' then 'admin'

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -75,11 +75,11 @@ class Tracker < Content
 ### ACL ###
 
   def updatable_by?(account)
-    account.moderator? || account.admin? || account.user_id == node.user_id
+    account.maintainer? || account.moderator? || account.admin? || account.user_id == node.user_id
   end
 
   def destroyable_by?(account)
-    account.moderator? || account.admin?
+    account.maintainer? || account.moderator? || account.admin?
   end
 
   def too_old_for_comments?

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -77,6 +77,7 @@
         - elsif account.admin?
           = button_to "Simple visiteur", admin_account_admin_path(account.id), method: :delete, class: "change_role"
         - elsif !account.inactive?
+          = button_to "Mainteneur", admin_account_maintainer_path(account.id), class: "change_role"
           = button_to "Modérateur", admin_account_moderator_path(account.id), class: "change_role"
           = button_to "Animateur", admin_account_editor_path(account.id), class: "change_role"
           = button_to "Admin", admin_account_admin_path(account.id), class: "change_role"

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -72,6 +72,8 @@
       %td
         - if account.editor?
           = button_to "Simple visiteur", admin_account_editor_path(account.id), method: :delete, class: "change_role"
+        - if account.maintainer?
+          = button_to "Simple visiteur", admin_account_maintainer_path(account.id), method: :delete, class: "change_role"
         - elsif account.moderator?
           = button_to "Simple visiteur", admin_account_moderator_path(account.id), method: :delete, class: "change_role"
         - elsif account.admin?

--- a/app/views/statistics/tracker.html.haml
+++ b/app/views/statistics/tracker.html.haml
@@ -36,7 +36,7 @@
 
     - if @stats.good_workers.any?
       - maxval = @stats.good_workers.map {|a| a["cnt"] }.max
-      %h2#nbfermees Nombre d’entrées fermées par les administrateurs
+      %h2#nbfermees Nombre d’entrées fermées par les mainteneurs et administrateurs
       %table
         %tr
           %th Personne

--- a/app/views/trackers/_form.html.haml
+++ b/app/views/trackers/_form.html.haml
@@ -19,7 +19,7 @@
     = form.select :state, Tracker::States.invert
   %p
     = form.label :assigned_to_user_id, "Assigné à"
-    = form.collection_select :assigned_to_user_id, Account.admin, :id, :login, include_blank: true
+    = form.collection_select :assigned_to_user_id, Account.admin, :user_id, :login, include_blank: true
 %p
   = form.submit "Prévisualiser", id: "tracker_preview"
   = form.submit "Soumettre", 'data-disable-with' => "Enregistrement en cours" if @preview_mode || @tracker.persisted?

--- a/app/views/trackers/_form.html.haml
+++ b/app/views/trackers/_form.html.haml
@@ -17,10 +17,10 @@
   %p
     = form.label :state, "État"
     = form.select :state, Tracker::States.invert
-  - if current_account.admin? or current_account.maintainer?
+  - if current_account.tracker_admin?
     %p
       = form.label :assigned_to_user_id, "Assigné à"
-      = form.collection_select :assigned_to_user_id, Account.maintainer, :user_id, :login, include_blank: true
+      = form.collection_select :assigned_to_user_id, Account.tracker_admin, :user_id, :login, include_blank: true
 %p
   = form.submit "Prévisualiser", id: "tracker_preview"
   = form.submit "Soumettre", 'data-disable-with' => "Enregistrement en cours" if @preview_mode || @tracker.persisted?

--- a/app/views/trackers/_form.html.haml
+++ b/app/views/trackers/_form.html.haml
@@ -17,9 +17,10 @@
   %p
     = form.label :state, "État"
     = form.select :state, Tracker::States.invert
-  %p
-    = form.label :assigned_to_user_id, "Assigné à"
-    = form.collection_select :assigned_to_user_id, Account.admin, :user_id, :login, include_blank: true
+  - if current_account.admin? or current_account.maintainer?
+    %p
+      = form.label :assigned_to_user_id, "Assigné à"
+      = form.collection_select :assigned_to_user_id, Account.maintainer, :user_id, :login, include_blank: true
 %p
   = form.submit "Prévisualiser", id: "tracker_preview"
   = form.submit "Soumettre", 'data-disable-with' => "Enregistrement en cours" if @preview_mode || @tracker.persisted?

--- a/app/views/trackers/_tracker.html.haml
+++ b/app/views/trackers/_tracker.html.haml
@@ -4,5 +4,7 @@
     %span.tracker_id ##{tracker.id}
     = posted_by(tracker)
     État de l’entrée : #{tracker.state_name}.
+    - if tracker.assigned_to_user_id?
+      Assigné à #{tracker.assigned_to}.
   - if current_account && current_account.can_update?(tracker)
     - c.actions = link_to("Modifier", "/suivi/#{tracker.to_param}/modifier", class: 'action')

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -22,7 +22,7 @@
     = f.collection_select :category_id, Category.all, :id, :title, include_blank: true
   %p
     = f.label :assigned_to_user_id, "Assigné à : "
-    = f.collection_select :assigned_to_user_id, Account.maintainer, :user_id, :name, include_blank: true
+    = f.collection_select :assigned_to_user_id, Account.tracker_admin, :user_id, :name, include_blank: true
   %p
     = label_tag :order, "Trier par : "
     = select_tag :order, options_for_select({ "Date d’ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -22,7 +22,7 @@
     = f.collection_select :category_id, Category.all, :id, :title, include_blank: true
   %p
     = f.label :assigned_to_user_id, "Assigné à : "
-    = f.collection_select :assigned_to_user_id, Account.admin, :user_id, :name, include_blank: true
+    = f.collection_select :assigned_to_user_id, Account.maintainer, :user_id, :name, include_blank: true
   %p
     = label_tag :order, "Trier par : "
     = select_tag :order, options_for_select({ "Date d’ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -22,7 +22,7 @@
     = f.collection_select :category_id, Category.all, :id, :title, include_blank: true
   %p
     = f.label :assigned_to_user_id, "Assigné à : "
-    = f.collection_select :assigned_to_user_id, Account.admin, :id, :name, include_blank: true
+    = f.collection_select :assigned_to_user_id, Account.admin, :user_id, :name, include_blank: true
   %p
     = label_tag :order, "Trier par : "
     = select_tag :order, options_for_select({ "Date d’ouverture" => "created_at", "Note" => "score", "Nombre de commentaires" => "comments_count", "Dernier commentaire" => "last_commented_at" }, @order)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Rails.application.routes.draw do
   get "/admin/debug" => "admin#debug"
   namespace :admin do
     resources :comptes, controller: "accounts", as: "accounts", only: [:index, :update, :destroy] do
+      resource :maintainer, only: [:create, :destroy]
       resource :moderator, only: [:create, :destroy]
       resource :editor, only: [:create, :destroy]
       resource :admin, only: [:create, :destroy]

--- a/db/migrate/20210131231806_fix_assigned_user_id_from_tracker.rb
+++ b/db/migrate/20210131231806_fix_assigned_user_id_from_tracker.rb
@@ -1,0 +1,17 @@
+class FixAssignedUserIdFromTracker < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+    UPDATE trackers
+    SET assigned_to_user_id = (SELECT user_id FROM accounts WHERE accounts.id = trackers.assigned_to_user_id)
+    WHERE assigned_to_user_id is NOT NULL;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+    UPDATE trackers
+    SET assigned_to_user_id = (SELECT id FROM accounts WHERE accounts.user_id = trackers.assigned_to_user_id)
+    WHERE assigned_to_user_id is NOT NULL;
+    SQL
+  end
+end

--- a/db/pages/aide.html
+++ b/db/pages/aide.html
@@ -114,6 +114,11 @@ il suffit de se <a href="/compte/inscription">créer un compte</a> sur le site e
 
 <p>Le modérateur est par ailleurs abonné à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/meta"><em>meta@</em></a> de coordination des équipes du site ainsi qu’à la liste de discussion <a href="https://lists.linuxfr.org/wws/arc/moderateurs"><em>moderateurs@</em></a>.</p>
 
+<p>Par rapport à un visiteur, un mainteneur (rôle <i>mainteneur</i>) peut :</p>
+<ul>
+<li>gérer les bogues et propositions d’évolution signalés dans le <a href="//linuxfr.org/suivi">système de suivi</a> (édition, assignation à un mainteneur et suppression) ;</li>
+</ul>
+
 <p>Un admin (rôle <i>admin</i>) cumule toutes les possibilités précédentes, et peut en plus :</p>
 <ul>
 <li>créditer le karma d’un compte de 50 points ;</li>
@@ -310,6 +315,7 @@ Seuls les administrateurs peuvent réaliser cette opération, définitive par na
 <li>compte fermé (<i>inactive</i>) : les comptes fermés ;</li>
 <li>modérateur (<i>moderator</i>) : les <a href="/team">modérateurs</a> ;</li>
 <li>animateur (<i>editor</i>) : les <a href="/team">animateurs de l’espace de rédaction</a> ;</li>
+<li>mainteneur (<i>maintainer</i>) : les <a href="/team">mainteneurs du site</a> ;</li>
 <li>visiteur ou contributeur (<i>visitor</i>) : les visiteurs, tous ceux qui ne sont pas dans une catégorie précédente, suivant s’ils ont déjà écrits des contenus ou non.</li>
 </ul>
 

--- a/db/pages/team.html
+++ b/db/pages/team.html
@@ -25,6 +25,16 @@ Ils sont notamment abonnés à la liste de diffusion &lt;redacteurs_@_linuxfr.or
 </p>
 {{editor_list}}
 
+<h2>Les mainteneurs du site</h2>
+<p>
+Ils s'occupent de maintenir et faire évoluer le code du site <em>LinuxFr.org</em>.
+Ils gèrent les bogues et propositions d'évolution signalés dans le 
+<a href="//linuxfr.org/suivi">système de suivi</a> (édition, assignation à un mainteneur et suppression).
+<p>
+  Les mainteneuses et mainteneurs actuels sont:
+</p>
+{{maintainer_list}}
+
 <h2>Les administrateurs</h2>
 <p>
 Les serveurs de <em>LinuxFr.org</em> sont administrés par une équipe très compétente (si si, je vous assure).

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_18_110400) do
+ActiveRecord::Schema.define(version: 2021_01_31_231806) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
Be careful, this PR contains the fix proposed by the PR #292

The idea is to add a maintainer role which corresponds to an active account with rights to manage the trackers.

As I was updating the tracker system, I took the opportunity to:

* display on the tracker node detail the `Assigné à xxx.` text in the metadata after the state of the item
* hide the "Assigné à"  input in the edit form if the current_user can't update this value