### PR TITLE
Include the Mastodon URL in a link element on user page (#2046)

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -22,9 +22,12 @@ docker-compose run linuxfr.org bin/rails db:setup
 Finally, the environment is ready and you can open [http://dlfp.lo](http://dlfp.lo)
 in your favorite browser.
 
-Note: to be able to access this URL, you'll need to add the line
-`127.0.0.1 dlfp.lo image.dlfp.lo` to the `/etc/hosts` file of your
-machine.
+Note: to be able to access this URL, you'll need to add the following line
+into the `/etc/hosts` file of your machine:
+
+```
+127.0.0.1 dlfp.lo image.dlfp.lo
+```
 
 Personalize configuration
 =========================
@@ -58,7 +61,9 @@ will directly detect changes and apply them on next page reload.
 Furthermore, if you need to access the Rails console, you need a second
 terminal and run:
 
-`docker-compose run linuxfr.org bin/rails console`
+```
+docker-compose run linuxfr.org bin/rails console
+```
 
 Note: currently, we didn't configure rails to show directly the
 `webconsole` in your browser. That's just because of time needed to
@@ -76,7 +81,9 @@ To get help about writing tests, see the
 
 To run tests with Docker environment, you need to use this command:
 
-`docker-compose run linuxfr.org bin/rails test -v`
+```
+docker-compose run linuxfr.org bin/rails test -v
+```
 
 Inspect database schema
 =======================
@@ -84,7 +91,9 @@ Inspect database schema
 In case you need to inspect the database, you need a second terminal
 and run:
 
-`docker-compose run database mysql -hdatabase -ulinuxfr_rails -p linuxfr_rails`
+```
+docker-compose run database mysql -hdatabase -ulinuxfr_rails -p linuxfr_rails
+```
 
 By default, the requested password is the same as the username.
 
@@ -94,12 +103,16 @@ Apply database migrations
 In case you need to apply new database migrations, you need a second
 terminal and run:
 
-`docker-compose run linuxfr.org bin/rails db:migrate`
+```
+docker-compose run linuxfr.org bin/rails db:migrate
+```
 
 If you had issue and want to reset all data in your database system,
 use:
 
-`docker-compose run linuxfr.org bin/rails db:reset`
+```
+docker-compose run linuxfr.org bin/rails db:reset
+```
 
 Services provided by the docker-compose
 =======================================

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,7 @@ protected
     @keywords      = %w(Linux Logiciel Libre GNU Free Software Actualité Forum Communauté)
     @description   = "L’actualité du logiciel libre et des sujets voisins (DIY, Open Hardware, Open Data, les Communs, etc.), sur un site francophone contributif géré par une équipe bénévole par et pour des libristes enthousiastes"
     @feeds         = {}
+    @links         = {}
     @last_comments = Comment.footer
     @popular_tags  = Tag.footer
     @friend_sites  = FriendSite.select([:url, :title])
@@ -56,7 +57,7 @@ protected
       :sort_by_date_on_home, :hide_signature, :show_negative_nodes,
       :totoz_style, :totoz_source,
       :board_in_sidebar,
-      user_attributes: [:id, :name, :homesite, :jabber_id, :signature, :avatar, :custom_avatar_url]
+      user_attributes: [:id, :name, :homesite, :jabber_id, :mastodon_url, :signature, :avatar, :custom_avatar_url]
     ])
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,10 @@ module ApplicationHelper
     @feeds[link] = title
   end
 
+  def link(rel, link)
+    @links[link] = rel
+  end
+
   def meta_for(content)
     @author      = content.node.user.try(:name)
     @keywords    = content.node.popular_tags.map &:name

--- a/app/helpers/node_helper.rb
+++ b/app/helpers/node_helper.rb
@@ -111,6 +111,7 @@ module NodeHelper
       user_infos = []
       user_infos << homesite_link(user)
       user_infos << jabber_link(user)
+      user_infos << mastodon_link(user)
       user_infos.compact!
       user_link += (" (" + user_infos.join(', ') + ")").html_safe  if user_infos.any?
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -40,4 +40,8 @@ module UsersHelper
     link_to("adresse XMPP", "xmpp:" + user.jabber_id)
   end
 
+  def mastodon_link(user)
+    return if user.mastodon_url.blank?
+    link_to("Mastodon", user.mastodon_url)
+  end
 end

