### PR TITLE
Fix diary converter

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -60,7 +60,7 @@ class Diary < Content
 
 ### Moving ###
   def convert_only_cc_licensed_diary
-    errors.add :base, :cannot_convert, message: "Le journal n’a pas été publié sous licence CC-BY-SA 4.0, il ne peut donc pas être proposé en dépêche." unless node.cc_licensed?
+    errors.add :base, :cannot_convert, message: "Le journal n’a pas été publié sous licence CC By-SA 4.0, il ne peut donc pas être proposé en dépêche." unless node.cc_licensed?
   end
 
   def convert

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -68,7 +68,7 @@ class Diary < Content
     @news.transaction do
       @news.save!
       $redis.set "convert/#{@news.id}", self.id
-      @news.node.update_column(:cc_licensed, true) if node.cc_licensed?
+      @news.node.update_column(:cc_licensed, node.cc_licensed)
       @news.links.create title: "Journal à l’origine de la dépêche", url: "https://#{MY_DOMAIN}/users/#{owner.to_param}/journaux/#{to_param}", lang: "fr"
       @news.submit! unless node.cc_licensed?
       @news

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -57,22 +57,13 @@ class DiaryTest < ActiveSupport::TestCase
     assert_equal "draft", news.state;
   end
 
-  test "convert copyrighted diary to news in moderation space" do
+  test "cannot convert non CC licensed diary to news" do
     diary = diaries(:lorem_copyright);
     diary.node = nodes(:diary_lorem_copyright);
-    created_news = diary.convert();
-    # Retrieve News from database to ensure it were saved correctly
-    news = News.find(created_news.id);
-    # Ensure convert work
-    assert_equal diary.title, news.title;
-    assert_equal "**TODO** insérer une synthèse du journal", news.versions.first().body;
-    assert_equal diary.wiki_body, news.versions.first().second_part;
-    assert_equal diary.owner.try(:name), news.author_name;
-    assert_equal diary.owner.try(:account).try(:email), news.author_email;
-    assert_equal diary.node.cc_licensed, news.node.cc_licensed;
-    assert_not news.node.cc_licensed;
-    assert_equal sections(:default).id, news.section_id;
-    # As diary is not cc_licensed, news cannot be reworked collectively in the redaction space
-    assert_equal "candidate", news.state;
+    assert_raises(ActiveRecord::RecordInvalid) do
+      diary.convert
+    end
+    assert_equal diary.errors.details[:base].first[:error], :cannot_convert
+    assert diary.invalid?(:convert)
   end
 end

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -69,9 +69,8 @@ class DiaryTest < ActiveSupport::TestCase
     assert_equal diary.wiki_body, news.versions.first().second_part;
     assert_equal diary.owner.try(:name), news.author_name;
     assert_equal diary.owner.try(:account).try(:email), news.author_email;
-    # Even if original diary were copyrighted, the created news is cc_licensed
-    assert_not_equal diary.node.cc_licensed, news.node.cc_licensed;
-    assert news.node.cc_licensed;
+    assert_equal diary.node.cc_licensed, news.node.cc_licensed;
+    assert_not news.node.cc_licensed;
     assert_equal sections(:default).id, news.section_id;
     # As diary is not cc_licensed, news cannot be reworked collectively in the redaction space
     assert_equal "candidate", news.state;


### PR DESCRIPTION
Note: This is the new PR created from #318 with only contain new behaviour for the diary converter

---

The diary to news converter creates always news with creative common license.
Even if the original author has removed the creative common license, the news created from it will be creative common licensed.

See commit 2a9c0a323687c2accfe52e8185046d7da4b4346c to understand why this fix is needed.

See [linked suivi request](https://linuxfr.org/suivi/licence-d-une-depeche-cree-a-partir-d-un-journal).