### PR TITLE
link and bookmark model validate URL

### DIFF
--- a/app/assets/javascripts/edition_in_place.coffee
+++ b/app/assets/javascripts/edition_in_place.coffee
@@ -42,6 +42,20 @@ class EditionInPlace
     false
 
   error: =>
+    try
+      error = @el.find("ul.error")
+      response = $.parseJSON(@xhr.responseText)
+      messages = []
+      for attribute, errors of response.errors
+        for message in errors
+          messages.push(message)
+      if messages.length == 1
+        error.text("Erreur : " + messages[0])
+      else
+        error.text("Erreurs :")
+        for message in messages
+          error.append($("<li>").append(message))
+      error.show()
     @el.trigger "in_place:error", @xhr
     @xhr = null
 

--- a/app/assets/stylesheets/parts/content.scss
+++ b/app/assets/stylesheets/parts/content.scss
@@ -13,7 +13,9 @@ body#news-revision #contents,
 body#boards-show #contents,
 body#stylesheets-edit #contents,
 body#wiki_pages-changes #contents,
-body#admin-index #container > ul {
+body#admin-index #container > ul,
+#redaction #new_link,
+#redaction .edit_link {
   display: block;
   background: white;
   padding: 10px $PX_PAD_NODE 10px $PX_PAD_NODE;

--- a/app/assets/stylesheets/parts/redaction.scss
+++ b/app/assets/stylesheets/parts/redaction.scss
@@ -503,6 +503,10 @@ body#redaction-index {
       }
     }
   }
+  #new_link,
+  .edit_link {
+    padding: 5px;
+  }
   input#link_title {
     width: 100%; // this rule force the input to not enlarge the #edition flex box
   }

--- a/app/controllers/redaction/links_controller.rb
+++ b/app/controllers/redaction/links_controller.rb
@@ -12,22 +12,29 @@ class Redaction::LinksController < RedactionController
   def create
     @link.attributes = link_params
     @link.user = current_user
-    @link.save
-    render partial: 'button'
+    if @link.save
+      render partial: 'button'
+    else
+      render status: :unprocessable_entity, json: { errors: @link.errors.as_json }
+    end
   end
 
   def edit
     if @link.lock_by(current_user)
       render partial: 'form'
     else
-      render status: :forbidden, text: "Désolé, #{@link.locker} est déjà en train de modifier ce lien !"
+      render status: :forbidden, plain: "Désolé, #{@link.locker} est déjà en train de modifier ce lien !"
     end
   end
 
   def update
     @link.attributes = link_params
     @link.update_by(current_user)
-    render @link
+    if @link.destroyed? || @link.save
+      render @link
+    else
+      render status: :unprocessable_entity, json: { errors: @link.errors.as_json }
+    end
   end
 
   def unlock

--- a/app/controllers/redaction/news_controller.rb
+++ b/app/controllers/redaction/news_controller.rb
@@ -65,8 +65,12 @@ class Redaction::NewsController < RedactionController
 
   def reorganized
     @news.editor = current_account
-    @news.reorganize news_params
-    redirect_to [@news.draft? ? :redaction : :moderation, @news]
+    if @news.reorganize news_params
+      redirect_to [@news.draft? ? :redaction : :moderation, @news]
+    else
+      load_board
+      render :reorganize, layout: "chat_n_edit"
+    end
   end
 
   def followup

--- a/app/controllers/redaction/news_controller.rb
+++ b/app/controllers/redaction/news_controller.rb
@@ -59,7 +59,7 @@ class Redaction::NewsController < RedactionController
       @news.put_paragraphs_together
       render :reorganize, layout: "chat_n_edit"
     else
-      render status: :forbidden, text: "Désolé, un verrou a déjà été posé sur cette dépêche !"
+      render status: :forbidden, plain: "Désolé, un verrou a déjà été posé sur cette dépêche !"
     end
   end
 

--- a/app/controllers/redaction/paragraphs_controller.rb
+++ b/app/controllers/redaction/paragraphs_controller.rb
@@ -25,7 +25,7 @@ class Redaction::ParagraphsController < RedactionController
     if @paragraph.lock_by(current_user)
       render partial: 'form'
     else
