### PR TITLE
Generalise use of “inclusive writing”

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -63,7 +63,7 @@ $("article.news .edited_by").each ->
   nb = field.find("a").length
   if nb > 3
     was = field.html()
-    field.html "<a>#{nb} contributeurs</a>"
+    field.html "<a>#{nb} personnes</a>"
     field.one "click", -> field.html was
 
 # Toolbar preferences

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -25,6 +25,6 @@
       %li= link_to "Suivi des suggestions et bogues", '/suivi'
       %li= link_to "Règles de modération", '/regles_de_moderation'
       %li= link_to "Statistiques", '/statistiques'
-      %li= link_to "API pour les développeurs", '/developpeur'
+      %li= link_to "API pour les développeurs et développeuses", '/developpeur'
       %li= link_to "Code source du site", '/code_source_du_site'
       %li= link_to "Plan du site", '/plan'

--- a/app/views/statistics/applications.html.haml
+++ b/app/views/statistics/applications.html.haml
@@ -7,7 +7,7 @@
       Statistiques mises à jour le #{l Time.now}
     %p= link_to("Retour à l’ensemble des statistiques", "/statistiques")
     %p
-      Des #{link_to("API pour les développeurs", "/developpeur")} sont disponibles pour réaliser des applications ou des sites Web interagissant avec le site LinuxFr.org.
+      Des #{link_to("API pour les développeurs et développeuses", "/developpeur")} sont disponibles pour réaliser des applications ou des sites Web interagissant avec le site LinuxFr.org.
 
     %h2 Sommaire
     %ul
@@ -18,7 +18,7 @@
 
     %h2#general Général
     %ul
-      %li #{pluralize @stats.applications, "application créée", "applications créées"} par #{pluralize @stats.applications_distinct_owners, "utilisateur", "utilisateurs distincts"}
+      %li #{pluralize @stats.applications, "application créée", "applications créées"} par #{pluralize @stats.applications_distinct_owners, "personne", "personnes distinctes"}
       %li #{pluralize @stats.access_grants, "autorisation créée", "autorisations créées"} pour #{pluralize @stats.access_grants_distinct_applications, "application", "applications distinctes"}
       %li #{pluralize @stats.access_tokens["total"], "jeton d’application créé", "jetons d’applications créés"} pour #{pluralize @stats.access_tokens_distinct_applications, "application", "applications distinctes"}, avec #{pluralize @stats.access_tokens["00"], "jeton actif (utilisé", "jetons actifs (utilisés"} au cours des 24 dernières heures), #{pluralize @stats.access_tokens["10"], "utilisable", "utilisables"} et #{pluralize @stats.access_tokens["11"], "périmé", "périmés"}
 

--- a/app/views/statistics/prizes.html.haml
+++ b/app/views/statistics/prizes.html.haml
@@ -58,7 +58,7 @@
         = list_of @stats.sum_comments_score(Post, 5) do |post, score|
           = link_to_content_with_score(post, score)
 
-    %h2 Les contributeurs les plus prolifiques
+    %h2 Les contributeurs et contributrices les plus prolifiques
 
     %div
       %h3 Dépêches

--- a/app/views/trackers/index.html.haml
+++ b/app/views/trackers/index.html.haml
@@ -12,7 +12,7 @@
 = form_for @tracker, url: trackers_path, method: :get do |f|
   %h2 Filtrer les entrées du suivi
   %p
-    %strong Si vous avez rencontré un bogue en parcourant le site web LinuxFr.org ou si vous avez une suggestion concernant l’évolution du site, c’est le bon endroit pour en informer les développeurs et/ou les administrateurs du site.
+    %strong Si vous avez rencontré un bogue en parcourant le site web LinuxFr.org ou si vous avez une suggestion concernant l’évolution du site, c’est le bon endroit pour en informer celles et ceux qui développent et/ou gèrent le site.
 
   %p
     = f.label :state, "État : "

--- a/db/pages/developer.html
+++ b/db/pages/developer.html
@@ -14,13 +14,13 @@
 <p>
   <a href="https://oauth.net/2/">OAuth2</a> est un protocole qui permet à des
   applications externes de demander l’autorisation d’accéder à des informations
