### PR TITLE
Docker setup fixes

### DIFF
--- a/deployment/linuxfr-board/Dockerfile
+++ b/deployment/linuxfr-board/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM ruby:2-slim-buster
 
 LABEL maintainer="adrien@adorsaz.ch"
 LABEL version="1.0"

--- a/deployment/nginx/templates/dlfp.conf.template
+++ b/deployment/nginx/templates/dlfp.conf.template
@@ -5,7 +5,9 @@ server {
   server_name ${DOMAIN};
 
   location /fonts {
-    alias /var/linuxfr/fonts;
+    access_log  off;
+    expires     7d;
+    root /var/linuxfr/;
   }
  
   location ~ ^/(avatars|medias)/ { 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     image: mariadb:10.1
     env_file:
       - deployment/default.env
-    restart: always
+    restart: unless-stopped
     volumes:
       - data-database:/var/lib/mysql
 
@@ -69,14 +69,14 @@ services:
       - deployment/default.env
     entrypoint: ["/linuxfr-entrypoint.sh"]
     command: ["mysqld"]
-    restart: always
+    restart: unless-stopped
     volumes:
       - data-database-test:/var/lib/mysql
       - ./deployment/database-test/entrypoint.sh:/linuxfr-entrypoint.sh
 
   redis:
     image: redis:5
-    restart: always
+    restart: unless-stopped
     volumes:
       - data-redis:/data
 


### PR DESCRIPTION
The always option caused the database and redis containers to start even if the
developper was not working on the code. To avoid to consume computer resources
uselessly, we ask to not restart if container was stopped.