### PR TITLE
use Debian Bullseye for linuxfr-board docker image

### DIFF
--- a/deployment/linuxfr-board/Dockerfile
+++ b/deployment/linuxfr-board/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer="adrien@adorsaz.ch"
-LABEL version="1.0"
+LABEL version="2.0"
 LABEL description="Run LinuxFr board service for LinuxFr.org Ruby on Rails website"
 
 WORKDIR /linuxfr-board


### PR DESCRIPTION
`linuxfr-board` has a dependency which requires now at least Ruby 2.5.0:

```
Step 7/10 : RUN gem install board-linuxfr -v '~> 0.1.3'
 ---> Running in 47eba4572c41
ERROR:  Error installing board-linuxfr:
        einhorn requires Ruby version >= 2.5.0.
Successfully installed multi_json-1.15.0
Successfully installed rack-1.6.13
Successfully installed async-rack-0.5.0
Successfully installed rack-accept-media-types-0.9
Successfully installed rack-respond_to-0.9.8
Successfully installed rack-contrib-1.8.0
The command '/bin/sh -c gem install board-linuxfr -v '~> 0.1.3'' returned a non-zero code: 1
ERROR: Service 'linuxfr-board' failed to build : Build failed
```