### PR TITLE
application_helper: if content has been recently published, set the robot index/follow threshold a bit higher than 0

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,12 @@ module ApplicationHelper
     @keywords    = content.node.popular_tags.map &:name
     @description = content.title
     @dont_index  = true if content.node.score < 0
+    published_at = content.node.try(:created_at) || DateTime.now()
+    # For all content recently published, ask robots to not index it if
+    # a minimum score is not reached during the first 24 hours.
+    # The threshold is set to the one used by moderated News, so the moderated
+    # content can still be fastly indexed by robots.
+    @dont_index ||= true if published_at > DateTime.now() - 24.hour && content.node.score <= News.accept_threshold
   end
 
 end


### PR DESCRIPTION
As proposed in this [suivi request](https://linuxfr.org/suivi/indexation-differee-des-contenus-non-moderes-a-priori)