### PR TITLE
mise à jour des raccourcis pour guillemets français

### DIFF
--- a/app/views/redaction/news/_wiki_help.html.haml
+++ b/app/views/redaction/news/_wiki_help.html.haml
@@ -82,10 +82,12 @@
       %td Alt Gr + B
     %tr
       %td «
-      %td Alt Gr + Z
+      %td Alt Gr + Z<br/>
+          Alt Gr + w
     %tr
       %td »
-      %td Alt Gr + X
+      %td Alt Gr + X<br/>
+          Alt Gr + x
     %tr
       %td ×
       %td Alt Gr + .

--- a/app/views/shared/_wiki_help.html.haml
+++ b/app/views/shared/_wiki_help.html.haml
@@ -15,7 +15,8 @@
         %td Alt Gr + Maj + B et Alt Gr + B
         %td apostrophe / guillemet fermant ’ et “
       %tr
-        %td Alt Gr + Z et Alt Gr + X
+        %td Alt Gr + Z et Alt Gr + X<br/>
+            Alt Gr + w et Alt Gr + x
         %td guillemets français « et »
       %tr
         %td Alt Gr + .


### PR DESCRIPTION
L'aide des raccourcis clavier actuels pour les guillemets français  (Alt Gr +Z et +X) semble venir d'un QWERTY. Il y a plein de claviers QWERTY (belge, suisse, anglais, ...). Je propose d'ajouter des raccourcis Azerty sous Linux (Alt Gr +w et +x). 

La semaine prochaine, je pourrai tester un QWERTY anglais (et jongler pour les autres).