### PR TITLE
improve user preferences for mastodon input

### DIFF
--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -14,9 +14,9 @@
     %p
       = u.label :mastodon_url, 'Adresse du compte Mastodon'
       = u.url_field :mastodon_url, placeholder: "https://mastodon.example/@me", maxlength: 100
-      %span.help
-        Après avoir enregistré l’adresse de votre compte Mastodon, vous pourrez utiliser le lien <kbd>#{user_url(current_user)}</kbd> pour
-        <a href="https://docs.joinmastodon.org/user/profile/#verification">prouver que le compte Mastodon et le compte LinuxFr.org appartiennent à la même personne.</a>
+    %p.help
+      Après avoir enregistré l’adresse de votre compte Mastodon, vous pourrez utiliser le lien <code>#{user_url(current_user)}</code> pour
+      <a href="https://docs.joinmastodon.org/user/profile/#verification">prouver que le compte Mastodon et le compte LinuxFr.org appartiennent à la même personne.</a>
     %p
       = u.label :signature, "Signature"
       = u.text_field :signature, maxlength: 250, size: 100


### PR DESCRIPTION
To avoid the help starts at end of the input, move it to a paragraph.

The `<kbd>` HTML tag should be used for keyboard inputs, so I've replaced it with `<code>` for the url profile link.