### PR TITLE
fix chat to create a more precise highlight

### DIFF
--- a/app/assets/javascripts/chat.coffee
+++ b/app/assets/javascripts/chat.coffee
@@ -127,7 +127,7 @@ class Chat
   right_highlitizer: (event) =>
     time = $(event.target).data("clockTime")
     index = $(event.target).data("clockIndex")
-    if time.length = 5
+    if time.length == 5
         @inbox.find("time[data-clock-time*=\"" + time + "\"]").addClass "highlighted"
     else
         @inbox.find("time[data-clock-time=\"" + time + "\"][data-clock-index=\"" + index + "\"]").addClass "highlighted"


### PR DESCRIPTION
When a board receives 2 messages the same second,
an identifier is added to the norloge to quote precisely a message.

This little coffescript bug made the quote in a new message to highlight all messages sent at the same time.

Fortunately JavaScript String length is read only and this bug did not affect other quotes: user can highlight a precise message using second precision and it can highlight all messages from the same minutes using minute precision.

On these screenshots, the mouse hovers the quote of the latest message:

before | after
-|-
<img width="849" height="172" alt="behavior with the bug" src="https://github.com/user-attachments/assets/c175b677-125e-41d4-bb19-5ec28b2e6348" /> | <img width="849" height="172" alt="behavior without the bug" src="https://github.com/user-attachments/assets/4915d37f-dd39-4762-bcbd-80ab779f9612" />