-      render status: :forbidden, text: "Désolé, #{@paragraph.locker} est déjà en train de modifier ce paragraphe !"
+      render status: :forbidden, plain: "Désolé, #{@paragraph.locker} est déjà en train de modifier ce paragraphe !"
     end
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -26,6 +26,7 @@ class Bookmark < Content
   validates :title,     presence: { message: "Le titre est obligatoire" },
                         length: { maximum: 100, message: "Le titre est trop long" }
   validates :link, presence: { message: "Vous ne pouvez pas poster un lien vide" },
+                   http_url: { message: "Le lien n'est pas valide" },
                    length: { maximum: 255, message: "Le lien est trop long" }
 
   def create_node(attrs={})

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -264,7 +264,8 @@ class News < Content
       Paragraph.where(news_id: self.id).delete_all
       self.attributes = params
       create_parts
-      save
+      # Let commit transaction only if save is successful so version will be well created
+      raise ActiveRecord::Rollback unless save
     end
     unlock
   end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -260,14 +260,20 @@ class News < Content
   end
 
   def reorganize(params)
+    reorganized = false
     self.transaction do
       Paragraph.where(news_id: self.id).delete_all
       self.attributes = params
       create_parts
       # Let commit transaction only if save is successful so version will be well created
-      raise ActiveRecord::Rollback unless save
+      if save
+        reorganized = true
+      else
+        raise ActiveRecord::Rollback
+      end
     end
-    unlock
+    unlock if reorganized
+    reorganized
   end
 
 ### Associated node ###

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -260,10 +260,12 @@ class News < Content
   end
 
   def reorganize(params)
-    Paragraph.where(news_id: self.id).delete_all
-    self.attributes = params
-    create_parts
-    save
+    self.transaction do
+      Paragraph.where(news_id: self.id).delete_all
+      self.attributes = params
+      create_parts
+      save
+    end
     unlock
   end
 

--- a/app/validators/http_url_validator.rb
+++ b/app/validators/http_url_validator.rb
@@ -1,0 +1,24 @@
+# Validate if a value is a HTTP url
+class HttpUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.present? && not(valid?(value, options))
+      record.errors.add attribute, (options[:message] || "n'est pas une URL HTTP valide")
+    end
+  end
+
+  private
+
+  def valid?(value, options)
+    uri = URI.parse(value)
+    if uri.scheme.blank? && uri.host.blank?
+      value = "http://#{value}"
+      uri = URI.parse(value)
+    end
+    if options.has_key?(:protocols)
+      return true if options[:protocols].include?(uri.scheme)
+    end
+    uri.scheme.nil? && uri.host == MY_DOMAIN
+  rescue URI::InvalidURIError
+    false
+  end 
+end

--- a/app/views/redaction/links/_form.html.haml
+++ b/app/views/redaction/links/_form.html.haml
@@ -1,10 +1,17 @@
 = form_for [:redaction, @link] do |form|
   - if @link.new_record?
     %input(type="hidden" name="news_id" value="#{@news.id}")
-  %p.link
+  %div.link
     = form.text_field :title, maxlength: 100, autocomplete: "off", placeholder: 'Titre'
     = form.url_field :url, autocomplete: "off", placeholder: 'Adresse'
     = form.select :lang, Lang.all
+    %br
+    %ul.error(style="display: none")
     - if @link.persisted?
       %button.cancel{'data-url' => unlock_redaction_link_path(@link), type: "button"} Annuler
+    - else
+      %button.cancel{type: "button"} Annuler
     = form.submit "OK"
+    - if @link.persisted?
+      %p
+        Note: pour supprimer le lien, videz le champ Adresse et cliquez sur OK

--- a/app/views/redaction/news/reorganize.html.haml
+++ b/app/views/redaction/news/reorganize.html.haml
@@ -9,6 +9,7 @@
 = render 'topbar', news: @news, show_backlink: false
 
 %article
+  = messages_on_error @news
   = form_for @news, url: reorganized_redaction_news_path(@news), method: :put do |form|
     %p
       = form.label :section_id, "Section"


### PR DESCRIPTION
For the link controller, the error handling has been added.
As the redaction system use ajax to update links, the controller return error
result in JSON format.

To handle validation errors correctly on client side, the edition_in_place
client javascript has to handle ajax error event:

when error is raised and response is JSON, event handler looks for error
messages and display them in the "ul.error" HTML tag.

Furthermore, the [`render text` has been deprecated](https://github.com/rails/rails/issues/12374)
I had to replace them with `render plain` for redaction locks.

See suivi bug report: https://linuxfr.org/suivi/corruption-de-depeches-et-url-avec-des-caracteres-non-ascii