### PR TITLE
Make the bookmark title field length consistent with the model

### DIFF
--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -2,7 +2,7 @@
 
 %p
   = form.label :title, "Sujet du lien"
-  = form.text_field :title, autocomplete: 'off', required: 'required', spellcheck: 'true', maxlength: 100
+  = form.text_field :title, autocomplete: 'off', required: 'required', spellcheck: 'true', maxlength: 160
 %p
   = form.label :link, "Lien à partager"
   = form.text_field :link, autocomplete: 'off', required: 'required', spellcheck: 'false', maxlength: 1024


### PR DESCRIPTION
The model specifies a max length of 160 for the title column, but the form template specified a max length of 100 for the title field.

Indeed, if you look in db/schema.rb you'll find:

    t.string "title", limit: 160, null: false

See https://linuxfr.org/users/tkr/liens/on-peut-tres-bien-vivre-sans-telephone-portable-comment-s-adaptent-ces-francais-qui-ont-delaiss#comment-1985307