### PR TITLE
ensure markdown export is using only LF as end of line

### DIFF
--- a/app/views/diaries/show.md.erb
+++ b/app/views/diaries/show.md.erb
@@ -1,3 +1,3 @@
 <%= render "nodes/front_matter", :content => @diary %>
 
-<%= raw @diary.wiki_body %>
+<%= raw @diary.wiki_body.encode(universal_newline: true) %>

--- a/app/views/news/show.md.erb
+++ b/app/views/news/show.md.erb
@@ -1,6 +1,6 @@
 <%= render "nodes/front_matter", :content => @news %>
 
-<%= raw @news.wiki_body %>
+<%= raw @news.wiki_body.encode(universal_newline: true) %>
 
 ----
 
@@ -10,4 +10,4 @@
 
 ----
 
-<%= raw @news.wiki_second_part %>
+<%= raw @news.wiki_second_part.encode(universal_newline: true) %>

--- a/app/views/polls/show.md.erb
+++ b/app/views/polls/show.md.erb
@@ -1,6 +1,6 @@
 <%= render "nodes/front_matter", :content => @poll %>
 
-<%= raw @poll.wiki_explanations %>
+<%= raw @poll.wiki_explanations.encode(universal_newline: true) %>
 
 <%- @poll.answers.each do |answer| -%>
 * <%= raw answer.answer %>

--- a/app/views/posts/show.md.erb
+++ b/app/views/posts/show.md.erb
@@ -1,3 +1,3 @@
 <%= render "nodes/front_matter", :content => @post %>
 
-<%= raw @post.wiki_body %>
+<%= raw @post.wiki_body.encode(universal_newline: true) %>

--- a/app/views/trackers/show.md.erb
+++ b/app/views/trackers/show.md.erb
@@ -1,3 +1,3 @@
 <%= render "nodes/front_matter", :content => @tracker %>
 
-<%= raw @tracker.wiki_body %>
+<%= raw @tracker.wiki_body.encode(universal_newline: true) %>

--- a/app/views/wiki_pages/show.md.erb
+++ b/app/views/wiki_pages/show.md.erb
@@ -1,3 +1,3 @@
 <%= render "nodes/front_matter", :content => @wiki_page %>
 
-<%= raw @wiki_page.versions.first.body %>
+<%= raw @wiki_page.versions.first.body.encode(universal_newline: true) %>


### PR DESCRIPTION
Web browsers send multiline textarea value with CRLF as end of line.

As the markdown export uses the raw value from database, we need to replace the CRLF by LF end of lines. Otherwise the file will have both type of end of lines.

See suivi request: https://linuxfr.org/suivi/export-markdown