### PR TITLE
remove automatic hyphens when user edit text in textareas

### DIFF
--- a/app/assets/stylesheets/common/generics.scss
+++ b/app/assets/stylesheets/common/generics.scss
@@ -40,3 +40,7 @@
 #edition img[alt=""] {
   border: 3px dotted red;
 }
+
+textarea {
+  hyphens: none;
+}


### PR DESCRIPTION
Disable hyphens [as requested by yPhil](https://linuxfr.org/suivi/cesure-inutile-toxique-dans-les-champs-de-saisie-texte).

The hyphens automatically added aren't real characters inside the textarea (user can't interact with them), but they are rendered as if it was added by the user itself. So, if the user want to "remove" the miss typed hyphen, he'll remove the character before the hyphen.

Furhtermore, the textarea won't have exactly same width than the final rendering div, so it doesn't make sense to show them while editing texts.