--- a/app/models/statistics/users.rb
+++ b/app/models/statistics/users.rb
@@ -109,4 +109,9 @@ class Statistics::Users < Statistics::Statistics
   def top_xmpp_domains
     select_all "SELECT SUBSTRING_INDEX(jabber_id,'@', -1) AS domain, COUNT(*) AS cnt FROM accounts LEFT JOIN users ON accounts.user_id=users.id WHERE jabber_id LIKE '%@%' AND current_sign_in_at > DATE_SUB(CURDATE(),INTERVAL 90 DAY) AND role<>'inactive' GROUP BY domain HAVING cnt > 3 ORDER BY cnt DESC LIMIT 10;"
   end
+
+  def top_mastodon_domains
+    # We assume Mastodon URLs will always start with "https://"
+    select_all "SELECT SUBSTRING_INDEX(SUBSTRING(mastodon_url, 9),'/', 1) AS domain, COUNT(*) AS cnt FROM accounts LEFT JOIN users ON accounts.user_id=users.id WHERE mastodon_url LIKE 'https://%/%' AND current_sign_in_at > DATE_SUB(CURDATE(),INTERVAL 90 DAY) AND role<>'inactive' GROUP BY domain HAVING cnt > 3 ORDER BY cnt DESC LIMIT 10;"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@
 #  name              :string(40)
 #  homesite          :string(100)
 #  jabber_id         :string(32)
+#  mastodon_url      :string(100)
 #  cached_slug       :string(32)       not null
 #  created_at        :datetime
 #  updated_at        :datetime
@@ -33,6 +34,8 @@ class User < ActiveRecord::Base
   validates :homesite, length: { maximum: 100, message: "L’adresse du site Web personnel est trop longue" }
   validates :name, length: { maximum: 40, message: "Le nom affiché est trop long" }
   validates :jabber_id, length: { maximum: 32, message: "L’adresse XMPP est trop longue" }
+  validates :mastodon_url, http_url: { protocols: ["https"], message: "L’adresse du compte Mastodon n’est pas une URL valide" },
+                           length: { maximum: 255, message: "L’adresse du compte Mastodon est trop longue" }
   validates :signature, length: { maximum: 255, message: "La signature est trop longue" }
   validates :custom_avatar_url, length: { maximum: 255, message: "L’adresse de l’avatar est trop longue" }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
   validates :homesite, length: { maximum: 100, message: "L’adresse du site Web personnel est trop longue" }
   validates :name, length: { maximum: 40, message: "Le nom affiché est trop long" }
   validates :jabber_id, length: { maximum: 32, message: "L’adresse XMPP est trop longue" }
-  validates :mastodon_url, http_url: { protocols: ["https"], message: "L’adresse du compte Mastodon n’est pas une URL valide" },
+  validates :mastodon_url, http_url: { protocols: ["https"], message: "L’adresse du compte Mastodon n’est pas valide" },
                            length: { maximum: 255, message: "L’adresse du compte Mastodon est trop longue" }
   validates :signature, length: { maximum: 255, message: "La signature est trop longue" }
   validates :custom_avatar_url, length: { maximum: 255, message: "L’adresse de l’avatar est trop longue" }

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -12,6 +12,12 @@
       %span.prefix xmpp:
       = u.text_field :jabber_id, placeholder: "me@example.net", maxlength: 32
     %p
+      = u.label :mastodon_url, 'Adresse du compte Mastodon'
+      = u.url_field :mastodon_url, placeholder: "https://mastodon.example/@me", maxlength: 255
+      %span.help
+        Après avoir enregistré l'adresse de votre compte Mastodon, vous pourrez utiliser le lien <kbd>https://linuxfr.org/users/#{current_user.login}</kbd> pour
+        <a href="https://docs.joinmastodon.org/user/profile/#verification">prouver que le compte Mastodon et le compte LinuxFr.org appartiennent à la même personne.</a>
+    %p
       = u.label :signature, "Signature"
       = u.text_field :signature, maxlength: 250, size: 100
   %p

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -15,7 +15,7 @@
       = u.label :mastodon_url, 'Adresse du compte Mastodon'
       = u.url_field :mastodon_url, placeholder: "https://mastodon.example/@me", maxlength: 255
       %span.help
