### PR TITLE
Fix diary converter and add some diary model tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,11 +45,15 @@ gem "sass-rails",            "~>5.0", require: assets
 gem "rails-sass-images",              require: assets
 gem "uglifier",                       require: assets
 
+group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem "byebug", platforms: :mri
+end
+
 group :development do
   gem "annotate"
   gem "better_errors"
   gem "binding_of_caller"
-  gem "byebug",                platform: :mri
   gem "capistrano",            "~>2.15", github: 'capistrano', branch: 'legacy-v2'
   gem "capistrano-maintenance"
   gem "letter_opener"
@@ -60,6 +64,12 @@ group :development do
   gem "sushi"
   gem "thin"
   gem "web-console"
+end
+
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem "capybara", ">= 2.15"
+  gem "selenium-webdriver"
 end
 
 group :production, :alpha do

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -68,7 +68,7 @@ class Diary < Content
     @news.transaction do
       @news.save!
       $redis.set "convert/#{@news.id}", self.id
-      @news.node.update_column(:cc_licensed, true) if node.cc_licensed?
+      @news.node.update_column(:cc_licensed, node.cc_licensed)
       @news.links.create title: "Journal à l’origine de la dépêche", url: "https://#{MY_DOMAIN}/users/#{owner.to_param}/journaux/#{to_param}", lang: "fr"
       @news.submit! unless node.cc_licensed?
       @news

--- a/deployment/linuxfr.org/Dockerfile
+++ b/deployment/linuxfr.org/Dockerfile
@@ -25,8 +25,7 @@ ENV HOME /home/linuxfr.org
 
 # Install node external dependencies
 COPY package*.json ./
-# Note: should use `npm ci`, but it freezes while running, that's strange
-RUN npm install --prod
+RUN npm ci
 
 # Install external dependencies
 COPY Gemfile* ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - ./app:/linuxfr.org/app
       - ./db:/linuxfr.org/db
       - ./public:/linuxfr.org/public
+      - ./test:/linuxfr.org/test
       # uploads are shared with the nginx service
       - data-uploads:/linuxfr.org/uploads
     tmpfs:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,5 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_firefox, screen_size: [1400, 1400]
+end

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,60 @@
+# Required Anonyme login for Account model
+anonymous:
+  user: community
+  login: Anonyme
+  email: anonymous@example.com
+  role: inactive
+
+<% 1000.times do |n| %>
+visitor_<%= n%>:
+  user: <%= "visitor_#{n}" %>
+  login: <%= "visitor_#{n}" %>
+  email: <%= "visitor_#{n}@example.com" %>
+  role: visitor
+<% end %>
+
+visitor_negative_karma:
+  user: visitor_negative_karma
+  login: visitor_negative_karma
+  email: visitor_negative_karma@example.com
+  role: visitor
+  karma: -100
+
+visitor_zero_karma:
+  user: visitor_zero_karma
+  login: visitor_zero_karma
+  email: visitor_zero_karma@example.com
+  role: visitor
+  karma: 0
+
+<% 7.times do |n| %>
+editor_<%= n%>:
+  user: <%= "editor_#{n}" %>
+  login: <%= "editor_#{n}" %>
+  email: <%= "editor_#{n}@example.com" %>
+  role: editor
+<% end %>
+
+<% 2.times do |n| %>
+maintainer_<%= n%>:
+  user: <%= "maintainer_#{n}" %>
+  login: <%= "maintainer_#{n}" %>
+  email: <%= "maintainer_#{n}@example.com" %>
+  role: maintainer
+<% end %>
+
+<% 12.times do |n| %>
+moderator_<%= n%>:
+  user: <%= "moderator_#{n}" %>
+  login: <%= "moderator_#{n}" %>
+  email: <%= "moderator_#{n}@example.com" %>
+  role: moderator
+<% end %>
+
+<% 6.times do |n| %>
+admin_<%= n%>:
+  user: <%= "admin_#{n}" %>
+  login: <%= "admin_#{n}" %>
+  email: <%= "admin_#{n}@example.com" %>
+  role: admin
+<% end %>

