### PR TITLE
Do not hide title links on hidden comments on mobile

### DIFF
--- a/app/assets/stylesheets/contrib/RonRonnement-Classic.scss
+++ b/app/assets/stylesheets/contrib/RonRonnement-Classic.scss
@@ -2091,9 +2091,6 @@ img {
   .node footer.actions .action .button_to {
     display: none;
   }
-  li.comment > h2 > a.title {
-    pointer-events: none;
-  }
   li.comment > ul {
     margin-left: 0.5em;
   }

--- a/app/assets/stylesheets/responsive/m.scss
+++ b/app/assets/stylesheets/responsive/m.scss
@@ -210,9 +210,6 @@
   .node footer.actions .action .button_to {
     display: none;
   }
-  li.comment > h2 > a.title {
-    pointer-events: none;
-  }
   li.comment > ul {
     margin-left: 0.5em;
   }


### PR DESCRIPTION
When browsing DLFP on mobile, title links to hidden comments are disabled which is not the case on desktop.

Those are the only two places disabling pointer-events:

```
$ git grep pointer-events | wc -l
0
```