### PR TITLE
Allow showing user e-mail address.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ protected
     devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
     devise_parameter_sanitizer.permit(:account_update, keys: [
       :login, :email, :password, :password_confirmation, :current_password,
-      :hide_avatar, :news_on_home, :diaries_on_home, :posts_on_home,
+      :hide_avatar, :news_on_home, :diaries_on_home, :posts_on_home, :show_email,
       :polls_on_home, :wiki_pages_on_home, :trackers_on_home, :bookmarks_on_home,
       :sort_by_date_on_home, :hide_signature, :show_negative_nodes,
       :totoz_style, :totoz_source,

--- a/app/helpers/node_helper.rb
+++ b/app/helpers/node_helper.rb
@@ -109,6 +109,7 @@ module NodeHelper
     if user
       user_link  = link_to(user.name, "/users/#{user.cached_slug}", rel: 'author')
       user_infos = []
+      user_infos << email_link(user)
       user_infos << homesite_link(user)
       user_infos << jabber_link(user)
       user_infos << mastodon_link(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -25,6 +25,13 @@ module UsersHelper
     image_tag(user.avatar_url, options)
   end
 
+  def email_link(user)
+    return if not user.account.show_email
+    karma = user.account.try(:karma).to_i
+    return unless karma > 0
+    link_to("courriel", "mailto:" + user.account.email)
+  end
+
   def homesite_link(user)
     return if user.homesite.blank?
     karma = user.account.try(:karma).to_i

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -353,6 +353,7 @@ class Account < ActiveRecord::Base
                          512 => :show_negative_nodes,
                         1024 => :bookmarks_on_home,
                         2048 => :board_in_sidebar,
+                        4096 => :show_email,
                          scopes: false
 
   def types_on_home

--- a/app/views/devise/registrations/_preferences.html.haml
+++ b/app/views/devise/registrations/_preferences.html.haml
@@ -21,6 +21,9 @@
       = u.label :signature, "Signature"
       = u.text_field :signature, maxlength: 250, size: 100
   %p
+    = f.check_box :show_email
+    = f.label :show_email, "Publier mon adresse de courriel"
+  %p
     = f.check_box :hide_avatar
     = f.label :hide_avatar, "Ne pas afficher les avatars sur le site"
   %p

--- a/app/views/statistics/users.html.haml
+++ b/app/views/statistics/users.html.haml
@@ -336,6 +336,11 @@
         .stat.misc(style="width: #{(width_stats * @stats.preferences(:hide_avatar) / maxval).to_i}px;")= @stats.preferences(:hide_avatar)
       %td #{@stats.pctrecent(@stats.preferences :hide_avatar)}
     %tr
+      %td.stat Publication de l'adresse de courriel
+      %td
+        .stat.misc(style="width: #{(width_stats * @stats.preferences(:show_email) / maxval).to_i}px;")= @stats.preferences(:show_email)
+      %td #{@stats.pctrecent(@stats.preferences :show_email)}
+    %tr
       %td.stat Affichage des contenus avec une note négative
       %td
         .stat.misc(style="width: #{(width_stats * @stats.preferences(:show_negative_nodes) / maxval).to_i}px;")= @stats.preferences(:show_negative_nodes)


### PR DESCRIPTION
As per https://linuxfr.org/suivi/permettre-aux-utilisateurs-de-publier-leur-adresse-de-courriel

This adds an account preference field "show_email" that is controlled by the user. When it is enabled, the user's e-mail is displayed along their username in a similar way than their website, XMPP address and Mastodon identifier.

Test plan:
* have a user with karma >0 and at least one post
* go to http://dlfp.lo/compte/modifier
* tick "Rendre mon adresse de courriel visible publiquement" and save
* check the e-mail is shown along the post
* go to http://dlfp.lo/statistiques/users#stats_fonctionnalites
* check "Publication de l'adresse de courriel" has at least one user