### PR TITLE
List blocked images

### DIFF
--- a/app/controllers/admin/images_controller.rb
+++ b/app/controllers/admin/images_controller.rb
@@ -1,0 +1,7 @@
+# encoding: UTF-8
+class Admin::ImagesController < AdminController
+
+  def index
+    @images = Image.blocked(100)
+  end
+end

--- a/app/controllers/moderation/images_controller.rb
+++ b/app/controllers/moderation/images_controller.rb
@@ -6,8 +6,10 @@ class Moderation::ImagesController < ModerationController
   end
 
   def destroy
-    Board.amr_notification("Une image #{moderation_images_url} a été bloquée par #{current_user.name} #{user_url(current_user)}")
-    Image.destroy params[:id] unless params[:id].blank?
+    unless params[:id].blank?
+      Board.amr_notification("Une image récente de #{moderation_images_url} a été bloquée par #{current_user.name} #{user_url(current_user)}")
+      Image.destroy params[:id]
+    end
     redirect_to moderation_images_url
   end
 end

--- a/app/views/admin/images/index.html.haml
+++ b/app/views/admin/images/index.html.haml
@@ -1,0 +1,13 @@
+# encoding: utf-8
+%h1 Images externes bloquées
+
+- if @images.any?
+  %p Liste des images externes bloquées :
+- else
+  %p Aucune image externe bloquée actuellement
+
+%ul
+  - @images.each do |image|
+    %li
+      %pre
+        = "#{image.link.html_safe} #{'⚠ image non bloquée' unless image.blocked}"

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -1,14 +1,15 @@
 =h1 "Administration"
 %ul
+  %li= link_to "Applications de l’API", admin_applications_path
+  %li= link_to "Bannières", admin_banners_path
+  %li= link_to "Débogage", "/admin/debug"
   %li= link_to "Derniers comptes", admin_accounts_path
+  %li= link_to "Catégories (pour le suivi)", admin_categories_path
+  %li= link_to "Feuilles de style", admin_stylesheet_path
+  %li= link_to "Forums", admin_forums_path
+  %li= link_to "Images", admin_images_path
+  %li= link_to "Logo", admin_logo_path
   %li= link_to "Réponses de refus (pour les dépêches)", admin_responses_path
   %li= link_to "Sections (pour les dépêches)", admin_sections_path
-  %li= link_to "Forums", admin_forums_path
-  %li= link_to "Catégories (pour le suivi)", admin_categories_path
-  %li= link_to "Bannières", admin_banners_path
-  %li= link_to "Logo", admin_logo_path
-  %li= link_to "Feuilles de style", admin_stylesheet_path
   %li= link_to "Sites amis", admin_friend_sites_path
   %li= link_to "Pages statiques", admin_pages_path
-  %li= link_to "Applications de l’API", admin_applications_path
-  %li= link_to "Débogage", "/admin/debug"

--- a/app/views/moderation/images/index.html.haml
+++ b/app/views/moderation/images/index.html.haml
@@ -2,12 +2,14 @@
 
 - if @images.any?
   %p Images externes les plus récentes
-  - @images.each do |image|
-    .image
-      = image.to_html.html_safe
-      - if image.blocked
-        = "⛔ Bloquée" if image.blocked
-      - else
-        = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Confirmez‑vous vouloir bloquer cette image ?" }
+  %ul
+    - @images.each do |image|
+      %li.image
+        - if image.blocked
+          %pre #{image.link.html_safe}
+          = "⛔ Bloquée"
+        - else
+          = image.to_html.html_safe
+          = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Confirmez‑vous vouloir bloquer cette image ?" }
 - else
   %p Aucune image externe actuellement

--- a/app/views/moderation/images/index.html.haml
+++ b/app/views/moderation/images/index.html.haml
@@ -1,6 +1,13 @@
 %h1 Images externes les plus récentes
 
-- @images.each do |image|
-  .image
-    = image.to_html.html_safe
-    = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Confirmez‑vous vouloir bloquer cette image ?" }
+- if @images.any?
+  %p Images externes les plus récentes
+  - @images.each do |image|
+    .image
+      = image.to_html.html_safe
+      - if image.blocked
+        = "⛔ Bloquée" if image.blocked
+      - else
+        = button_to "Bloquer", moderation_image_path(image.encoded_link), method: :delete, data: { confirm: "Confirmez‑vous vouloir bloquer cette image ?" }
+- else
+  %p Aucune image externe actuellement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
     end
     resources :pages, except: [:show]
     resources :applications, except: [:new, :create]
+    resources :images, except: [:show]
   end
 
   # Search

--- a/db/redis.txt
+++ b/db/redis.txt
@@ -11,6 +11,7 @@ Key                                            | Type   | Value                 
 `convert/<news_id>`                            | string |      `<diary_id>`     |     no     | Conversions from diary to news
 `dashboard/<account_id>`                       |  set   |      `<node_id>`      |   1 week   | Notifications from answers
 `img/<uri>`                                    |  hash  |                       |     no     | Images, with fields 'created_at': seconds since Epoch, 'status': 'Blocked' if administratively blocked (by moderation), 'type': content-type like 'image/jpeg' (set by `img` daemon), 'checksum': SHA1 (set by `img` daemon), and 'etag': etag (set by `img` daemon)
+`img/blocked`                                  |  list  |         URIs          |     no     | Images blocked by moderation team
 `img/err/<uri>`                                | string |         error         |     no     | Images in error, like "Invalid content-type", created by `img` daemon but removed by `dlfp`
 `img/latest`                                   |  list  |         URIs          | no, limited| Last images, limited to NB_IMG_IN_LATEST = 100
 `img/updated/<uri>`                            | string |        modtime        |     1h     | Cached images, created by `img` daemon, value like "Thu, 12 Dec 2013 12:28:47 GMT"


### PR DESCRIPTION
Cf https://linuxfr.org/suivi/lister-les-images-bloquees

- Moderation team can block and see last blocked images.
- Admin team can see all blocked images.
- Full remove of blocked images still by hand (delete in img/latest, img/blocked and img/<uri> for redis)