-  privées d’un utilisateur avec un compte <em>LinuxFr.org</em> et de faire des actions
-  en son nom. L’utilisateur n’a pas besoin de fournir son mot de passe au site
-  externe et reste maître des autorisations qu’il a fournies.
+  privées d’une utilisatrice avec un compte <em>LinuxFr.org</em> et de faire des actions
+  en son nom. L’utilisatrice n’a pas besoin de fournir son mot de passe au site
+  externe et reste maître des autorisations qu’elle a fournies.
 </p>
 
 <p>
-  Si vous êtes un développeur d’applications Web et que vous souhaitez utiliser
+  Si vous développez des applications Web et que vous souhaitez utiliser
   l’API de <em>LinuxFr.org</em>, la première chose à faire est
   d’<a href="/api/applications">enregistrer votre application</a>.
   Vous obtiendrez ainsi un identifiant et un secret qui vous serviront lors des
@@ -29,8 +29,8 @@
 
 <p>
   OAuth fonctionne avec un principe de jetons. Quand une application Web
-  souhaite accéder aux données confidentielles de l'utilisateur, il va demander
-  à l’utilisateur un jeton d’autorisation qui sera délivré par <em>LinuxFr.org</em>,
+  souhaite accéder aux données confidentielles d’une utilisatrice, il va demander
+  à cette utilisatrice un jeton d’autorisation qui sera délivré par <em>LinuxFr.org</em>,
   puis il pourra utiliser ce jeton pour accéder aux informations.
 </p>
 
@@ -48,11 +48,11 @@
 
 <h2>Obtention d’un jeton d’autorisation</h2>
 
-<h3>Redirection de l’utilisateur vers LinuxFr.org</h3>
+<h3>Redirection de l’utilisatrice vers LinuxFr.org</h3>
 
 <p>
-  La première étape consiste à envoyer l’utilisateur sur <em>LinuxFr.org</em>
-  pour qu’il puisse accepter ou refuser de donner l’autorisation.
+  La première étape consiste à envoyer l’utilisatrice sur <em>LinuxFr.org</em>
+  pour qu’elle puisse accepter ou refuser de donner l’autorisation.
 </p>
 <pre>
 GET https://linuxfr.org/api/oauth/authorize
@@ -68,7 +68,7 @@ GET https://linuxfr.org/api/oauth/authorize
   <dt>redirect_uri</dt>
   <dd>
     Chaîne de caractères obligatoire — l’URL vers laquelle sera redirigé
-    l’utilisateur ou l’utilisatrice après l’autorisation.
+    l’utilisatrice après l’autorisation.
   </dd>
   <dt>response_type</dt>
   <dd>
@@ -79,17 +79,17 @@ GET https://linuxfr.org/api/oauth/authorize
   <dd>
     Chaîne de caractères facultative — la liste des scopes demandées, séparés
     par des espaces (URL encodés en +). Cela indique les actions que
-    l’application pourra faire au nom de l’utilisateur. Exemple :
+    l’application pourra faire au nom de l’utilisatrice. Exemple :
     <var>scope=account+board</var>. Par défaut, seul le scope
     <var>account</var> sera fourni.
   </dd>
 </dl>
 
 
-<h3>L’utilisateur revient sur le site</h3>
+<h3>L’utilisatrice revient sur le site</h3>
 
 <p>
-  Si l’utilisateur accepte l’autorisation, il est renvoyé sur le site d’origine
+  Si l’utilisatrice accepte l’autorisation, elle est renvoyée sur le site d’origine
   avec un <var>code</var> temporaire. Le code sera passé dans la <i>query string</i>
   sur l’URL de redirection. Le site peut alors échanger ce code contre le jeton
   d’autorisation.
@@ -121,8 +121,8 @@ POST https://linuxfr.org/api/oauth/token
   </dd>
   <dt><var>redirect_uri</var></dt>
   <dd>
