### PR TITLE
Users stats for xmpp/mastodon: percentage % declared

### DIFF
--- a/app/models/statistics/users.rb
+++ b/app/models/statistics/users.rb
@@ -4,7 +4,12 @@ class Statistics::Users < Statistics::Statistics
   def pctrecent(value)
     "%.0f%%" % (100.0 * value / nb_recently_seen_accounts)
   end
-
+  
+  def pctrecent_filled(value,field)
+    # take into account those having declared an xmpp or mastodon account
+    "%.0f%%" % (100.0 * value / filled(field))
+  end
+  
   def nb_users
     count "SELECT COUNT(*) AS cnt FROM users"
   end

--- a/app/views/statistics/users.html.haml
+++ b/app/views/statistics/users.html.haml
@@ -249,6 +249,7 @@
       %th Domaines à plus de trois comptes
       %th Nombre de comptes
       %th Actifs
+      %th % déclarés
     - @stats.top_xmpp_domains.each do |domain|
       %tr
         %td.stat
@@ -257,6 +258,8 @@
           .stat.misc(style="width: #{(width_stats * domain["cnt"] / maxval).to_i}px;")= domain["cnt"]
         %td
           #{@stats.pctrecent(domain["cnt"])}
+        %td
+          #{@stats.pctrecent_filled(domain["cnt"],"jabber_id")}
 
   %h2#stats_mastodon Domaines Mastodon
   %p
@@ -267,6 +270,7 @@
       %th Domaines à plus de trois comptes
       %th Nombre de comptes
       %th Actifs
+      %th % déclarés
     - @stats.top_mastodon_domains.each do |domain|
       %tr
         %td.stat
@@ -275,6 +279,9 @@
           .stat.misc(style="width: #{(width_stats * domain["cnt"] / maxval).to_i}px;")= domain["cnt"]
         %td
           #{@stats.pctrecent(domain["cnt"])}
+        %td
+          #{@stats.pctrecent_filled(domain["cnt"],"mastodon_url")}
+
 
   %h2#stats_fonctionnalites Utilisation des fonctionnalités
   %p


### PR DESCRIPTION
Following the proposal at https://linuxfr.org/suivi/pourcentages-xmpp-mastodon-ceux-qui-ont-renseigne-le-champ here's a tentative pull-request to add a percentage for domains, taking into account those having declared an xmpp or mastodon account.

I'm not sure of the choice to add a new function pctrecent_filled to the model, maybe do the calculation directly in the view?