### PR TITLE
update mimemagic gem to 0.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,9 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -388,4 +390,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ Packages to install from main Stretch source:
 build-essential openssl libreadline-dev curl libcurl4-openssl-dev zlib1g \
 zlib1g-dev libssl-dev libxml2-dev libxslt-dev autoconf libgmp-dev libyaml-dev \
 ncurses-dev bison automake libtool imagemagick libc6-dev hunspell \
-hunspell-fr-comprehensive redis-server ruby ruby-dev ruby-rack
+hunspell-fr-comprehensive redis-server ruby ruby-dev ruby-rack shared-mime-info
 ```
 
 Note:

--- a/deployment/linuxfr.org/Dockerfile
+++ b/deployment/linuxfr.org/Dockerfile
@@ -14,7 +14,7 @@ RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> '/etc/apt/
     build-essential openssl libreadline-dev curl libcurl4-openssl-dev zlib1g \
     zlib1g-dev libssl-dev libxml2-dev libxslt-dev autoconf libgmp-dev libyaml-dev \
     ncurses-dev bison automake libtool imagemagick libc6-dev hunspell \
-    hunspell-fr-comprehensive ruby ruby-dev ruby-rack \
+    hunspell-fr-comprehensive ruby ruby-dev ruby-rack shared-mime-info \
   && apt-get install -t stretch-backports -y --no-install-recommends \
     nodejs npm \
   && gem install bundler \


### PR DESCRIPTION
This fix the Docker environment creation (see [suivi request](https://linuxfr.org/suivi/le-script-de-build-docker-compose-de-linuxfr-n-est-pas-a-jour)).

I've applied `bundle update mimemagic` inside my previous working Docker container and then tried to build again the environment.

My container is using the `bundle` 2.1.4 release as shown by this `Gemfile.lock` update:

```diff
BUNDLED WITH
-   1.17.3
+   2.1.4
```

@nono should I let my merge request update the bundled version or should I try to apply the update exactly with bundle `1.17.3` ? I don't know what will be available on production and what is the impact of this hint in the Gemfile.lock.