### PR TITLE
docker-compose: remove useless restart policy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,6 @@ services:
       context: deployment/database
     env_file:
       - deployment/default.env
-    restart: unless-stopped
     ports:
       - "3306:3306"
     volumes:
@@ -68,7 +67,6 @@ services:
 
   redis:
     image: redis:5
-    restart: unless-stopped
     volumes:
       - data-redis:/data
 


### PR DESCRIPTION
The default is "no" which is good to just try and forget hack on linuxfr.org. If developer want to change it, it can override compose configuration with a docker-compose.local.yml file.