### PR TITLE
notify node owner for new answer

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,6 +31,11 @@ class Comment < ActiveRecord::Base
   scope :under,        ->(path) { where("materialized_path LIKE ?", "#{path}_%") }
   scope :published,    -> { where(state: 'published') }
   scope :on_dashboard, -> { published.order(created_at: :desc) }
+  scope :last_published, -> {
+    published.
+    order(created_at: :desc).
+    limit(1)
+  }
   scope :footer,       -> {
     # MariaDB tries to scan nodes first, which is a very slow, so we add an index hint
     from("comments USE INDEX (index_comments_on_state_and_created_at)").published.
@@ -136,6 +141,15 @@ class Comment < ActiveRecord::Base
       next if p.user_id == user_id
       account = p.user.try(:account)
       account.notify_answer_on node_id if account
+    end
+  end
+
+  after_create :notify_node_owner
+  def notify_node_owner
+    # Only notify for node types shown in dashboard
+    if Set['Post', 'Tracker'].include?(content_type) and user_id != node.user_id 
+      node_owner = node.user.try(:account)
+      node_owner.notify_answer_on node_id if node_owner
     end
   end
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -106,6 +106,10 @@ class Node < ActiveRecord::Base
     @threads ||= Threads.all(self.id)
   end
 
+  def last_answer
+    comments.last_published.first
+  end
+
 ### Readings ###
 
   def self.readings_keys_of(account_id)

--- a/app/views/dashboard/_posts.html.haml
+++ b/app/views/dashboard/_posts.html.haml
@@ -8,14 +8,20 @@
     %tr
       %th Forum
       %th Sujet
+      %th Date
       %th Note
-      %th Nombre de commentaires
-      %th Date du message
+      %th <abbr title="Nombre de réponses">Rép.</abbr>
+      %th Dernière réponse
     - @posts.each do |node|
       - post = node.content
+      - answer = node.last_answer
       %tr
         %td= post.forum.title
         %td= link_to post.title, [post.forum, post]
-        %td.number= node.score
-        %td.number= node.comments.count
         %td.date= post.created_at.to_s(:posted)
+        %td.number= node.score
+        %td.number
+          - if answer && !answer.read_by?(current_account)
+            = image_tag "/images/icones/comment.png", alt: "Nouveaux commentaires !", class: "thread-new-comments"
+          = node.comments.count
+        %td.date= answer ? answer.created_at.to_s(:posted) : " "

--- a/app/views/dashboard/_trackers.html.haml
+++ b/app/views/dashboard/_trackers.html.haml
@@ -8,16 +8,22 @@
     %tr
       %th Catégorie
       %th Sujet
+      %th Date
       %th État
       %th Note
-      %th Nombre de commentaires
-      %th Date du message
+      %th <abbr title="Nombre de réponses">Rép.</abbr>
+      %th Dernière réponse
     - @trackers.each do |node|
       - tracker = node.content
+      - answer = node.last_answer
       %tr{class: tracker.state}
         %td= tracker.category.title
         %td= link_to tracker.title, tracker
+        %td.date= tracker.created_at.to_s(:posted)
         %td= tracker.state_name
         %td.number= node.score
-        %td.number= node.comments.count
-        %td.date= tracker.created_at.to_s(:posted)
+        %td.number
+          - if answer && !answer.read_by?(current_account)
+            = image_tag "/images/icones/comment.png", alt: "Nouveaux commentaires !", class: "thread-new-comments"
+          = node.comments.count
+        %td.date= answer ? answer.created_at.to_s(:posted) : " "


### PR DESCRIPTION
For node of type Post and Tracker, notify the owner of new
answers (in existing thread or new thread).

Currently only limited to Post and Tracker as they are the only one
shown in the dashboard.

See suivi request: https://linuxfr.org/suivi/notifier-les-nouveaux-commentaire-sur-ses-messages-du-forum