### PR TITLE
bookmark defaults scheme to HTTP and HTTP validator only check scheme and host

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -29,6 +29,21 @@ class Bookmark < Content
                    http_url: { message: "Le lien n'est pas valide" },
                    length: { maximum: 255, message: "Le lien est trop long" }
 
+  def link=(raw)
+    raw.strip!
+    return write_attribute :url, nil if raw.blank?
+    uri = URI.parse(raw)
+    # Default to HTTP link if neither scheme nor host is found
+    if uri.scheme.blank? && uri.host.blank?
+      raw = "http://#{raw}"
+      uri = URI.parse(raw)
+    end
+    write_attribute :link, uri.to_s
+  # Let raw value if error when parsed, HttpUrlValidator will manage it
+  rescue URI::InvalidURIError
+    write_attribute :link, raw
+  end
+
   def create_node(attrs={})
     attrs[:cc_licensed] = false
     super

--- a/app/validators/http_url_validator.rb
+++ b/app/validators/http_url_validator.rb
@@ -9,15 +9,16 @@ class HttpUrlValidator < ActiveModel::EachValidator
   private
 
   def valid?(value, options)
+    # Valid links can be parsed by URI
     uri = URI.parse(value)
-    if uri.scheme.blank? && uri.host.blank?
-      value = "http://#{value}"
-      uri = URI.parse(value)
-    end
+    # Authorize protocol
     if options.has_key?(:protocols)
-      return true if options[:protocols].include?(uri.scheme)
+      return options[:protocols].include?(uri.scheme)
     end
-    uri.scheme.nil? && uri.host == MY_DOMAIN
+    # Links starting with "//MY_DOMAIN" are current scheme dependent and are valid
+    return true if uri.scheme.nil? && uri.host == MY_DOMAIN
+    # All other links are valid only if scheme and host exists
+    return uri.scheme.present? && uri.host.present?
   rescue URI::InvalidURIError
     false
   end 


### PR DESCRIPTION
I tried to fixup the [bookmark validation](https://linuxfr.org/suivi/echec-de-validation-de-lien) which is not working.

Compared to the links in the news, bookmarks didn't default link with `http://` scheme. It would made sense to default too to http, so I've just added it there and removed it from validation process.

Now, validation only parse the URI, then validate the scheme if protocol authorization is requested.

If protocol authorization is not requested, it allows either links with protocol and host, or links without protocol but same domain than current server name (like `//linuxfr.org`).