-    Chaîne de caractères obligatoire — l’URI vers laquelle l’utilisateur
-    sera redirigé après obtention du jeton (doit être la même que celle
+    Chaîne de caractères obligatoire — l’URI vers laquelle l’utilisatrice
+    sera redirigée après obtention du jeton (doit être la même que celle
     indiquée lors de l’enregistrement de l’application).
   </dd>
 </dl>
@@ -175,12 +175,12 @@ GET https://linuxfr.org/api/v1/me
 <dl>
   <dt><var>login</var></dt>
   <dd>
-    Chaîne de caractères — l’identifiant du compte utilisateur sur
+    Chaîne de caractères — l’identifiant du compte personnel sur
     <em>LinuxFr.org</em>.
   </dd>
   <dt><var>email</var></dt>
   <dd>
-    Chaîne de caractères — l’adresse de courriel de l’utilisateur ou 
+    Chaîne de caractères — l’adresse de courriel de
     l’utilisatrice (note : elle a déjà été validée à l’inscription sur <em>LinuxFr.org</em>
     et il n’est donc pas souhaitable de revalider cette adresse de courriel).
   </dd>
@@ -268,7 +268,7 @@ POST https://linuxfr.org/api/v1/journaux
   <dt><var>id</var></dt>
   <dd>Entier - identifiant du journal qui vient d’être créé.</dd>
   <dt><var>owner_id</var></dt>
-  <dd>Entier - identifiant de l’utilisateur qui vient de créer le journal.</dd>
+  <dd>Entier - identifiant de l’utilisatrice qui vient de créer le journal.</dd>
   <dt><var>cached_slug</var></dt>
   <dd>Chaîne de caractères — le « <em><a href="https://fr.wikipedia.org/wiki/Slug_(journalisme)">slug</a></em> » du journal.</dd>
   <dt><var>title</var></dt>

--- a/db/pages/faire_un_don.html
+++ b/db/pages/faire_un_don.html
@@ -9,9 +9,9 @@ un groupe restreint de personnes bénévoles motivées.
 </p>
 
 <p>
-Grâce à de nombreux contributeurs, les frais financiers restent relativement faibles.
+Grâce à de nombreux contributeurs et contributrices, les frais financiers restent relativement faibles.
 Cependant, comme le site ne génère aucun revenu, les frais engendrés sont quasi‐exclusivement
-financés par les donateurs.
+financés par les donateurs et donatrices.
 </p>
 
 <p>Pour aider l’association, vous pouvez faire un don via l’un des moyens suivants :</p>
@@ -31,16 +31,16 @@ BL 6-113
 </ul>
 
 <p>
-Chaque don est mentionné sur cette page lorsque le donateur ne souhaite pas rester anonyme.
+Chaque don est mentionné sur cette page lorsque le donateur ou la donatrice ne souhaite pas rester anonyme.
 Les dons envoyés ne vous permettent pas d’avoir une réduction d’impôts, il faudrait que 
 nous soyons déclarés d’intérêt public pour cela
 (mais <a href="https://fsffrance.org/donations/howto.fr.html">ce serait possible</a>,
 si quelqu’un souhaite s’en occuper, qu’il nous contacte). Nous pouvons vous faire parvenir
 un reçu si vous le désirez.
 </p>
-<p>Voici donc la liste des donateurs, par ordre plus ou moins chronologique, sauf erreur ou oubli, hors anonymes, certains pouvant être présents plusieurs fois :</p>
+<p>Voici donc la liste des donateurs et donatrices, par ordre plus ou moins chronologique, sauf erreur ou oubli, hors anonymes, certains et certaines pouvant apparaître plusieurs fois :</p>
 
-<h3>Particuliers</h3>
+<h3>Particuliers, particulières</h3>
 <ul>
 <li>de multiples anonymes</li>
 <li>Jocelyn JOVÈNE</li>
@@ -204,4 +204,4 @@ un reçu si vous le désirez.
 <li>S. A. R. L. AESIS Conseil</li>
 <li><a href="https://www.besttech.fr/">BestTech</a></li>
 </ul>
-Un grand merci à eux.
+Un grand merci à tout ce monde.


### PR DESCRIPTION
Since LinuxFR.org has a (somewhat) stated policy of favouring “inclusive writing” (i.e. avoiding the use of phrasing that can be understood to refer specifically to males, depending on whether you accept that French “masculine” forms can be gender-neutral or not), this PR removes some (not all!) instances of masculine-only forms at various places.

Corresponding ticket: https://linuxfr.org/suivi/ecriture-epicene-manquante