### PR TITLE
Fix validating the URL of user home sites

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,8 @@ class User < ActiveRecord::Base
   has_many :taggings, -> { includes(:tag) }, dependent: :destroy
   has_many :tags, -> { distinct }, through: :taggings
 
-  validates_format_of :homesite, message: "L’adresse du site Web personnel n’est pas valide", with: URI::regexp(%w(http https)), allow_blank: true
-  validates :homesite, length: { maximum: 100, message: "L’adresse du site Web personnel est trop longue" }
+  validates :homesite, http_url: { protocols: ["http", "https"], message: "L’adresse du site Web personnel n’est pas valide" },
+                       length: { maximum: 100, message: "L’adresse du site Web personnel est trop longue" }
   validates :name, length: { maximum: 40, message: "Le nom affiché est trop long" }
   validates :jabber_id, length: { maximum: 32, message: "L’adresse XMPP est trop longue" }
   validates :signature, length: { maximum: 255, message: "La signature est trop longue" }


### PR DESCRIPTION
Home site validation used the URL regexp, but didn't anchor it. Because of this it was possible to add text before or after the URL and have it considered valid. For instance, this was considered a valid homesite value: "lorem ipsum https://example.org/#foo#bar dolor sit amet"

It is possible to fix it by anchoring the regexp, but IMO it is wiser to use the same URL validator used at other places in the site. Hence this commit replaces this validation with the `http_url` validator used for news links and bookmarks.

https://linuxfr.org/suivi/impossible-de-mettre-un-lien-vers-un-salon-matrix-dans-les-liens-d-une-depeche#comment-1911550

NB: it doesn't fix the problem in the suivi entry but another problem explained in the comment.