### PR TITLE
docker: Fix creating linuxfr.org using docker-compose

### DIFF
--- a/deployment/linuxfr.org/Dockerfile
+++ b/deployment/linuxfr.org/Dockerfile
@@ -7,11 +7,14 @@ LABEL description="Run LinuxFr.org Ruby on Rails website"
 WORKDIR /linuxfr.org
 
 # Install system dependencies
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> '/etc/apt/sources.list.d/linuxfr.list' \
+# Debian Stretch has been archived so we replace the sources with the archived ones
+RUN echo 'deb http://archive.debian.org/debian stretch main' > '/etc/apt/sources.list' \
+  && echo 'deb http://archive.debian.org/debian stretch-proposed-updates main' >> '/etc/apt/sources.list' \
+  && echo 'deb http://archive.debian.org/debian stretch-backports main' >> '/etc/apt/sources.list.d/linuxfr.list' \
   && apt-get update \
-  && apt-get install -y --no-install-recommends \
+  && apt-get install -y --no-install-recommends --allow-downgrades \
     mysql-client libmysql++-dev git \
-    build-essential openssl libreadline-dev curl libcurl4-openssl-dev zlib1g \
+    build-essential openssl libreadline-dev curl libcurl4-openssl-dev zlib1g=1:1.2.8.dfsg-5 \
     zlib1g-dev libssl-dev libxml2-dev libxslt-dev autoconf libgmp-dev libyaml-dev \
     ncurses-dev bison automake libtool imagemagick libc6-dev hunspell \
     hunspell-fr-comprehensive ruby ruby-dev ruby-rack \


### PR DESCRIPTION
This commit fixes errors related to the recent-ish archival of Debian Stretch. Indeed, the linuxfr.org container is still based on Debian Stretch but this version of the distribution was archived when Bookworm was released. This implies a change in the APT sources but neither the debian:stretch-slim nor this repository were updated accordingly.

The errors fixed are:

 - we replace the `deb.debian.org` domain with `archive.debian.org`, where the archived repositories are located;
 - we downgrade `zlib1g` forcefully because the version which is already installed in the upstream container is newer than the one we can find in the archived repositories, and it caused a dependency issue when trying to install the `zlib1g-dev` package.