### PR TITLE
add instructions for login

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,6 +2,6 @@
   %h1 Se connecter
   %p
     %strong Attention :
-    l’identifiant et le mot de passe sont <strong>sensibles à la casse</strong>. Respectez les majuscules et minuscules pour ces deux champs.
+    l’identifiant et le mot de passe sont <strong>sensibles à la casse</strong>. Respectez les majuscules et minuscules pour ces deux champs. L'email n'est <strong>pas</strong> un identifiant valide!
   = render "devise/sessions/new", id_suffix: ""
   = render "devise/shared/links"


### PR DESCRIPTION
Hello,
This PR is about https://linuxfr.org/suivi/mot-de-passe-ne-marche-jamais.
I don't know at all Ruby so I'm not able to do the improvements mentionned in the thread, but I think just add a message for the user could be less misleading until the "true fix" availability.
If you have another suggestions for the text, please tell me.

Thanks, Pol

![image](https://user-images.githubusercontent.com/82312908/115567676-ce614f80-a2bb-11eb-8abf-59c0a8f672ba.png)