-        Après avoir enregistré l'adresse de votre compte Mastodon, vous pourrez utiliser le lien <kbd>https://linuxfr.org/users/#{current_user.login}</kbd> pour
+        Après avoir enregistré l’adresse de votre compte Mastodon, vous pourrez utiliser le lien <kbd>https://linuxfr.org/users/#{current_user.login}</kbd> pour
         <a href="https://docs.joinmastodon.org/user/profile/#verification">prouver que le compte Mastodon et le compte LinuxFr.org appartiennent à la même personne.</a>
     %p
       = u.label :signature, "Signature"

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -18,3 +18,5 @@
     %meta(name="robots" content="noindex, nofollow")
   - @feeds.each do |link,title|
     = auto_discovery_link_tag :atom, link, { title: title }
+  - @links.each do |link,rel|
+    %link(rel=rel href=link)

--- a/app/views/statistics/users.html.haml
+++ b/app/views/statistics/users.html.haml
@@ -19,6 +19,7 @@
       %li= link_to("Informations personnelles", "#stats_infosperso")
       %li= link_to("Domaines des courriels", "#stats_courriel")
       %li= link_to("Domaines XMPP", "#stats_xmpp")
+      %li= link_to("Domaines Mastodon", "#stats_mastodon")
       %li= link_to("Utilisation des fonctionnalités", "#stats_fonctionnalites")
       %li= link_to("Style (CSS)", "#stats_css")
       %li= link_to("Karmas des utilisatrices et utilisateurs", "#stats_karma")
@@ -244,6 +245,24 @@
       %th Nombre de comptes
       %th Actifs
     - @stats.top_xmpp_domains.each do |domain|
+      %tr
+        %td.stat
+          = domain["domain"]
+        %td
+          .stat.misc(style="width: #{(width_stats * domain["cnt"] / maxval).to_i}px;")= domain["cnt"]
+        %td
+          #{@stats.pctrecent(domain["cnt"])}
+
+  %h2#stats_mastodon Domaines Mastodon
+  %p
+    Sur #{pluralize @stats.nb_recently_used_accounts, "compte valide et utilisé", "comptes valides et utilisés"} au cours des trois derniers mois :
+  %table
+    - maxval = @stats.nb_recently_used_accounts
+    %tr
+      %th Domaines à plus de trois comptes
+      %th Nombre de comptes
+      %th Actifs
+    - @stats.top_mastodon_domains.each do |domain|
       %tr
         %td.stat
           = domain["domain"]

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -4,5 +4,7 @@
 
 =h1 "#{@user.name} a écrit #{pluralize @nodes.total_count, "contenu"} de type dépêche ou journal"
 - feed "Flux Atom de #{@user.name}", "/users/#{@user.to_param}.atom"
+- if @user.mastodon_url
+  - link "me", @user.mastodon_url
 - filter_pagination_params ['id', 'order', 'page']
 = paginated_nodes @nodes

--- a/db/migrate/20221219214058_add_mastodon_url_to_users.rb
+++ b/db/migrate/20221219214058_add_mastodon_url_to_users.rb
@@ -1,0 +1,5 @@
+class AddMastodonUrlToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :mastodon_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_31_231806) do
+ActiveRecord::Schema.define(version: 2022_12_19_214058) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -373,6 +373,7 @@ ActiveRecord::Schema.define(version: 2021_01_31_231806) do
     t.string "avatar"
     t.string "signature"
     t.string "custom_avatar_url"
+    t.string "mastodon_url"
     t.index ["cached_slug"], name: "index_users_on_cached_slug"
   end
 


### PR DESCRIPTION
We add a `<link rel="me" href="https://mastodon.example/@me">` URL in  the `<head>` when the user configures their Mastodon URL.
    
We only accept URLs (not `@me@mastodon.example`-style identifiers) for    the sake of simplicity, because it's both the most universal format and    the one required for the "verification" feature. A placeholder is used     to convey that fact.
    
For the record, at this time Mastodon requires a `<a>` or `<link>`     element with `rel="me"` and an `href` attribute pointing to the     `https://` URL of the Mastodon account. I opted for the `<link>` element     because it didn't involve modifying the web interface any further. See     https://docs.joinmastodon.org/user/profile/#verification for details.
    
https://linuxfr.org/suivi/faire-valider-sa-page-perso-linuxfr-org-sur-mastodon

I also fixed the formatting of command lines in Docker.md while I was at it.

## Updated options

![image](https://user-images.githubusercontent.com/10519/210018871-bb31eb2d-e92a-4386-b12b-3aa217d567b2.png)

## `<head>`

![image](https://user-images.githubusercontent.com/10519/210018910-9f42a054-d2f3-47b2-8721-199538ff4704.png)