--- a/test/fixtures/diaries.yml
+++ b/test/fixtures/diaries.yml
@@ -1,0 +1,6 @@
+lorem:
+  title: Lorem ipsum
+  cached_slug: lorem-ipsum
+  owner: visitor_1
+  body: Lorem ipsum
+  wiki_body: Lorem ipsum

--- a/test/fixtures/diaries.yml
+++ b/test/fixtures/diaries.yml
@@ -1,6 +1,77 @@
-lorem:
+lorem_cc_licensed:
   title: Lorem ipsum
   cached_slug: lorem-ipsum
   owner: visitor_1
-  body: Lorem ipsum
-  wiki_body: Lorem ipsum
+  body: |-
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+    Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+    Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum
+    diam nisl sit amet erat. Duis semper.
+
+    Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue.
+    Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue.
+
+    Praesent egestas leo in pede. Praesent blandit odio eu enim.
+    Pellentesque sed dui ut augue blandit sodales.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum.
+    Maecenas adipiscing ante non diam sodales hendrerit. 
+  wiki_body: >-
+    <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+    Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+    Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum
+    diam nisl sit amet erat. Duis semper.
+    </p>
+    <p>
+    Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue.
+    Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue.
+    </p>
+    <p>
+    Praesent egestas leo in pede. Praesent blandit odio eu enim.
+    Pellentesque sed dui ut augue blandit sodales.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum.
+    Maecenas adipiscing ante non diam sodales hendrerit. 
+    </p>
+
+lorem_copyright:
+  title: Lorem ipsum
+  cached_slug: lorem-ipsum
+  owner: visitor_2
+  body: |-
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+    Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+    Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum
+    diam nisl sit amet erat. Duis semper.
+
+    Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue.
+    Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue.
+
+    Praesent egestas leo in pede. Praesent blandit odio eu enim.
+    Pellentesque sed dui ut augue blandit sodales.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum.
+    Maecenas adipiscing ante non diam sodales hendrerit. 
+  wiki_body: >-
+    <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+    Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+    Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum
+    diam nisl sit amet erat. Duis semper.
+    </p>
+    <p>
+    Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue.
+    Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue.
+    </p>
+    <p>
+    Praesent egestas leo in pede. Praesent blandit odio eu enim.
+    Pellentesque sed dui ut augue blandit sodales.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum.
+    Maecenas adipiscing ante non diam sodales hendrerit. 
+    </p>

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -1,0 +1,11 @@
+diary_lorem_cc_licensed:
+  cc_licensed: true
+  user: visitor_1
+  content: lorem_cc_licensed
+  content_type: Journal
+
+diary_lorem_copyright:
+  cc_licensed: false
+  user: visitor_2
+  content: lorem_copyright
+  content_type: Journal

--- a/test/fixtures/sections.yml
+++ b/test/fixtures/sections.yml
@@ -1,0 +1,3 @@
+default:
+  title: LinuxFr.org
+  cached_slug: linuxfr-org

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,42 @@
+# Required Collectif user for User model
+community:
+  name: Collectif
+  cached_slug: collectif
+
+<% 1000.times do |n| %>
+visitor_<%= n%>:
+  name: <%= "visitor_#{n}" %>
+  cached_slug: <%= "visitor_#{n}" %>
+<% end %>
+
+visitor_negative_karma:
+  name: visitor_negative_karma
+  cached_slug: visitor_negative_karma
+
+visitor_zero_karma:
+  name: visitor_zero_karma
+  cached_slug: visitor_zero_karma
+
+<% 7.times do |n| %>
+editor_<%= n%>:
+  name: <%= "editor_#{n}" %>
+  cached_slug: <%= "editor_#{n}" %>
+<% end %>
+
+<% 2.times do |n| %>
+maintainer_<%= n%>:
+  name: <%= "maintainer_#{n}" %>
+  cached_slug: <%= "maintainer_#{n}" %>
+<% end %>
+
+<% 12.times do |n| %>
+moderator_<%= n%>:
+  name: <%= "moderator_#{n}" %>
+  cached_slug: <%= "moderator_#{n}" %>
+<% end %>
+
+<% 6.times do |n| %>
+admin_<%= n%>:
+  name: <%= "admin_#{n}" %>
+  cached_slug: <%= "admin_#{n}" %>
+<% end %>

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -1,28 +1,29 @@
+# encoding: utf-8
 require 'test_helper'
 
 class DiaryTest < ActiveSupport::TestCase
   test "user with positive karma can create diary" do
