### PR TITLE
Don't show Jabber ID for sub-zero karma users.

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -37,6 +37,8 @@ module UsersHelper
   def jabber_link(user)
     return unless current_account
     return if user.jabber_id.blank?
+    karma = user.account.try(:karma).to_i
+    return unless karma > 0
     link_to("adresse XMPP", "xmpp:" + user.jabber_id)
   end
 


### PR DESCRIPTION
We already do that for website and Mastodon. No reason to treat Jabber any different.