-    diary = diaries(:lorem).dup;
+    diary = diaries(:lorem_cc_licensed).dup;
     assert diary.creatable_by?(diary.owner.account);
     assert diary.save();
   end
 
   test "user with zero karma cannot create diary" do
-    diary = diaries(:lorem).dup;
+    diary = diaries(:lorem_cc_licensed).dup;
     diary.owner = users(:visitor_zero_karma);
     assert_not diary.creatable_by?(diary.owner.account);
     assert diary.save(), "Diary model were not saved";
   end
 
   test "user with negative karma cannot create diary" do
-    diary = diaries(:lorem).dup;
+    diary = diaries(:lorem_cc_licensed).dup;
     diary.owner = users(:visitor_negative_karma);
     assert_not diary.creatable_by?(diary.owner.account);
     assert diary.save(), "Diary model were not saved";
   end
 
   test "only admin and moderator can update a diary" do
-    diary = diaries(:lorem);
+    diary = diaries(:lorem_cc_licensed);
     assert_not diary.updatable_by?(accounts(:visitor_1));
     assert_not diary.updatable_by?(accounts(:maintainer_1));
     assert diary.updatable_by?(accounts(:moderator_1));
@@ -30,10 +31,49 @@ class DiaryTest < ActiveSupport::TestCase
   end
 
   test "only admin and moderator can destroy a diary" do
-    diary = diaries(:lorem);
+    diary = diaries(:lorem_cc_licensed);
     assert_not diary.destroyable_by?(accounts(:visitor_1));
     assert_not diary.destroyable_by?(accounts(:maintainer_1));
     assert diary.destroyable_by?(accounts(:moderator_1));
     assert diary.destroyable_by?(accounts(:admin_1));
+  end
+
+  test "convert cc_licensed diary to news in redaction space" do
+    diary = diaries(:lorem_cc_licensed);
+    diary.node = nodes(:diary_lorem_cc_licensed);
+    created_news = diary.convert();
+    # Retrieve News from database to ensure it were saved correctly
+    news = News.find(created_news.id);
+    # Ensure convert work
+    assert_equal diary.title, news.title;
+    assert_equal "**TODO** insérer une synthèse du journal", news.versions.first().body;
+    assert_equal diary.wiki_body, news.versions.first().second_part;
+    assert_equal diary.owner.try(:name), news.author_name;
+    assert_equal diary.owner.try(:account).try(:email), news.author_email;
+    assert_equal diary.node.cc_licensed, news.node.cc_licensed;
+    assert news.node.cc_licensed;
+    assert_equal sections(:default).id, news.section_id;
+    # As diary is cc_licensed, news can be reworked collectively in the redaction space
+    assert_equal "draft", news.state;
+  end
+
+  test "convert copyrighted diary to news in moderation space" do
+    diary = diaries(:lorem_copyright);
+    diary.node = nodes(:diary_lorem_copyright);
+    created_news = diary.convert();
+    # Retrieve News from database to ensure it were saved correctly
+    news = News.find(created_news.id);
+    # Ensure convert work
+    assert_equal diary.title, news.title;
+    assert_equal "**TODO** insérer une synthèse du journal", news.versions.first().body;
+    assert_equal diary.wiki_body, news.versions.first().second_part;
+    assert_equal diary.owner.try(:name), news.author_name;
+    assert_equal diary.owner.try(:account).try(:email), news.author_email;
+    # Even if original diary were copyrighted, the created news is cc_licensed
+    assert_not_equal diary.node.cc_licensed, news.node.cc_licensed;
+    assert news.node.cc_licensed;
+    assert_equal sections(:default).id, news.section_id;
+    # As diary is not cc_licensed, news cannot be reworked collectively in the redaction space
+    assert_equal "candidate", news.state;
   end
 end

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class DiaryTest < ActiveSupport::TestCase
+  test "user with positive karma can create diary" do
+    diary = diaries(:lorem).dup;
+    assert diary.creatable_by?(diary.owner.account);
+    assert diary.save();
+  end
+
+  test "user with zero karma cannot create diary" do
+    diary = diaries(:lorem).dup;
+    diary.owner = users(:visitor_zero_karma);
+    assert_not diary.creatable_by?(diary.owner.account);
+    assert diary.save(), "Diary model were not saved";
+  end
+
+  test "user with negative karma cannot create diary" do
+    diary = diaries(:lorem).dup;
+    diary.owner = users(:visitor_negative_karma);
+    assert_not diary.creatable_by?(diary.owner.account);
+    assert diary.save(), "Diary model were not saved";
+  end
+end

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -20,4 +20,20 @@ class DiaryTest < ActiveSupport::TestCase
     assert_not diary.creatable_by?(diary.owner.account);
     assert diary.save(), "Diary model were not saved";
   end
+
+  test "only admin and moderator can update a diary" do
+    diary = diaries(:lorem);
+    assert_not diary.updatable_by?(accounts(:visitor_1));
+    assert_not diary.updatable_by?(accounts(:maintainer_1));
+    assert diary.updatable_by?(accounts(:moderator_1));
+    assert diary.updatable_by?(accounts(:admin_1));
+  end
+
+  test "only admin and moderator can destroy a diary" do
+    diary = diaries(:lorem);
+    assert_not diary.destroyable_by?(accounts(:visitor_1));
+    assert_not diary.destroyable_by?(accounts(:maintainer_1));
+    assert diary.destroyable_by?(accounts(:moderator_1));
+    assert diary.destroyable_by?(accounts(:admin_1));
+  end
 end

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -57,22 +57,13 @@ class DiaryTest < ActiveSupport::TestCase
     assert_equal "draft", news.state;
   end
 
-  test "convert copyrighted diary to news in moderation space" do
+  test "cannot convert non CC licensed diary to news" do
     diary = diaries(:lorem_copyright);
     diary.node = nodes(:diary_lorem_copyright);
-    created_news = diary.convert();
-    # Retrieve News from database to ensure it were saved correctly
-    news = News.find(created_news.id);
-    # Ensure convert work
-    assert_equal diary.title, news.title;
-    assert_equal "**TODO** insérer une synthèse du journal", news.versions.first().body;
-    assert_equal diary.wiki_body, news.versions.first().second_part;
-    assert_equal diary.owner.try(:name), news.author_name;
-    assert_equal diary.owner.try(:account).try(:email), news.author_email;
-    assert_equal diary.node.cc_licensed, news.node.cc_licensed;
-    assert_not news.node.cc_licensed;
-    assert_equal sections(:default).id, news.section_id;
-    # As diary is not cc_licensed, news cannot be reworked collectively in the redaction space
-    assert_equal "candidate", news.state;
+    assert_raises(ActiveRecord::RecordInvalid) do
+      diary.convert
+    end
+    assert_equal diary.errors.details[:base].first[:error], :cannot_convert
+    assert diary.invalid?(:convert)
   end
 end

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -69,9 +69,8 @@ class DiaryTest < ActiveSupport::TestCase
     assert_equal diary.wiki_body, news.versions.first().second_part;
     assert_equal diary.owner.try(:name), news.author_name;
     assert_equal diary.owner.try(:account).try(:email), news.author_email;
-    # Even if original diary were copyrighted, the created news is cc_licensed
-    assert_not_equal diary.node.cc_licensed, news.node.cc_licensed;
-    assert news.node.cc_licensed;
+    assert_equal diary.node.cc_licensed, news.node.cc_licensed;
+    assert_not news.node.cc_licensed;
     assert_equal sections(:default).id, news.section_id;
     # As diary is not cc_licensed, news cannot be reworked collectively in the redaction space
     assert_equal "candidate", news.state;

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,10 @@
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
+
+class ActiveSupport::TestCase
+  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  fixtures :all
+
+  # Add more helper methods to be used by all tests here...
+end


### PR DESCRIPTION
The diary to news converter creates always news with creative common license.
Even if the original author has removed the creative common license, the news created from it will be creative common licensed.

See commit 2a9c0a323687c2accfe52e8185046d7da4b4346c to understand why this fix is needed.

See [linked suivi request](https://linuxfr.org/suivi/licence-d-une-depeche-cree-a-partir-d-un-journal).